### PR TITLE
chore: add missing generated artifact entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 .docusaurus/
 
 # Quality tool output
+.phpunit.cache/
 phpmetrics/
 phpqa/
 coverage/


### PR DESCRIPTION
Adds `.phpunit.cache/` to `.gitignore` to prevent generated test artifacts from being tracked. These cause unnecessary dirty-submodule noise in the parent repo.

Already present: `coverage/`, `phpmetrics/`