### PR TITLE
chore: Restructure specs to proper OpenSpec format

### DIFF
--- a/openspec/specs/component-tokens/spec.md
+++ b/openspec/specs/component-tokens/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Component Tokens Specification
 
 ## Purpose

--- a/openspec/specs/custom-css-overrides/spec.md
+++ b/openspec/specs/custom-css-overrides/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Custom CSS Overrides Specification
 
 ## Purpose

--- a/openspec/specs/docs-content/spec.md
+++ b/openspec/specs/docs-content/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 ## ADDED Requirements
 
 ### Requirement: Documentation landing page

--- a/openspec/specs/extended-token-sets/spec.md
+++ b/openspec/specs/extended-token-sets/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Extended Token Sets Specification
 
 ## Purpose

--- a/openspec/specs/nextcloud-variable-mapping/spec.md
+++ b/openspec/specs/nextcloud-variable-mapping/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Nextcloud Variable Mapping Specification
 
 ## Purpose

--- a/openspec/specs/nl-design/spec.md
+++ b/openspec/specs/nl-design/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # NL Design System Compliance — Delta Spec
 
 ## Purpose

--- a/openspec/specs/theming-sync-dialog/spec.md
+++ b/openspec/specs/theming-sync-dialog/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Theming Sync Dialog Specification
 
 ## Purpose

--- a/openspec/specs/token-editor-ui/spec.md
+++ b/openspec/specs/token-editor-ui/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Token Editor UI Specification
 
 ## Purpose

--- a/openspec/specs/token-import-export/spec.md
+++ b/openspec/specs/token-import-export/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Token Import/Export Specification
 
 ## Purpose

--- a/openspec/specs/token-set-apply-dialog/spec.md
+++ b/openspec/specs/token-set-apply-dialog/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Token-Set Apply Dialog Specification
 
 ## Purpose

--- a/openspec/specs/token-set-dropdown/spec.md
+++ b/openspec/specs/token-set-dropdown/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Token Set Dropdown Specification
 
 ## Purpose

--- a/openspec/specs/token-sync-workflow/spec.md
+++ b/openspec/specs/token-sync-workflow/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # Token Sync Workflow Specification
 
 ## Purpose

--- a/openspec/specs/vng-token-set/spec.md
+++ b/openspec/specs/vng-token-set/spec.md
@@ -1,3 +1,7 @@
+---
+status: reviewed
+---
+
 # VNG Token Set Specification
 
 ## Purpose


### PR DESCRIPTION
## Summary
- Add `status: reviewed` frontmatter to 13 specs that were missing it
- All 20 specs document implemented functionality — no specs moved to `changes/`
- Specs cover: admin-settings, component-tokens, css-architecture, custom-css-overrides, docs-content, extended-token-sets, hide-slogan, menu-labels, nextcloud-variable-mapping, nl-design, prometheus-metrics, theming-sync, theming-sync-dialog, token-editor-ui, token-import-export, token-set-apply-dialog, token-set-dropdown, token-sets, token-sync-workflow, vng-token-set

## Test plan
- [ ] Verify all specs have `status: reviewed` or `status: enriched` frontmatter
- [ ] Verify no content was lost