### PR TITLE
chore: Final OpenSpec structure cleanup

### DIFF
--- a/openspec/changes/archive/2026-02-15-add-vng-token-set/specs/vng-token-set/spec.md
+++ b/openspec/changes/archive/2026-02-15-add-vng-token-set/specs/vng-token-set/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Define requirements for adding VNG (Vereniging Nederlandse Gemeenten) as a selectable design token set in the nldesign Nextcloud app. VNG tokens are manually converted from the tilburg-woo-ui project since they are not available in the upstream nl-design-system/themes repository.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: VNG Token CSS File
 The system MUST provide a `css/tokens/vng.css` file containing VNG design tokens in `:root` scope with `--nldesign-*` semantic tokens and `--vng-*` organization palette tokens.

--- a/openspec/changes/archive/2026-03-02-enhance-docs-website/specs/docs-content/spec.md
+++ b/openspec/changes/archive/2026-03-02-enhance-docs-website/specs/docs-content/spec.md
@@ -1,4 +1,4 @@
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Documentation landing page
 The documentation site SHALL have an `intro.md` file at `docs/intro.md` that serves as the entry point for all documentation. It SHALL provide a high-level overview of what nldesign is, link to key sections (getting started, features, reference), and use the Docusaurus `slug: /` frontmatter to become the docs root.

--- a/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/custom-css-overrides/spec.md
+++ b/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/custom-css-overrides/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Defines the CSS file persistence layer for user-defined token customizations. `custom-overrides.css` is the single write target for all theme editor output. It is loaded last in the CSS stack so user intent always wins. NL Design token set CSS files are read-only presets and are never modified.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Custom Overrides File
 The system MUST maintain a `custom-overrides.css` file in the nldesign app's CSS directory. This file MUST be written exclusively by the theme editor backend — no other write path exists.

--- a/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/nl-design/spec.md
+++ b/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/nl-design/spec.md
@@ -29,7 +29,7 @@ The nldesign app MUST support all organization token sets available in the confi
 - AND `custom-overrides.css` MUST remain unchanged
 - AND no visual change MUST persist
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: App Identity
 The app MUST be positioned as a **Nextcloud Theme Editor with NL Design System support** in its user-facing name, description, and admin settings heading. The scope is broader than NL Design loading: it encompasses editing any Nextcloud CSS custom property.

--- a/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/token-editor-ui/spec.md
+++ b/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/token-editor-ui/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Provides a tabbed admin settings panel for browsing and editing all editable Nextcloud CSS custom properties (`--color-*`) with live preview and per-token reset controls. Changes are previewed in the browser before being committed to `custom-overrides.css`.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Token Editor Panel
 The admin settings page MUST include a token editor panel below the existing NL Design token-set selector. The panel MUST be rendered as a Vue component within the existing nldesign admin settings template.

--- a/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/token-import-export/spec.md
+++ b/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/token-import-export/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Allows admins to download the current `custom-overrides.css` as a portable file and upload a previously saved file to restore or share a token configuration. Only known, editable Nextcloud `--color-*` tokens are accepted on import — unknown variables are silently rejected and their count is reported.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Export Current Overrides
 The admin settings panel MUST provide a **Download** button that exports the current `custom-overrides.css` as a file download.

--- a/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/token-set-apply-dialog/spec.md
+++ b/openspec/changes/archive/2026-03-03-nextcloud-theme-editor/specs/token-set-apply-dialog/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Defines the modal dialog shown when an admin selects a new NL Design token set. The dialog shows which Nextcloud CSS variable values would change (resolved current value vs the value from the new token set), lets the admin check or uncheck individual changes, and writes only the checked values to `custom-overrides.css`. The NL Design token set CSS file itself is never applied directly.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Dialog Trigger
 Selecting a different NL Design token set from the selector MUST open the apply dialog instead of immediately switching themes.

--- a/openspec/changes/archive/2026-03-06-full-nextcloud-token-support-from-nldesign/specs/component-tokens/spec.md
+++ b/openspec/changes/archive/2026-03-06-full-nextcloud-token-support-from-nldesign/specs/component-tokens/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Introduces component-level NL Design System tokens using the `--nldesign-component-*` prefix, with a temporary bridge file that maps the current `--utrecht-*` component tokens to the nldesign namespace.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: NLDesign Component Token Prefix
 All component-level tokens MUST use the `--nldesign-component-*` prefix for consistency with the rest of the nldesign token system.

--- a/openspec/changes/archive/2026-03-06-full-nextcloud-token-support-from-nldesign/specs/extended-token-sets/spec.md
+++ b/openspec/changes/archive/2026-03-06-full-nextcloud-token-support-from-nldesign/specs/extended-token-sets/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Expands the nldesign app from 5 manually maintained token sets to all available NL Design System organization token sets (48+), using auto-generation from official upstream JSON token files.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Support All Available Token Sets
 The system MUST support all organization token sets available in the `nl-design-system/themes` repository.

--- a/openspec/changes/archive/2026-03-06-full-nextcloud-token-support-from-nldesign/specs/nextcloud-variable-mapping/spec.md
+++ b/openspec/changes/archive/2026-03-06-full-nextcloud-token-support-from-nldesign/specs/nextcloud-variable-mapping/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Provides a complete, audited mapping between all Nextcloud CSS custom properties and `--nldesign-*` design tokens, with comprehensive documentation and a defaults layer that ensures all tokens always have a value.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Complete Nextcloud Variable Audit
 The system MUST include a mapping for every CSS custom property defined by Nextcloud's theming system (DefaultTheme.php, CommonThemeTrait.php, and core SCSS files).

--- a/openspec/changes/archive/2026-03-06-full-nextcloud-token-support-from-nldesign/specs/token-sync-workflow/spec.md
+++ b/openspec/changes/archive/2026-03-06-full-nextcloud-token-support-from-nldesign/specs/token-sync-workflow/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Automates the synchronization of NL Design System token sets from the upstream `nl-design-system/themes` repository via a nightly GitHub Actions workflow that generates CSS token files and opens PRs when changes are detected.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Nightly Schedule
 The sync workflow MUST run automatically every night to check for upstream token changes.

--- a/openspec/changes/archive/2026-03-06-sync-theming-on-token-change/specs/theming-sync-dialog/spec.md
+++ b/openspec/changes/archive/2026-03-06-sync-theming-on-token-change/specs/theming-sync-dialog/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 After an admin selects a different token set in nldesign, offer to automatically update Nextcloud's built-in theming values (primary color, background color, logo, background image) to match the selected token set, preventing a split-brain theming state where CSS tokens and Nextcloud theming are out of sync.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Theming Metadata in Token Sets
 Each token set entry in `token-sets.json` MAY include a `theming` object with optional fields: `primary_color`, `background_color`, `logo`, and `background`.

--- a/openspec/changes/archive/2026-03-06-sync-theming-on-token-change/specs/token-set-dropdown/spec.md
+++ b/openspec/changes/archive/2026-03-06-sync-theming-on-token-change/specs/token-set-dropdown/spec.md
@@ -3,7 +3,7 @@
 ## Purpose
 Replace the radio button list for token set selection with a searchable dropdown (`<select>`) that scales to 400+ entries, improving usability as the number of available token sets grows.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Dropdown Token Set Selector
 The admin settings page MUST use a `<select>` dropdown instead of radio buttons for token set selection.

--- a/openspec/specs/component-tokens/spec.md
+++ b/openspec/specs/component-tokens/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Component Tokens Specification
 
 ## Purpose
 Introduces component-level NL Design System tokens using the `--nldesign-component-*` prefix, with a temporary bridge file that maps the current `--utrecht-*` component tokens to the nldesign namespace.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: NLDesign Component Token Prefix
 All component-level tokens MUST use the `--nldesign-component-*` prefix for consistency with the rest of the nldesign token system.

--- a/openspec/specs/custom-css-overrides/spec.md
+++ b/openspec/specs/custom-css-overrides/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Custom CSS Overrides Specification
 
 ## Purpose
 Defines the CSS file persistence layer for user-defined token customizations. `custom-overrides.css` is the single write target for all theme editor output. It is loaded last in the CSS stack so user intent always wins. NL Design token set CSS files are read-only presets and are never modified.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Custom Overrides File
 The system MUST maintain a `custom-overrides.css` file in the nldesign app's CSS directory. This file MUST be written exclusively by the theme editor backend — no other write path exists.

--- a/openspec/specs/docs-content/spec.md
+++ b/openspec/specs/docs-content/spec.md
@@ -1,4 +1,8 @@
-## ADDED Requirements
+---
+status: implemented
+---
+
+## Requirements
 
 ### Requirement: Documentation landing page
 The documentation site SHALL have an `intro.md` file at `docs/intro.md` that serves as the entry point for all documentation. It SHALL provide a high-level overview of what nldesign is, link to key sections (getting started, features, reference), and use the Docusaurus `slug: /` frontmatter to become the docs root.

--- a/openspec/specs/extended-token-sets/spec.md
+++ b/openspec/specs/extended-token-sets/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Extended Token Sets Specification
 
 ## Purpose
 Expands the nldesign app from 5 manually maintained token sets to all available NL Design System organization token sets (48+), using auto-generation from official upstream JSON token files.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Support All Available Token Sets
 The system MUST support all organization token sets available in the `nl-design-system/themes` repository.

--- a/openspec/specs/nextcloud-variable-mapping/spec.md
+++ b/openspec/specs/nextcloud-variable-mapping/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Nextcloud Variable Mapping Specification
 
 ## Purpose
 Provides a complete, audited mapping between all Nextcloud CSS custom properties and `--nldesign-*` design tokens, with comprehensive documentation and a defaults layer that ensures all tokens always have a value.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Complete Nextcloud Variable Audit
 The system MUST include a mapping for every CSS custom property defined by Nextcloud's theming system (DefaultTheme.php, CommonThemeTrait.php, and core SCSS files).

--- a/openspec/specs/nl-design/spec.md
+++ b/openspec/specs/nl-design/spec.md
@@ -1,3 +1,7 @@
+---
+status: implemented
+---
+
 # NL Design System Compliance — Delta Spec
 
 ## Purpose

--- a/openspec/specs/theming-sync-dialog/spec.md
+++ b/openspec/specs/theming-sync-dialog/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Theming Sync Dialog Specification
 
 ## Purpose
 After an admin selects a different token set in nldesign, offer to automatically update Nextcloud's built-in theming values (primary color, background color, logo, background image) to match the selected token set, preventing a split-brain theming state where CSS tokens and Nextcloud theming are out of sync.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Theming Metadata in Token Sets
 Each token set entry in `token-sets.json` MAY include a `theming` object with optional fields: `primary_color`, `background_color`, `logo`, and `background`.

--- a/openspec/specs/token-editor-ui/spec.md
+++ b/openspec/specs/token-editor-ui/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Token Editor UI Specification
 
 ## Purpose
 Provides a tabbed admin settings panel for browsing and editing all editable Nextcloud CSS custom properties (`--color-*`) with live preview and per-token reset controls. Changes are previewed in the browser before being committed to `custom-overrides.css`.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Token Editor Panel
 The admin settings page MUST include a token editor panel below the existing NL Design token-set selector. The panel MUST be rendered as a Vue component within the existing nldesign admin settings template.

--- a/openspec/specs/token-import-export/spec.md
+++ b/openspec/specs/token-import-export/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Token Import/Export Specification
 
 ## Purpose
 Allows admins to download the current `custom-overrides.css` as a portable file and upload a previously saved file to restore or share a token configuration. Only known, editable Nextcloud `--color-*` tokens are accepted on import — unknown variables are silently rejected and their count is reported.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Export Current Overrides
 The admin settings panel MUST provide a **Download** button that exports the current `custom-overrides.css` as a file download.

--- a/openspec/specs/token-set-apply-dialog/spec.md
+++ b/openspec/specs/token-set-apply-dialog/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Token-Set Apply Dialog Specification
 
 ## Purpose
 Defines the modal dialog shown when an admin selects a new NL Design token set. The dialog shows which Nextcloud CSS variable values would change (resolved current value vs the value from the new token set), lets the admin check or uncheck individual changes, and writes only the checked values to `custom-overrides.css`. The NL Design token set CSS file itself is never applied directly.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Dialog Trigger
 Selecting a different NL Design token set from the selector MUST open the apply dialog instead of immediately switching themes.

--- a/openspec/specs/token-set-dropdown/spec.md
+++ b/openspec/specs/token-set-dropdown/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Token Set Dropdown Specification
 
 ## Purpose
 Replace the radio button list for token set selection with a searchable dropdown (`<select>`) that scales to 400+ entries, improving usability as the number of available token sets grows.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Dropdown Token Set Selector
 The admin settings page MUST use a `<select>` dropdown instead of radio buttons for token set selection.

--- a/openspec/specs/token-sync-workflow/spec.md
+++ b/openspec/specs/token-sync-workflow/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # Token Sync Workflow Specification
 
 ## Purpose
 Automates the synchronization of NL Design System token sets from the upstream `nl-design-system/themes` repository via a nightly GitHub Actions workflow that generates CSS token files and opens PRs when changes are detected.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: Nightly Schedule
 The sync workflow MUST run automatically every night to check for upstream token changes.

--- a/openspec/specs/vng-token-set/spec.md
+++ b/openspec/specs/vng-token-set/spec.md
@@ -1,9 +1,13 @@
+---
+status: implemented
+---
+
 # VNG Token Set Specification
 
 ## Purpose
 Define requirements for adding VNG (Vereniging Nederlandse Gemeenten) as a selectable design token set in the nldesign Nextcloud app. VNG tokens are manually converted from the tilburg-woo-ui project since they are not available in the upstream nl-design-system/themes repository.
 
-## ADDED Requirements
+## Requirements
 
 ### Requirement: VNG Token CSS File
 The system MUST provide a `css/tokens/vng.css` file containing VNG design tokens in `:root` scope with `--nldesign-*` semantic tokens and `--vng-*` organization palette tokens.


### PR DESCRIPTION
## Summary
- Add `status: implemented` frontmatter to 13 specs missing it
- Rename `## ADDED Requirements` to `## Requirements` in all specs and archives