### PR TITLE
chore: harmonize .gitignore with shared template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,51 @@
+# IDE
+/.idea/
+/*.iml
+*.Identifier
+.vscode/
+
 # Dependencies
-node_modules/
-vendor/
+/vendor/
+/node_modules/
 
 # Build artifacts
-build/
-dist/
-.docusaurus/
+/js/
+/build/
+/dist/
 
-# Quality tool output
+# Documentation
+/docs/node_modules/
+/docs/build/
+/docs/.docusaurus/
+/website/node_modules/
+/website/.docusaurus/
+
+# Testing & Quality
+/.php-cs-fixer.cache
+/tests/.phpunit.cache
+/.phpunit.cache/
 .phpunit.cache/
-phpmetrics/
-phpqa/
-coverage/
+.phpunit.result.cache
+/coverage/
+/coverage-frontend/
+/phpmetrics/
+/quality-reports/
+/phpqa/
 phpcs-output.json
 
-# IDE
-.idea/
-.vscode/
-*.swp
-*.swo
+# Nextcloud
+/custom_apps/
+/config/
+.htaccess
 
 # OS
 .DS_Store
 Thumbs.db
 
-# Nextcloud
-.htaccess
-
-# Test/build artifacts
-.phpunit.cache
-.phpunit.result.cache
-
 # SBOM is published as release asset (see SECURITY.md), not stored in repo
 sbom.cdx.json
 bom-php.cdx.json
 bom-npm.cdx.json
+
+# Claude Code
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Harmonize `.gitignore` with the shared cross-project template
- Add missing patterns: `.phpunit.cache`, `docs/.docusaurus`, `docs/node_modules`, `/js/`, `coverage-frontend/`, `quality-reports/`, `.claude/worktrees/`, etc.
- Use anchored paths (`/vendor/`, `/node_modules/`) for clarity

Closes #54