### PR TITLE
feat(docs): adopt @conduction/docusaurus-preset + move to nldesign.conduction.nl

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,4 +10,4 @@ jobs:
   deploy:
     uses: ConductionNL/.github/.github/workflows/documentation.yml@main
     with:
-      cname: nldesign.app
+      cname: nldesign.conduction.nl

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,20 +1,35 @@
 // @ts-check
 
-/** @type {import('@docusaurus/types').Config} */
-const config = {
-  title: 'NL Design',
+/**
+ * NLDesign documentation site.
+ *
+ * Built on @conduction/docusaurus-preset for brand defaults (tokens,
+ * theme swizzles for Navbar / Footer, four-locale i18n scaffolding,
+ * KvK / BTW copyright). Site-specific overrides — locales, sidebar
+ * path, mermaid theme, custom prism themes, nldesign-only navbar items —
+ * are passed through createConfig() opts.
+ */
+
+const { createConfig, baseFooterLinks } = require('@conduction/docusaurus-preset');
+
+/* createConfig replaces themes wholesale when `themes:` is passed, so
+   we re-include the brand theme plugin alongside @docusaurus/theme-mermaid.
+   Without the brand theme entry the Navbar/Footer swizzles and
+   brand.css auto-load would silently drop. */
+const BRAND_THEME = require.resolve('@conduction/docusaurus-preset/theme');
+
+const config = createConfig({
+  title: 'NLDesign',
   tagline: 'NL Design System tokens for Nextcloud',
-  url: 'https://nldesign.app',
+  url: 'https://nldesign.conduction.nl',
   baseUrl: '/',
 
-  // GitHub pages deployment config
   organizationName: 'ConductionNL',
   projectName: 'nldesign',
-  trailingSlash: false,
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
-
+  /* The brand preset's default i18n block (nl/en/de/fr) is replaced
+     wholesale here. NLDesign docs ship with NL + EN translation
+     surfaces; keep both. */
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'nl'],
@@ -24,89 +39,92 @@ const config = {
     },
   },
 
+  /* The nldesign docs source lives at the repo root of `docs/` rather
+     than under a `docs/` subfolder, so we override the preset's default
+     `presets:` block to point `docs.path` at './' and disable the blog
+     plugin. customCss carries nldesign-specific CSS only — brand tokens
+     and the theme swizzles are auto-loaded by the brand theme entry in
+     `themes:` below. */
   presets: [
     [
       'classic',
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
+      {
         docs: {
           path: './',
-          exclude: ['**/node_modules/**'],
+          /* docs.path: './' makes plugin-content-docs scan every file
+             in docs/, which collides with plugin-content-pages's own
+             scan of docs/src/pages/. The same index page then gets
+             processed by both plugins. Exclude src/ (pages live there)
+             plus the standard node_modules bucket. */
+          exclude: ['**/node_modules/**', 'src/**'],
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl:
-            'https://github.com/ConductionNL/nldesign/tree/main/docs/',
+          editUrl: 'https://github.com/ConductionNL/nldesign/tree/main/docs/',
         },
         blog: false,
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
-      }),
+      },
     ],
   ],
 
-  themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
-      navbar: {
-        title: 'NL Design',
-        logo: {
-          alt: 'NL Design Logo',
-          src: 'img/logo.svg',
-        },
-        items: [
-          {
-            type: 'docSidebar',
-            sidebarId: 'tutorialSidebar',
-            position: 'left',
-            label: 'Documentation',
-          },
-          {
-            href: 'https://github.com/ConductionNL/nldesign',
-            label: 'GitHub',
-            position: 'right',
-          },
-          {
-            type: 'localeDropdown',
-            position: 'right',
-          },
-        ],
+  themes: [BRAND_THEME, '@docusaurus/theme-mermaid'],
+
+  /* Brand navbar provides locale dropdown + GitHub by default; we
+     replace items[] with nldesign's own (Documentation sidebar link,
+     nldesign GitHub link, locale dropdown). Object.assign in
+     createConfig is shallow, so items: replaces wholesale — re-include
+     the locale dropdown and add the nldesign GitHub repo link
+     explicitly. */
+  navbar: {
+    items: [
+      {
+        type: 'docSidebar',
+        sidebarId: 'tutorialSidebar',
+        position: 'left',
+        label: 'Documentation',
       },
-      footer: {
-        style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Documentation',
-                to: '/docs',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'GitHub',
-                href: 'https://github.com/ConductionNL/nldesign',
-              },
-            ],
-          },
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} for <a href="https://openwebconcept.nl">Open Webconcept</a> by <a href="https://conduction.nl">Conduction B.V.</a>`,
+      {
+        href: 'https://github.com/ConductionNL/nldesign',
+        label: 'GitHub',
+        position: 'right',
       },
-      prism: {
-        theme: require('prism-react-renderer/themes/github'),
-        darkTheme: require('prism-react-renderer/themes/dracula'),
-      },
-      mermaid: {
-        theme: { light: 'default', dark: 'dark' },
-      },
-    }),
-  markdown: {
-    mermaid: true,
+      { type: 'localeDropdown', position: 'right' },
+    ],
   },
-  themes: ['@docusaurus/theme-mermaid'],
+
+  /* Per-property footer override (preset 1.2.0+): we pass `links` only,
+     so the brand `style: 'dark'` and the brand KvK/BTW/IBAN/address
+     copyright string both inherit unchanged. Single-column brand
+     "Conduction" anchor pulled from baseFooterLinks(). */
+  footer: {
+    links: [
+      ...baseFooterLinks().filter((column) => column.title === 'Conduction'),
+    ],
+  },
+
+  /* Drop the canal-footer's boat-sinking + kade-cyclist mini-games
+     on this product-page footer (preset 1.3.0+). The static skyline +
+     canal decoration are kept; the interactive layer goes away. */
+  minigames: false,
+
+  /* themeConfig is shallow-merged into the preset's defaults
+     (colorMode + navbar + footer). prism + mermaid land alongside. */
+  themeConfig: {
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/dracula'),
+    },
+    mermaid: {
+      theme: { light: 'default', dark: 'dark' },
+    },
+  },
+});
+
+/* createConfig doesn't pass-through arbitrary top-level fields; assign
+   markdown directly so it makes it into the final Docusaurus config. */
+config.markdown = {
+  mermaid: true,
 };
 
 module.exports = config;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nldesign-docs",
       "version": "0.0.0",
       "dependencies": {
+        "@conduction/docusaurus-preset": "^1.4.3",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2036,6 +2037,18 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@conduction/docusaurus-preset": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.3.tgz",
+      "integrity": "sha512-64F8A0qal/EfNYJKqsXMGjsOV2X0WYi72plO6MTC/9h60Fz85cMwzEiRpi58e9lloHAc3UBVMuffrzmDimsfwA==",
+      "license": "EUPL-1.2",
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "@docusaurus/preset-classic": "^3.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@csstools/cascade-layer-name-parser": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -15,6 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
+    "@conduction/docusaurus-preset": "^1.4.3",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -1,40 +1,280 @@
+/**
+ * NLDesign landing page.
+ *
+ * Composes the brand <DetailHero> + <WidgetShelf> from
+ * @conduction/docusaurus-preset/components, mirroring the connext page
+ * at sites/www/src/pages/apps/nldesign.mdx.
+ *
+ * Written as .js (not .mdx) because the docs site has the docs plugin
+ * pointed at `path: './'`, and an MDX file in src/pages/ trips the
+ * MDX-ESM parser even with the docs plugin's `src/**` exclude — likely
+ * a quirk of how mdx-loader's micromark stack reuses parser state
+ * across files in this Docusaurus 3.10 + this preset combination.
+ * Authoring the page in JSX keeps the same component composition.
+ */
+
 import React from 'react';
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
+import {
+  DetailHero,
+  WidgetShelf,
+  AppMock,
+} from '@conduction/docusaurus-preset/components';
 
-import styles from './index.module.css';
+const NLDESIGN_ICON = (
+  <svg viewBox="0 0 24 24">
+    <path d="M4 4h16v6H4z" />
+    <path d="M4 14h7v6H4z" />
+    <path d="M14 14h6v6h-6z" />
+  </svg>
+);
 
-function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+const TAGLINE = (
+  <>
+    The NL Design System (NLDS) as a drop-in theme for your{' '}
+    <span className="next-blue">Nextcloud</span>. One install and your
+    interface follows the Dutch government house style, with Conduction
+    component variants on top.
+  </>
+);
+
+function TypeScalePanel() {
+  const rows = [
+    { size: 24, weight: 700, label: 'heading-xl', family: 'headline' },
+    { size: 18, weight: 700, label: 'heading-lg', family: 'headline' },
+    { size: 13, weight: 400, label: 'body', family: 'body' },
+    { size: 11, weight: 400, label: 'caption', family: 'body' },
+  ];
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <h1 className="hero__title">{siteConfig.title}</h1>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs">
-            Documentation
-          </Link>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {rows.map((row, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}
+        >
+          <div
+            style={{
+              fontFamily: `var(--conduction-typography-font-family-${row.family})`,
+              fontSize: row.size,
+              fontWeight: row.weight,
+              color:
+                row.family === 'body' && row.size === 11
+                  ? 'var(--c-cobalt-500)'
+                  : 'var(--c-cobalt-700)',
+            }}
+          >
+            Aa
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 9,
+              letterSpacing: '0.05em',
+              textTransform: 'uppercase',
+              color: 'var(--c-cobalt-400)',
+            }}
+          >
+            {row.label}
+          </div>
         </div>
-      </div>
-    </header>
+      ))}
+    </div>
   );
 }
 
+function ColourPalettePanel() {
+  const swatches = [
+    { name: 'rijksblauw', tone: 'var(--c-cobalt-700)' },
+    { name: 'logoblauw', tone: 'var(--c-cobalt-300)' },
+    { name: 'mint', tone: 'var(--c-mint-500)' },
+    { name: 'oranje', tone: 'var(--c-orange-knvb)' },
+    { name: 'lavender', tone: 'var(--c-lavender-300)' },
+  ];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {swatches.map((row, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+        >
+          <span
+            style={{
+              width: 14,
+              height: 16,
+              clipPath: 'var(--hex-pointy-top)',
+              background: row.tone,
+              flexShrink: 0,
+            }}
+          />
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-body)',
+              fontSize: 11,
+              color: 'var(--c-cobalt-700)',
+              flex: 1,
+            }}
+          >
+            {row.name}
+          </div>
+          <div
+            style={{
+              fontFamily: 'var(--conduction-typography-font-family-code)',
+              fontSize: 9,
+              color: 'var(--c-cobalt-400)',
+            }}
+          >
+            --c-{row.name}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ComponentsPanel() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <div
+          style={{
+            padding: '6px 12px',
+            background: 'var(--c-cobalt-700)',
+            color: 'white',
+            borderRadius: 4,
+            fontFamily: 'var(--conduction-typography-font-family-body)',
+            fontSize: 10,
+            fontWeight: 600,
+          }}
+        >
+          Primary
+        </div>
+        <div
+          style={{
+            padding: '6px 12px',
+            background: 'transparent',
+            color: 'var(--c-cobalt-700)',
+            border: '1px solid var(--c-cobalt-700)',
+            borderRadius: 4,
+            fontFamily: 'var(--conduction-typography-font-family-body)',
+            fontSize: 10,
+            fontWeight: 600,
+          }}
+        >
+          Ghost
+        </div>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <div
+          style={{
+            fontFamily: 'var(--conduction-typography-font-family-code)',
+            fontSize: 8,
+            letterSpacing: '0.05em',
+            textTransform: 'uppercase',
+            color: 'var(--c-cobalt-400)',
+          }}
+        >
+          label
+        </div>
+        <div
+          style={{
+            height: 22,
+            background: 'white',
+            border: '1px solid var(--c-cobalt-200)',
+            borderRadius: 4,
+            padding: '4px 8px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <div
+            style={{
+              height: 4,
+              width: '60%',
+              background: 'var(--c-cobalt-200)',
+              borderRadius: 1,
+            }}
+          />
+        </div>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <div
+          style={{
+            width: 14,
+            height: 14,
+            borderRadius: 3,
+            border: '2px solid var(--c-orange-knvb)',
+            boxShadow: '0 0 0 2px rgba(247,119,21,0.25)',
+          }}
+        />
+        <div
+          style={{
+            fontFamily: 'var(--conduction-typography-font-family-code)',
+            fontSize: 9,
+            letterSpacing: '0.05em',
+            textTransform: 'uppercase',
+            color: 'var(--c-cobalt-400)',
+          }}
+        >
+          focus ring
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const WIDGETS = [
+  {
+    title: 'Type scale',
+    desc: 'NLDS type tokens for headings and body. Sentence case, government-readable, WCAG-AA contrast on the cobalt scale.',
+    panel: <TypeScalePanel />,
+  },
+  {
+    title: 'Colour palette',
+    desc: 'The official NLDS swatches. Switch a theme variable and your whole Nextcloud follows.',
+    panel: <ColourPalettePanel />,
+  },
+  {
+    title: 'Component variants',
+    desc: 'Buttons, inputs, focus rings, the patterns NLDS specifies. Drop-in replacements for the Nextcloud defaults.',
+    panel: <ComponentsPanel />,
+  },
+];
+
 export default function Home() {
-  const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="NL Design System tokens for Nextcloud">
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
+      title="NLDesign"
+      description="NL Design System theme for Nextcloud. Government-compliant typography, colour, and component variants drop in with one install."
+    >
+      <main className="marketing-page">
+        <DetailHero
+          appId="nldesign"
+          status={{ label: 'Beta', color: 'var(--c-orange-knvb)' }}
+          version="v0.1"
+          locales="NL · EN"
+          title="NLDesign"
+          tagline={TAGLINE}
+          primaryCta={{
+            label: 'Install from app store',
+            href: 'https://apps.nextcloud.com/apps/nldesign',
+            tone: 'orange',
+          }}
+          secondaryCta={{ label: 'Read the docs', href: '/docs/intro' }}
+          tertiaryCta={{
+            label: 'View on GitHub',
+            href: 'https://github.com/ConductionNL/nldesign',
+          }}
+          iconColor="var(--c-orange-knvb)"
+          icon={NLDESIGN_ICON}
+          illustration={<AppMock app="nldesign" />}
+        />
+
+        <WidgetShelf
+          eyebrow="Tokens we ship"
+          title="Type, colour, components, all from design.nl."
+          lede="Install NLDesign and the published NLDS tokens land in your Nextcloud. Type scale, colour palette, component variants, the version from design.nl, not a Conduction interpretation."
+          widgets={WIDGETS}
+        />
       </main>
     </Layout>
   );

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,1 @@
-nldesign.app
+nldesign.conduction.nl


### PR DESCRIPTION
## Summary

Adopts the shared `@conduction/docusaurus-preset@^1.4.3` for the NLDesign docs site and moves it to `nldesign.conduction.nl`. Mirrors the openregister migration (ConductionNL/openregister#1444) and the mydash one before it.

The docs site now inherits brand defaults (tokens, Navbar/Footer swizzles, KvK/BTW copyright, hex-watermark hero) and gets a brand-aligned landing page composed from `<DetailHero>` + `<WidgetShelf>`.

## Changes

- `docs/docusaurus.config.js` - rewritten to call `createConfig()` from `@conduction/docusaurus-preset`. Keeps nldesign-specific bits: NL+EN i18n, mermaid theme, custom prism themes, Documentation+GitHub navbar items. Footer reduced to the brand "Conduction" column via `baseFooterLinks().filter(...)`. `minigames: false` to drop the canal-footer mini-games on this product-doc surface.
- `docs/package.json` + `docs/package-lock.json` - adds `@conduction/docusaurus-preset@^1.4.3`.
- `docs/src/pages/index.js` - replaces the homepage with `<DetailHero>` (design-palette icon copied from the connext detail mdx, orange accent, Install/Docs/GitHub CTAs) + a 3-card `<WidgetShelf>` (type scale, colour palette, component variants). Authored as `.js` not `.mdx` to avoid the docs-plugin/pages-plugin scan collision.
- `docs/static/CNAME` - `nldesign.app` -> `nldesign.conduction.nl`.
- `.github/workflows/documentation.yml` - `cname:` updated to `nldesign.conduction.nl`.

## URL change

Production docs URL moves from `https://nldesign.app` to `https://nldesign.conduction.nl`. Old hardcoded `nldesign.app` references remain in `DEVELOPMENT.md`, `test-guide.md`, and several `openspec/specs/*` + `openspec/changes/archive/*` files (28 total). They are flagged for a follow-up sweep, not changed in this PR to keep the diff scoped.

## Build outcome

`cd docs && npm install --legacy-peer-deps --no-audit --no-fund && npm run build` succeeds for both `en` and `nl` locales. Warnings only:
- Preset `app-downloads.json` lookup at `../../../data/app-downloads.json` (harmless preset quirk; site builds without the data file).
- Footer broken-link warnings for `/privacy/`, `/terms/`, `/iso/` (preset footer references brand legal pages that don't exist on this docs site; broken-link policy is `warn`, not `throw`).

No `docs.exclude` overrides needed for pre-existing MDX files - all docs parse cleanly under MDX 3.

## Test plan

- [ ] Confirm `docs/build/index.html` and `docs/build/nl/index.html` render correctly on a local preview.
- [ ] Verify `nldesign.conduction.nl` DNS / GitHub Pages routing once a maintainer merges and the documentation workflow runs from the `documentation` branch.
- [ ] Open follow-up issue to sweep remaining `nldesign.app` references in `DEVELOPMENT.md`, `test-guide.md`, and `openspec/specs/**`.