### PR TITLE
feat(docs): cobalt hero on landing (preset 1.5.1)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -15,7 +15,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^1.4.3",
+    "@conduction/docusaurus-preset": "^1.5.1",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -249,6 +249,7 @@ export default function Home() {
       <main className="marketing-page">
         <DetailHero
           appId="nldesign"
+          background="cobalt"
           status={{ label: 'Beta', color: 'var(--c-orange-knvb)' }}
           version="v0.1"
           locales="NL · EN"


### PR DESCRIPTION
Cobalt-background hero variant + full-bleed clipping fix from preset 1.5.1. See https://mydash.conduction.nl/ for the live look. Tiny diff: 2 files changed.