### PR TITLE
chore(brand): align app-store hex to canonical cobalt #21468B

### DIFF
--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
+  <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#21468B"/>
   <g transform="translate(136, 136) scale(7.5)" fill="#ffffff" stroke="#ffffff">
     <rect x="4" y="4" width="10" height="10" rx="2" fill="none" stroke-width="1.8"/>
     <rect x="18" y="4" width="10" height="10" rx="2" fill="none" stroke-width="1.8"/>


### PR DESCRIPTION
Single-file change to `img/app-store.svg`: hex polygon fill updated from legacy `#4376FC` to canonical `#21468B` (`--c-blue-cobalt`). Part of the fleet sweep aligning the app icon to the brand cobalt — see [design-system colors.html](https://identity.conduction.nl/preview/colors.html) for the rationale. No code or behavior changes.