### PR TITLE
chore(docs): bump preset to ^3.6.0 + sync lockfile

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "nldesign-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^2.6.1",
+        "@conduction/docusaurus-preset": "^3.6.0",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2040,10 +2040,13 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-2.6.1.tgz",
-      "integrity": "sha512-hOkS2XAj3p1wfaZWjvIqKzwC5cbTSLUPm+DJxUp7TePbnU37kaHGegjLjfVOnQ312G8an+0M5VWIhmg/YhRVyA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.6.0.tgz",
+      "integrity": "sha512-gjnM6G+Cjx1WKniMhbQDYjgje0J4nqjeArKUHxisEdsY62fp8mfEzP1NXeD/2F2aYa+eHShCHeYGUM9jTl6yKQ==",
       "license": "EUPL-1.2",
+      "bin": {
+        "validate-ai-baseline": "bin/validate-ai-baseline.mjs"
+      },
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",
         "@docusaurus/preset-classic": "^3.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "ci": "npm ci --legacy-peer-deps && npm run build"
   },
   "dependencies": {
-    "@conduction/docusaurus-preset": "^3.5.0",
+    "@conduction/docusaurus-preset": "^3.6.0",
     "@docusaurus/core": "^3.7.0",
     "@docusaurus/preset-classic": "^3.7.0",
     "@docusaurus/theme-mermaid": "^3.7.0",


### PR DESCRIPTION
Preset 3.6.0 = traditional-SEO baseline. Lockfile regenerated with --min-release-age=0 per .npmrc cooldown override.