### PR TITLE
fix(ci): dependabot should target development per branching strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Per memory feedback_feature-branches-from-dev: dependabot PRs should target development, not main. Default base is main causing check-branch failures on every dependabot PR.