### PR TITLE
chore(docs): sync development -> documentation (3.9.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,51 @@
+# IDE
+/.idea/
+/*.iml
+*.Identifier
+.vscode/
+
 # Dependencies
-node_modules/
-vendor/
+/vendor/
+/node_modules/
 
 # Build artifacts
-build/
-dist/
-.docusaurus/
+/js/
+/build/
+/dist/
 
-# Quality tool output
+# Documentation
+/docs/node_modules/
+/docs/build/
+/docs/.docusaurus/
+/website/node_modules/
+/website/.docusaurus/
+
+# Testing & Quality
+/.php-cs-fixer.cache
+/tests/.phpunit.cache
+/.phpunit.cache/
 .phpunit.cache/
-phpmetrics/
-phpqa/
-coverage/
+.phpunit.result.cache
+/coverage/
+/coverage-frontend/
+/phpmetrics/
+/quality-reports/
+/phpqa/
 phpcs-output.json
 
-# IDE
-.idea/
-.vscode/
-*.swp
-*.swo
+# Nextcloud
+/custom_apps/
+/config/
+.htaccess
 
 # OS
 .DS_Store
 Thumbs.db
 
-# Nextcloud
-.htaccess
-
-# Test/build artifacts
-.phpunit.cache
-.phpunit.result.cache
-
 # SBOM is published as release asset (see SECURITY.md), not stored in repo
 sbom.cdx.json
 bom-php.cdx.json
 bom-npm.cdx.json
+
+# Claude Code
+.claude/worktrees/

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2040,9 +2040,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.8.0.tgz",
-      "integrity": "sha512-aakDh5eyzA4qMhExiU+gOCVLviB/ol8UMulFHiFKz5lKGEf5AKPR7NDuE6rnBpS5qakGyiCwgLSojP3HnBROCA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.9.0.tgz",
+      "integrity": "sha512-WYzKUiF0VyRzhy0ChReAx/w/Dn0HfIKemtr0R+Skt+Q+2+ekA4yffZLJr4zCXexi6wW17XDqh+m9sqsXQqh3RQ==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -54,3 +54,5 @@ rules:
     - Test Nextcloud theming sync (colors, logo)
     - Test dark mode compatibility
     - Verify WCAG AA contrast ratios
+    - Follow mandatory task categories from ADRs 005, 009, 010, 011
+    - Deduplication check focuses on existing token sets and CSS layers (not OpenRegister services)


### PR DESCRIPTION
Brings the 3.9.0 lockfile onto documentation for deploy.