### PR TITLE
sync: development to documentation (meta descriptions #81)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 0
 slug: /
+description: Get started with the NL Design System for Nextcloud. WCAG-AA tokens, components, and CSS variables for government-grade theming across apps.
 ---
 
 # NL Design — User Guide

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -244,7 +244,7 @@ export default function Home() {
   return (
     <Layout
       title="NL Design System, government theming for Nextcloud apps"
-      description="NL Design System theme for Nextcloud. Government-compliant typography, colour, and component variants drop in with one install."
+      description="NL Design System for Nextcloud. Government-grade theming with WCAG-AA tokens, type scale, and CSS variables for every Conduction app."
     >
       <main className="marketing-page">
         <DetailHero


### PR DESCRIPTION
Sync development to documentation so the meta-description deploy fires.