### PR TITLE
chore: sync canonical root configs + capture phpstan baseline

### DIFF
--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * Warn when a PHP class or public method lacks an @spec PHPDoc tag.
+ *
+ * ConductionNL ADR-003 (Backend rules) mandates that every class and public
+ * method MUST have one or more @spec PHPDoc tags linking back to the OpenSpec
+ * change that caused the code to exist:
+ *
+ *     @spec openspec/changes/{change-name}/tasks.md#task-N
+ *
+ * This sniff emits warnings (not errors) so that CI surfaces the gap without
+ * blocking merges while teams backfill coverage. Tests files and magic
+ * methods are skipped, as are private/protected methods — the ADR only
+ * mandates @spec for classes and public methods.
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * SpecTagSniff — warns when @spec PHPDoc tag is missing on classes / public methods.
+ */
+class SpecTagSniff implements Sniff
+{
+
+
+    /**
+     * PHP magic methods that are exempt from the @spec requirement.
+     *
+     * @var array<string>
+     */
+    private const MAGIC_METHODS = [
+        '__construct',
+        '__destruct',
+        '__get',
+        '__set',
+        '__call',
+        '__callstatic',
+        '__isset',
+        '__unset',
+        '__tostring',
+        '__invoke',
+        '__clone',
+        '__sleep',
+        '__wakeup',
+        '__serialize',
+        '__unserialize',
+        '__set_state',
+        '__debuginfo',
+    ];
+
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Process a T_CLASS or T_FUNCTION token.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Skip test files.
+        if ($this->isTestFile(phpcsFile: $phpcsFile) === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $code   = $tokens[$stackPtr]['code'];
+
+        if ($code === T_CLASS) {
+            $this->processClass(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+        if ($code === T_FUNCTION) {
+            $this->processFunction(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+    }//end process()
+
+
+    /**
+     * Check a class declaration for an @spec docblock tag.
+     *
+     * Skips anonymous classes (no name follows the T_CLASS keyword).
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_CLASS token.
+     *
+     * @return void
+     */
+    private function processClass(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Anonymous classes — $var = new class { ... } — have no name; skip.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1), null, false, null, true);
+        if ($namePtr === false) {
+            return;
+        }
+
+        // Sanity: name should be on the same line or within a short window.
+        $openBracePtr = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1));
+        if ($openBracePtr !== false && $namePtr > $openBracePtr) {
+            return;
+        }
+
+        $className = $tokens[$namePtr]['content'];
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Class %s is missing @spec PHPDoc tag — link back to openspec/changes/{name}/tasks.md#task-N';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingClassSpec', [$className]);
+
+    }//end processClass()
+
+
+    /**
+     * Check a function declaration for an @spec docblock tag.
+     *
+     * Only flags public methods declared inside a class. Global functions,
+     * private/protected methods, and magic methods are skipped.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return void
+     */
+    private function processFunction(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Must be inside a class scope.
+        $className = $this->getEnclosingClassName(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+        if ($className === null) {
+            return;
+        }
+
+        // Get method name.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
+        if ($namePtr === false) {
+            return;
+        }
+
+        $methodName = $tokens[$namePtr]['content'];
+
+        // Skip magic methods.
+        if (in_array(strtolower($methodName), self::MAGIC_METHODS, true) === true) {
+            return;
+        }
+
+        // Determine visibility: default is public when no modifier present.
+        if ($this->isPublicMethod(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === false) {
+            return;
+        }
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Public method %s::%s() is missing @spec PHPDoc tag';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingMethodSpec', [$className, $methodName]);
+
+    }//end processFunction()
+
+
+    /**
+     * Check whether the docblock directly preceding $stackPtr contains an @spec tag.
+     *
+     * Walks backwards from the token skipping whitespace, attribute tokens, and
+     * visibility/abstract/final/static modifiers. If the next non-skipped token
+     * is the close of a doc comment, scan the block for @spec.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the class/function token.
+     *
+     * @return bool True when an @spec tag is present.
+     */
+    private function hasSpecTag(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $skip = [
+            T_WHITESPACE,
+            T_ABSTRACT,
+            T_FINAL,
+            T_STATIC,
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE,
+            T_READONLY,
+            T_ATTRIBUTE,
+            T_ATTRIBUTE_END,
+        ];
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+
+            // Skip over attribute blocks (PHP 8 #[Attribute]) in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if (in_array($code, $skip, true) === true) {
+                $ptr--;
+                continue;
+            }
+
+            break;
+        }
+
+        if ($ptr < 0) {
+            return false;
+        }
+
+        if ($tokens[$ptr]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return false;
+        }
+
+        if (isset($tokens[$ptr]['comment_opener']) === false) {
+            return false;
+        }
+
+        $opener = $tokens[$ptr]['comment_opener'];
+        for ($i = $opener; $i <= $ptr; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG
+                && strtolower($tokens[$i]['content']) === '@spec'
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end hasSpecTag()
+
+
+    /**
+     * Determine if the function at $stackPtr is a public method.
+     *
+     * Methods default to public when no visibility modifier is present.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return bool True when the method is public (explicit or default).
+     */
+    private function isPublicMethod(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+            if ($code === T_PUBLIC) {
+                return true;
+            }
+
+            if ($code === T_PROTECTED || $code === T_PRIVATE) {
+                return false;
+            }
+
+            if ($code === T_WHITESPACE
+                || $code === T_ABSTRACT
+                || $code === T_FINAL
+                || $code === T_STATIC
+                || $code === T_READONLY
+            ) {
+                $ptr--;
+                continue;
+            }
+
+            // Skip attributes in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if ($code === T_DOC_COMMENT_CLOSE_TAG
+                || $code === T_COMMENT
+                || $code === T_OPEN_CURLY_BRACKET
+                || $code === T_CLOSE_CURLY_BRACKET
+                || $code === T_SEMICOLON
+            ) {
+                // No visibility modifier found — default public.
+                return true;
+            }
+
+            $ptr--;
+        }
+
+        return true;
+
+    }//end isPublicMethod()
+
+
+    /**
+     * Return the name of the class/interface/trait/enum enclosing $stackPtr, or null.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token to inspect.
+     *
+     * @return string|null The enclosing class name, or null when at file scope.
+     */
+    private function getEnclosingClassName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return null;
+        }
+
+        // Walk the conditions chain looking for the innermost class-like scope.
+        $classLike = [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM, T_ANON_CLASS];
+
+        foreach (array_reverse($tokens[$stackPtr]['conditions'], true) as $scopePtr => $scopeCode) {
+            if (in_array($scopeCode, $classLike, true) === true) {
+                $namePtr = $phpcsFile->findNext(T_STRING, ($scopePtr + 1));
+                if ($namePtr === false) {
+                    return '{anonymous}';
+                }
+
+                // Sanity: ensure the name is before the opening brace for that class.
+                if (isset($tokens[$scopePtr]['scope_opener']) === true
+                    && $namePtr > $tokens[$scopePtr]['scope_opener']
+                ) {
+                    return '{anonymous}';
+                }
+
+                return $tokens[$namePtr]['content'];
+            }
+        }
+
+        return null;
+
+    }//end getEnclosingClassName()
+
+
+    /**
+     * Check whether the currently-scanned file is a test file.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return bool True for files under /tests/ or /Tests/.
+     */
+    private function isTestFile(File $phpcsFile): bool
+    {
+        $path = str_replace('\\', '/', $phpcsFile->getFilename());
+        return (stripos($path, '/tests/') !== false);
+
+    }//end isTestFile()
+
+
+}//end class

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Forbid the legacy named accessors on \OC::$server that were removed in Nextcloud 34.
+ *
+ * Flags patterns like:
+ *   \OC::$server->getDatabaseConnection()
+ *   \OC::$server->getSystemConfig()
+ *   \OC::$server->getLogger()
+ *
+ * These named accessors were removed in Nextcloud 34. The replacement pattern
+ * is constructor dependency injection of the equivalent OCP interface.
+ *
+ * PSR-11 lookups such as \OC::$server->get(SomeClass::class) are NOT flagged
+ * here; service-locator deprecation is tracked separately (design.md, D4).
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Nextcloud;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NoLegacyServerAccessorsSniff — forbids removed \OC::$server->getX() accessors.
+ */
+class NoLegacyServerAccessorsSniff implements Sniff
+{
+
+
+    /**
+     * Map of known named accessors to their approved OCP replacement interface.
+     *
+     * Covers the accessors that still appeared in this codebase plus the most
+     * frequently used Nextcloud 34 removals. The error message interpolates the
+     * accessor name and the replacement from this table so engineers see the
+     * intended DI target at the violation site.
+     *
+     * @var array<string, string>
+     */
+    private const REPLACEMENTS = [
+        'getSystemConfig'           => '\OCP\IConfig',
+        'getConfig'                 => '\OCP\IConfig',
+        'getDatabaseConnection'     => '\OCP\IDBConnection',
+        'getLogger'                 => '\Psr\Log\LoggerInterface',
+        'getL10NFactory'            => '\OCP\L10N\IFactory',
+        'getL10N'                   => '\OCP\IL10N (via \OCP\L10N\IFactory)',
+        'getUserSession'            => '\OCP\IUserSession',
+        'getUserManager'            => '\OCP\IUserManager',
+        'getGroupManager'           => '\OCP\IGroupManager',
+        'getURLGenerator'           => '\OCP\IURLGenerator',
+        'getRequest'                => '\OCP\IRequest',
+        'getRootFolder'             => '\OCP\Files\IRootFolder',
+        'getAppManager'             => '\OCP\App\IAppManager',
+        'getSession'                => '\OCP\ISession',
+        'getMemCacheFactory'        => '\OCP\ICacheFactory',
+        'getEventDispatcher'        => '\OCP\EventDispatcher\IEventDispatcher',
+        'getNotificationManager'    => '\OCP\Notification\IManager',
+        'getTempManager'            => '\OCP\ITempManager',
+        'getMimeTypeDetector'       => '\OCP\Files\IMimeTypeDetector',
+        'getMimeTypeLoader'         => '\OCP\Files\IMimeTypeLoader',
+        'getActivityManager'        => '\OCP\Activity\IManager',
+        'getDateTimeFormatter'      => '\OCP\IDateTimeFormatter',
+        'getDateTimeZone'           => '\OCP\IDateTimeZone',
+        'getTrustedDomainHelper'    => '\OCP\Security\ITrustedDomainHelper',
+        'getRegisteredAppContainer' => 'explicit constructor injection of the specific service',
+    ];
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * Anchors on T_DOUBLE_COLON so we can reconstruct the full pattern
+     * \OC :: $server -> getX ( in a single process() call.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_DOUBLE_COLON];
+
+    }//end register()
+
+    /**
+     * Process a T_DOUBLE_COLON token — flag if part of \OC::$server->getX().
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_DOUBLE_COLON token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Previous non-whitespace token must be T_STRING "OC".
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false
+            || $tokens[$prev]['code'] !== T_STRING
+            || $tokens[$prev]['content'] !== 'OC'
+        ) {
+            return;
+        }
+
+        // Next non-whitespace token must be T_VARIABLE "$server".
+        $afterColon = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($stackPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($afterColon === false
+            || $tokens[$afterColon]['code'] !== T_VARIABLE
+            || $tokens[$afterColon]['content'] !== '$server'
+        ) {
+            return;
+        }
+
+        // Expect T_OBJECT_OPERATOR '->'.
+        $arrow = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($afterColon + 1),
+            end: null,
+            exclude: true
+        );
+        if ($arrow === false || $tokens[$arrow]['code'] !== T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        // Expect T_STRING method name.
+        $methodPtr = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($arrow + 1),
+            end: null,
+            exclude: true
+        );
+        if ($methodPtr === false || $tokens[$methodPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Must be followed by ( to be a call.
+        $openParen = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($methodPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($openParen === false || $tokens[$openParen]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $methodName = $tokens[$methodPtr]['content'];
+
+        // PSR-11 ->get(...) is deferred (D4 in design.md) — not flagged here.
+        if ($methodName === 'get') {
+            return;
+        }
+
+        // Only flag named accessors: getX where X starts with an uppercase letter.
+        if (preg_match(pattern: '/^get[A-Z]/', subject: $methodName) !== 1) {
+            return;
+        }
+
+        $replacement = self::REPLACEMENTS[$methodName] ?? 'the corresponding OCP interface';
+
+        $error = 'Named accessor \\OC::$server->%s() is removed in Nextcloud 34. Inject %s via the constructor instead.';
+        $phpcsFile->addError(
+            $error,
+            $stackPtr,
+            'LegacyNamedAccessor',
+            [$methodName, $replacement]
+        );
+
+    }//end process()
+}//end class

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,8 +6,15 @@
 
     <!-- Exclude external and vendor files -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor-bin/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt)
+         keep it out of lint scope; no-op for apps without the directory. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface phpcs warnings (e.g. SpecTagSniff) in CI logs without failing the build. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
@@ -38,7 +45,6 @@
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
     <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
-    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
     <rule ref="Squiz.Commenting.BlockComment"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
@@ -49,8 +55,13 @@
     <rule ref="Squiz.Commenting.VariableComment"/>
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Scope.MethodScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
@@ -72,14 +83,18 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="lineLimit" value="125"/>
+            <property name="lineLimit" value="150"/>
             <property name="absoluteLineLimit" value="150"/>
         </properties>
     </rule>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.LowerCaseKeyword"/>
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <rule ref="PSR2.Classes.PropertyDeclaration"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
@@ -203,6 +218,17 @@
     <!-- Custom rule to enforce named parameters -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php">
         <type>error</type>
+    </rule>
+
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query() removed in Nextcloud 34. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
+        <type>error</type>
+    </rule>
+
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag (hydra ADR-003).
+         Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
+        <type>warning</type>
     </rule>
 
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,57 @@
+# PHPStan baseline — generated post-canonical-sync (Phase 2 fleet rollout).
+# Cleanup tracked in https://github.com/ConductionNL/nldesign/issues/98
+# Notable: absorbs OCA\Theming\ImageManager / ThemingDefaults references from
+# lib/Service/ThemingService.php. OCA\Theming is a server-internal namespace
+# (not exposed via OCP); if other apps baseline the same family, consider
+# promoting an OCA\\Theming\\ ignore pattern to canonical phpstan.neon.
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Call to method getImageUrl\\(\\) on an unknown class OCA\\\\Theming\\\\ImageManager\\.$#"
+			count: 2
+			path: lib/Controller/SettingsController.php
+
+		-
+			message: "#^Call to method hasImage\\(\\) on an unknown class OCA\\\\Theming\\\\ImageManager\\.$#"
+			count: 2
+			path: lib/Controller/SettingsController.php
+
+		-
+			message: "#^Call to method set\\(\\) on an unknown class OCA\\\\Theming\\\\ThemingDefaults\\.$#"
+			count: 1
+			path: lib/Service/ThemingService.php
+
+		-
+			message: "#^Call to method updateImage\\(\\) on an unknown class OCA\\\\Theming\\\\ImageManager\\.$#"
+			count: 1
+			path: lib/Service/ThemingService.php
+
+		-
+			message: "#^Method OCA\\\\NLDesign\\\\Service\\\\ThemingService\\:\\:getImageManager\\(\\) has invalid return type OCA\\\\Theming\\\\ImageManager\\.$#"
+			count: 2
+			path: lib/Service/ThemingService.php
+
+		-
+			message: "#^Parameter \\$imageManager of method OCA\\\\NLDesign\\\\Service\\\\ThemingService\\:\\:__construct\\(\\) has invalid type OCA\\\\Theming\\\\ImageManager\\.$#"
+			count: 2
+			path: lib/Service/ThemingService.php
+
+		-
+			message: "#^Parameter \\$themingDefaults of method OCA\\\\NLDesign\\\\Service\\\\ThemingService\\:\\:__construct\\(\\) has invalid type OCA\\\\Theming\\\\ThemingDefaults\\.$#"
+			count: 2
+			path: lib/Service/ThemingService.php
+
+		-
+			message: "#^Property OCA\\\\NLDesign\\\\Service\\\\ThemingService\\:\\:\\$imageManager has unknown class OCA\\\\Theming\\\\ImageManager as its type\\.$#"
+			count: 2
+			path: lib/Service/ThemingService.php
+
+		-
+			message: "#^Property OCA\\\\NLDesign\\\\Service\\\\ThemingService\\:\\:\\$themingDefaults has unknown class OCA\\\\Theming\\\\ThemingDefaults as its type\\.$#"
+			count: 2
+			path: lib/Service/ThemingService.php
+
+		-
+			message: "#^Property OCA\\\\NLDesign\\\\Settings\\\\Admin\\:\\:\\$l is never read, only written\\.$#"
+			count: 1
+			path: lib/Settings/Admin.php

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * PHPStan bootstrap file - registers OCP autoloader for static analysis.
+ */
+
+$autoloader = require __DIR__ . '/vendor/autoload.php';
+$autoloader->addPsr4('OCP\\', __DIR__ . '/vendor/nextcloud/ocp/OCP/');
+$autoloader->addPsr4('NCU\\', __DIR__ . '/vendor/nextcloud/ocp/NCU/');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,19 +1,59 @@
+includes:
+    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
+    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
+    # across the fleet.
+    - phpstan-baseline.neon
+
 parameters:
     level: 5
     paths:
         - lib
     bootstrapFiles:
-        - vendor/autoload.php
+        - phpstan-bootstrap.php
+    excludePaths:
+        - vendor
+        - vendor-bin
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
+        - lib/Resources/template
     scanDirectories:
         - vendor/nextcloud/ocp
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
-        # Nextcloud internal classes that PHPStan might not recognize
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
         - '#Access to static property \$server on an unknown class OC#'
-        # Theming app classes are not available as stubs
-        - '#unknown class OCA\\Theming\\#'
-        - '#invalid (return )?type OCA\\Theming\\#'
-        - '#Call to method .+ on an unknown class OCA\\Theming\\#'
-        - '#invalid type OCA\\Theming\\#'
+        - '#unknown class OC\\#'
+        - '#Caught class OC\\#'
+        - '#unknown class OC_App#'
+        - '#Class OC_App not found#'
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
+        - '#unknown class OCA\\DAV\\#'
+        - '#Class OCA\\DAV\\#'
+        # OCA classes from other apps (OpenRegister) not available during static analysis
+        - '#unknown class OCA\\OpenRegister\\#'
+        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\OpenRegister\\#'
+        - '#has invalid return type OCA\\OpenRegister\\#'
+        - '#has invalid type OCA\\OpenRegister\\#'
+        - '#implements unknown interface OCA\\OpenRegister\\#'
+        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
+        - '#unknown class GuzzleHttp\\#'
+        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class GuzzleHttp\\#'
+        - '#invalid type GuzzleHttp\\#'
+        - '#Caught class GuzzleHttp\\#'
+        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
+        # Dynamic HTTP status codes from business rule validation results
+        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        # OCP stub gaps for methods that exist at runtime
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,11 @@
                 <referencedClass name="OCP\AppFramework\Controller"/>
                 <referencedClass name="OCP\AppFramework\IAppContainer"/>
                 <referencedClass name="OCP\App\IAppManager"/>
+                <referencedClass name="OCP\BackgroundJob\IJobList"/>
+                <referencedClass name="OCP\BackgroundJob\QueuedJob"/>
+                <referencedClass name="OCP\BackgroundJob\TimedJob"/>
+                <referencedClass name="OCP\EventDispatcher\Event"/>
+                <referencedClass name="OCP\EventDispatcher\IEventListener"/>
                 <referencedClass name="OCP\IAppConfig"/>
                 <referencedClass name="OCP\ICacheFactory"/>
                 <referencedClass name="OCP\IConfig"/>
@@ -34,15 +39,55 @@
                 <referencedClass name="OCP\IGroupManager"/>
                 <referencedClass name="OCP\IUserManager"/>
                 <referencedClass name="OCP\IUserSession"/>
+                <referencedClass name="OCP\IMemcache"/>
                 <referencedClass name="OCP\IRequest"/>
                 <referencedClass name="OCP\EventDispatcher\IEventDispatcher"/>
+                <referencedClass name="OCP\DB\QueryBuilder\IQueryBuilder"/>
+                <referencedClass name="OCP\AppFramework\Db\QBMapper"/>
+                <referencedClass name="OCP\AppFramework\Db\Entity"/>
+                <referencedClass name="OCP\Files\IRootFolder"/>
+                <referencedClass name="OCP\Files\Node"/>
+                <referencedClass name="OCP\Files\File"/>
+                <referencedClass name="OCP\Files\Folder"/>
+                <referencedClass name="OCP\Files\NotFoundException"/>
                 <referencedClass name="OCP\AppFramework\Http\JSONResponse"/>
                 <referencedClass name="OCP\AppFramework\Http\TemplateResponse"/>
+                <referencedClass name="OCP\AppFramework\Http\DataResponse"/>
                 <referencedClass name="OCP\IL10N"/>
                 <referencedClass name="OCP\IURLGenerator"/>
-                <!-- Nextcloud Theming Classes -->
-                <referencedClass name="OCA\Theming\ImageManager"/>
-                <referencedClass name="OCA\Theming\ThemingDefaults"/>
+                <referencedClass name="OCP\Http\Client\IClient"/>
+                <referencedClass name="OCP\Http\Client\IClientService"/>
+                <referencedClass name="OCP\Notification\IManager"/>
+                <referencedClass name="OCP\Share\IManager"/>
+                <!-- OpenRegister cross-app classes (loaded dynamically) -->
+                <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
+                <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
+                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
+                <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
+                <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
+                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
+                <referencedClass name="OCA\OpenRegister\Service\FileService"/>
+                <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
+                <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- Additional OCP infrastructure types used across the fleet -->
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
+                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
+                <referencedClass name="OCP\DB\Exception"/>
+                <referencedClass name="OCP\IGroup"/>
+                <referencedClass name="OCP\IUser"/>
+                <referencedClass name="OCP\Migration\IRepairStep"/>
+                <!-- Nextcloud server internals -->
+                <referencedClass name="OC"/>
+                <!-- GuzzleHttp (loaded via composer at runtime) -->
+                <referencedClass name="GuzzleHttp\Client"/>
+                <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedMagicMethod errorLevel="suppress"/>
@@ -64,6 +109,8 @@
         <NoValue errorLevel="suppress"/>
         <TypeDoesNotContainNull errorLevel="suppress"/>
         <TypeDoesNotContainType errorLevel="suppress"/>
+        <InvalidArrayOffset errorLevel="suppress"/>
+        <InvalidCast errorLevel="suppress"/>
         <InvalidArgument errorLevel="suppress"/>
         <InvalidReturnType errorLevel="suppress"/>
         <InvalidReturnStatement errorLevel="suppress"/>
@@ -71,7 +118,8 @@
         <EmptyArrayAccess errorLevel="suppress"/>
         <ImplementedReturnTypeMismatch errorLevel="suppress"/>
         <InvalidMethodCall errorLevel="suppress"/>
-        <InvalidArrayOffset errorLevel="suppress"/>
+        <UndefinedInterfaceMethod errorLevel="suppress"/>
+        <MissingTemplateParam errorLevel="suppress"/>
     </issueHandlers>
     <extraFiles>
         <directory name="vendor/nextcloud/ocp" />


### PR DESCRIPTION
Part of the Phase 2 fleet rollout consolidating root-level PHP quality configs onto the canonical version maintained in `nextcloud-app-template`.

Pattern proven on shillinq#300 (merged) and decidesk#243 (merged).

## Synced from canonical

- `phpcs.xml` (cosmetic: ruleset name -> "NLDesign")
- `phpmd.xml` (cosmetic: ruleset name -> "NLDesign Nextcloud Rules")
- `psalm.xml`
- `phpstan.neon`
- `phpstan-bootstrap.php` (new)
- `phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php` (new)
- `phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php` (new)

## Baseline

`phpstan-baseline.neon` regenerated; absorbs 17 errors — predominantly the `OCA\Theming\ImageManager` / `ThemingDefaults` family from `lib/Service/ThemingService.php`. `OCA\Theming` is a server-internal namespace not exposed via `OCP`, similar to `OCA\DAV`. If other apps need to baseline the same family during Phase 2, consider promoting an `OCA\\Theming\\` ignore pattern to canonical `phpstan.neon`.

## Mechanical phpmd fixes

**None applied.** phpmd reports 7 issues, all architectural (`StaticAccess`, `LongVariable`, `ExcessiveMethodLength`). No mechanical-fix categories (`MissingImport`, `ElseExpression`, `UnusedLocalVariable`, `UnusedFormalParameter`, `BooleanArgumentFlag`) were present.

## Gates after sync

| gate    | result                                      |
|---------|---------------------------------------------|
| phpcs   | 27 errors / 69 warnings (15 auto-fixable)   |
| phpstan | 0 errors (17 absorbed by baseline)          |
| psalm   | 11 errors                                   |
| phpmd   | 7 architectural issues                      |

Follow-ups tracked in #98.