### PR TITLE
chore(deps): bump composer config.platform.php to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.1"
+			"php": "8.3"
 		}
 	}
 }


### PR DESCRIPTION
Aligns composer platform pin with the runtime constraint (`require.php` bumped to `^8.3` fleet-wide yesterday). Container + CI already use PHP 8.3.30; this just keeps composer's resolver consistent. Part of the fleet-wide PHP 8.3 sweep.