### PR TITLE
fix(metrics): re-increment nldesign_theming_syncs_total on successful theming sync

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -213,11 +213,13 @@ class SettingsController extends Controller
         $customOverridesService = new CustomOverridesService(appManager: $this->appManager);
         $customOverridesService->ensureExists();
 
-        return new JSONResponse([
-            'registry'  => TokenRegistry::getTokens(),
-            'tabs'      => TokenRegistry::getTabLabels(),
-            'overrides' => $customOverridesService->read(),
-        ]);
+        return new JSONResponse(
+                [
+                    'registry'  => TokenRegistry::getTokens(),
+                    'tabs'      => TokenRegistry::getTabLabels(),
+                    'overrides' => $customOverridesService->read(),
+                ]
+                );
     }//end getOverrides()
 
     /**
@@ -261,6 +263,12 @@ class SettingsController extends Controller
         $updatedColors = $this->themingService->applyColors(params: $params);
         $updatedImages = $this->themingService->applyImages(params: $params);
         $updated       = array_merge($updatedColors, $updatedImages);
+
+        // Increment the theming sync counter exposed by MetricsController as
+        // nldesign_theming_syncs_total. Only counted on success (after both
+        // apply* calls completed without throwing).
+        $current = (int) $this->config->getAppValue(Application::APP_ID, 'theming_syncs_total', '0');
+        $this->config->setAppValue(Application::APP_ID, 'theming_syncs_total', (string) ($current + 1));
 
         return new JSONResponse(['status' => 'ok', 'updated' => $updated]);
     }//end updateThemingValues()


### PR DESCRIPTION
## Summary
- The Prometheus counter `nldesign_theming_syncs_total` is exposed by `lib/Controller/MetricsController.php` (line 88) but was never incremented anywhere in `lib/`, so the metric perpetually reported `0`. Flagged in `openspec/coverage-report.md` Bucket 3a.
- Adds the increment in `SettingsController::updateThemingValues` after both `applyColors` and `applyImages` succeed (failure paths intentionally do not count, matching `REQ-PROM-007`).
- Drive-by phpcbf auto-fix on `getOverrides` (multi-line `JSONResponse` formatting) — pre-existing PHPCS error.

## Where
- `lib/Controller/SettingsController.php::updateThemingValues` — `IConfig::setAppValue(APP_ID, 'theming_syncs_total', (string) ($current + 1))` at end of success path.
- Counter has no labels, so cardinality matches the read site in `MetricsController::index` exactly.

## Historical evidence
- `git log --all -p -- lib/` shows only the READ line (`getAppValue`) ever existed across all branches; no prior `inc()` / `setAppValue` for this key was found. The Bucket 3a "removed-lines cache 4 hits" appears to be the same READ line moved between revisions, not a lost write. The increment was therefore never wired — this PR adds it for the first time.

## Test plan
- [x] `composer lint` — passes (no syntax errors)
- [x] `composer phpcs` — 0 errors (was 2 pre-existing, auto-fixed); 11 `@spec` warnings remain (Bucket 4 — separate annotation PR)
- [x] `composer psalm` — 11 pre-existing `UndefinedClass OCA\Theming\*` errors (no Theming app in vendor-only env, unchanged from baseline)
- [x] `composer test:unit` — 12 tests / 393 assertions pass
- [ ] Manual: POST `/apps/nldesign/settings/theming` with valid colors; GET `/apps/nldesign/api/metrics` should show `nldesign_theming_syncs_total` incremented

Refs #105