### PR TITLE
chore(retrofit): drive nldesign spec-coverage to zero

### DIFF
--- a/lib/Service/CssParserService.php
+++ b/lib/Service/CssParserService.php
@@ -58,6 +58,8 @@ class CssParserService
      * @param string $css The raw CSS string containing a :root {} block.
      *
      * @return array<string, string> Map of token name => value.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-27
      */
     public function parseRootBlock(string $css): array
     {

--- a/lib/Service/TokenRegistry.php
+++ b/lib/Service/TokenRegistry.php
@@ -232,6 +232,8 @@ class TokenRegistry implements TokenRegistryInterface
      * Returns tokens grouped by tab.
      *
      * @return array<string, array<string, array{tab: string, type: string, label: string}>> Tokens grouped by tab id.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-46
      */
     public static function getTokensByTab(): array
     {


### PR DESCRIPTION
## Summary
Annotates the two remaining uncovered backend methods in nldesign, driving mechanical spec-coverage to **0 uncovered methods**.

Both methods are real observable behavior that match existing REQs already covered by the archived retrofit change `retrofit-2026-05-24-annotate-nldesign`:

- `lib/Service/CssParserService.php::parseRootBlock` — parses tokens from a `:root {}` block (delegates to the already-annotated `parseDeclarations`). Maps to token-import-export Import Validation (parse CSS), **task-27**.
- `lib/Service/TokenRegistry.php::getTokensByTab` — groups editable tokens by tab id, sibling of the already-annotated `getTabLabels`/`isEditable`. Maps to token-editor-ui Functional Tab Groups, **task-46**.

No reverse-spec needed — both are covered by existing REQs.

## Verification
`python3 csc.py --mode report` → `uncovered_count: 0`.