### PR TITLE
fix: bring CI green — SPDX, route-auth, PHPCS, PHPMD, Psalm, stylelint

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -183,18 +183,15 @@
 	bottom: 0;
 	background: var(--color-main-background);
 	padding-top: 8px;
+	display: flex;
+	gap: 8px;
+	margin-top: 16px;
+	justify-content: flex-end;
 }
 
 .nldesign-dialog h3 {
 	margin-top: 0;
 	margin-bottom: 0.75em;
-}
-
-.nldesign-dialog-actions {
-	display: flex;
-	gap: 8px;
-	margin-top: 16px;
-	justify-content: flex-end;
 }
 
 .nldesign-dialog-cancel,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Application Bootstrap.
  *
- * @category Application
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Application
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-1
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-2
@@ -54,6 +58,8 @@ class Application extends App implements IBootstrap
      * @return void
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter) - required by IBootstrap interface
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-1
      */
     public function register(IRegistrationContext $context): void
     {
@@ -103,7 +109,7 @@ class Application extends App implements IBootstrap
         $designSystem   = $dsService->getDesignSystem($designSystemId);
 
         // 2. Load design system stylesheets in declared order.
-        //    For "none" (stock Nextcloud) this array is empty — no CSS loads.
+        // For "none" (stock Nextcloud) this array is empty — no CSS loads.
         foreach ($designSystem['stylesheets'] as $stylesheet) {
             \OCP\Util::addStyle(application: self::APP_ID, file: $stylesheet);
         }

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Health Controller.
  *
- * @category Controller
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Controller
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-3
  */
@@ -28,8 +32,6 @@ use Psr\Log\LoggerInterface;
  */
 class HealthController extends Controller
 {
-
-
     /**
      * Constructor.
      *
@@ -42,10 +44,9 @@ class HealthController extends Controller
         IRequest $request,
         private readonly LoggerInterface $logger
     ) {
-        parent::__construct($appName, $request);
+        parent::__construct(appName: $appName, request: $request);
 
     }//end __construct()
-
 
     /**
      * Return health check status.
@@ -53,6 +54,8 @@ class HealthController extends Controller
      * @return JSONResponse JSON response with health status and checks.
      *
      * @NoCSRFRequired
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) - \OCP\Server::get() is the NC service-locator API
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-3
      */
@@ -66,10 +69,13 @@ class HealthController extends Controller
         try {
             $config   = \OCP\Server::get(\OCP\IConfig::class);
             $tokenSet = $config->getAppValue('nldesign', 'token_set', 'rijkshuisstijl');
-            $checks['configuration'] = ($tokenSet !== '') ? 'ok' : 'degraded';
+            $checks['configuration'] = 'degraded';
+            if ($tokenSet !== '') {
+                $checks['configuration'] = 'ok';
+            }
         } catch (\Exception $e) {
             $checks['configuration'] = 'error';
-            $status                   = 'error';
+            $status = 'error';
             $this->logger->error('Health check: configuration failed', ['exception' => $e->getMessage()]);
         }
 
@@ -81,6 +87,4 @@ class HealthController extends Controller
         );
 
     }//end index()
-
-
 }//end class

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Metrics Controller.
  *
- * @category Controller
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Controller
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-4
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-5
@@ -36,30 +40,27 @@ use Psr\Log\LoggerInterface;
  */
 class MetricsController extends Controller
 {
-
-
     /**
      * Constructor.
      *
-     * @param string                 $appName                The app name.
-     * @param IRequest               $request                The request object.
-     * @param IConfig                $config                 The config service.
-     * @param TokenSetService        $tokenSetService        The token set service.
-     * @param CustomOverridesService $customOverridesService The custom overrides service.
-     * @param LoggerInterface        $logger                 Logger for error reporting.
+     * @param string                 $appName          The app name.
+     * @param IRequest               $request          The request object.
+     * @param IConfig                $config           The config service.
+     * @param TokenSetService        $tokenSetService  The token set service.
+     * @param CustomOverridesService $overridesService The custom overrides service.
+     * @param LoggerInterface        $logger           Logger for error reporting.
      */
     public function __construct(
         string $appName,
         IRequest $request,
         private readonly IConfig $config,
         private readonly TokenSetService $tokenSetService,
-        private readonly CustomOverridesService $customOverridesService,
+        private readonly CustomOverridesService $overridesService,
         private readonly LoggerInterface $logger
     ) {
-        parent::__construct($appName, $request);
+        parent::__construct(appName: $appName, request: $request);
 
     }//end __construct()
-
 
     /**
      * Expose Prometheus metrics.
@@ -89,10 +90,10 @@ class MetricsController extends Controller
         $lines[] = 'nldesign_up 1';
 
         // Token sets total.
-        $this->collectTokenSetMetrics($lines);
+        $this->collectTokenSetMetrics(lines: $lines);
 
         // Custom overrides total.
-        $this->collectOverrideMetrics($lines);
+        $this->collectOverrideMetrics(lines: $lines);
 
         // Theming syncs counter.
         $syncsTotal = (int) $this->config->getAppValue(Application::APP_ID, 'theming_syncs_total', '0');
@@ -108,7 +109,6 @@ class MetricsController extends Controller
 
     }//end index()
 
-
     /**
      * Collect token set metrics.
      *
@@ -121,7 +121,7 @@ class MetricsController extends Controller
     private function collectTokenSetMetrics(array &$lines): void
     {
         try {
-            $tokenSets    = $this->tokenSetService->getAvailableTokenSets();
+            $tokenSets     = $this->tokenSetService->getAvailableTokenSets();
             $tokenSetCount = count($tokenSets);
 
             $lines[] = '# HELP nldesign_token_sets_total Total number of available token sets';
@@ -142,7 +142,6 @@ class MetricsController extends Controller
 
     }//end collectTokenSetMetrics()
 
-
     /**
      * Collect custom overrides metrics.
      *
@@ -155,7 +154,7 @@ class MetricsController extends Controller
     private function collectOverrideMetrics(array &$lines): void
     {
         try {
-            $overrides    = $this->customOverridesService->read();
+            $overrides     = $this->overridesService->read();
             $overrideCount = count($overrides);
 
             $lines[] = '# HELP nldesign_custom_overrides_total Total custom CSS overrides';
@@ -169,6 +168,4 @@ class MetricsController extends Controller
         }
 
     }//end collectOverrideMetrics()
-
-
 }//end class

--- a/lib/Controller/OverridesController.php
+++ b/lib/Controller/OverridesController.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Overrides Controller.
  *
- * @category Controller
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Controller
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-7
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-8
@@ -25,7 +29,9 @@ namespace OCA\NLDesign\Controller;
 use OCA\NLDesign\Service\CssParserService;
 use OCA\NLDesign\Service\CustomOverridesService;
 use OCA\NLDesign\Service\TokenRegistry;
+use OCA\NLDesign\Settings\Admin;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\DataDownloadResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -74,69 +80,10 @@ class OverridesController extends Controller
         CustomOverridesService $overridesService,
         CssParserService $cssParser
     ) {
-        parent::__construct($appName, $request);
+        parent::__construct(appName: $appName, request: $request);
         $this->overridesService = $overridesService;
         $this->cssParser        = $cssParser;
     }//end __construct()
-
-    /**
-     * Get the current custom token overrides.
-     *
-     * Returns only tokens explicitly set in custom-overrides.css,
-     * plus the full editable token registry for the UI.
-     *
-     * @return JSONResponse The overrides and token registry.
-     *
-     * @AuthorizedAdminSetting(settings=OCA\NLDesign\Settings\Admin)
-     *
-     * @SuppressWarnings(PHPMD.StaticAccess) - TokenRegistry uses static methods by design
-     *
-     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-7
-     */
-    public function getOverrides(): JSONResponse
-    {
-        $overrides = $this->overridesService->read();
-        $registry  = TokenRegistry::getTokens();
-        $tabs      = TokenRegistry::getTabLabels();
-
-        return new JSONResponse(
-            [
-                'overrides' => $overrides,
-                'registry'  => $registry,
-                'tabs'      => $tabs,
-            ]
-        );
-    }//end getOverrides()
-
-    /**
-     * Write new custom token overrides to custom-overrides.css.
-     *
-     * Accepts a JSON body with an 'overrides' key containing token name => value pairs.
-     * Only tokens in the TokenRegistry are accepted; others are silently ignored.
-     *
-     * @return JSONResponse Status and count of written tokens.
-     *
-     * @AuthorizedAdminSetting(settings=OCA\NLDesign\Settings\Admin)
-     *
-     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-8
-     */
-    public function setOverrides(): JSONResponse
-    {
-        $params    = $this->request->getParams();
-        $overrides = $params['overrides'] ?? [];
-
-        if (is_array($overrides) === false) {
-            return new JSONResponse(['error' => 'overrides must be an object'], 400);
-        }
-
-        try {
-            $this->overridesService->write(tokens: $overrides);
-        } catch (\RuntimeException $e) {
-            return new JSONResponse(['error' => $e->getMessage()], 500);
-        }
-
-        return new JSONResponse(['status' => 'ok', 'written' => count($overrides)]);
-    }//end setOverrides()
 
     /**
      * Download custom-overrides.css as a file.
@@ -147,6 +94,7 @@ class OverridesController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-9
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function exportOverrides(): DataDownloadResponse
     {
         $content = $this->overridesService->getRawContent();
@@ -171,6 +119,7 @@ class OverridesController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-10
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function importOverrides(): JSONResponse
     {
         $validationError = $this->validateUploadedFile();
@@ -183,7 +132,7 @@ class OverridesController extends Controller
             return new JSONResponse(['error' => 'Could not read uploaded file'], 400);
         }
 
-        $parsed = $this->cssParser->parseDeclarations($content);
+        $parsed = $this->cssParser->parseDeclarations(content: $content);
         if ($parsed === null) {
             return new JSONResponse(
                 ['error' => 'No CSS custom property declarations found in the uploaded file'],
@@ -191,7 +140,7 @@ class OverridesController extends Controller
             );
         }
 
-        return $this->writeImportedTokens($parsed);
+        return $this->writeImportedTokens(parsed: $parsed);
     }//end importOverrides()
 
     /**

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Settings Controller.
  *
- * @category Controller
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Controller
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-14
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-15
@@ -33,8 +37,10 @@ use OCA\NLDesign\Service\ThemingService;
 use OCA\NLDesign\Service\TokenRegistry;
 use OCA\NLDesign\Service\TokenSetPreviewService;
 use OCA\NLDesign\Service\TokenSetService;
+use OCA\NLDesign\Settings\Admin;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -135,6 +141,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-14
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function setTokenSet(string $tokenSet): JSONResponse
     {
         $tokenSetService = new TokenSetService(appManager: $this->appManager);
@@ -156,6 +163,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-15
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function getTokenSet(): JSONResponse
     {
         $tokenSet = $this->config->getAppValue(
@@ -176,6 +184,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-16
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function getAvailableTokenSets(): JSONResponse
     {
         $tokenSets = $this->tokenSetService->getAvailableTokenSets();
@@ -214,6 +223,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-18
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function setSloganSetting(bool $hideSlogan): JSONResponse
     {
         $this->saveBooleanSetting(key: 'hide_slogan', value: $hideSlogan);
@@ -232,6 +242,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-19
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function setMenuLabelsSetting(bool $showMenuLabels): JSONResponse
     {
         $this->saveBooleanSetting(key: 'show_menu_labels', value: $showMenuLabels);
@@ -246,18 +257,21 @@ class SettingsController extends Controller
      *
      * @AuthorizedAdminSetting(settings=OCA\NLDesign\Settings\Admin)
      *
+     * @SuppressWarnings(PHPMD.StaticAccess) - TokenRegistry uses static methods by design
+     *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-20
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function getOverrides(): JSONResponse
     {
-        $customOverridesService = new CustomOverridesService(appManager: $this->appManager);
-        $customOverridesService->ensureExists();
+        $overridesSvc = new CustomOverridesService(appManager: $this->appManager);
+        $overridesSvc->ensureExists();
 
         return new JSONResponse(
                 [
                     'registry'  => TokenRegistry::getTokens(),
                     'tabs'      => TokenRegistry::getTabLabels(),
-                    'overrides' => $customOverridesService->read(),
+                    'overrides' => $overridesSvc->read(),
                 ]
                 );
     }//end getOverrides()
@@ -273,10 +287,11 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-21
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function setOverrides(array $overrides): JSONResponse
     {
-        $customOverridesService = new CustomOverridesService(appManager: $this->appManager);
-        $customOverridesService->write(tokens: $overrides);
+        $overridesSvc = new CustomOverridesService(appManager: $this->appManager);
+        $overridesSvc->write(tokens: $overrides);
 
         return new JSONResponse(['status' => 'ok']);
     }//end setOverrides()
@@ -290,6 +305,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-22
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function updateThemingValues(): JSONResponse
     {
         $params = $this->request->getParams();
@@ -326,6 +342,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-23
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function getThemingValues(): JSONResponse
     {
         $values = $this->buildThemingSnapshot();
@@ -368,6 +385,7 @@ class SettingsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-25
      */
+    #[AuthorizedAdminSetting(settings: Admin::class)]
     public function getTokenSetPreview(string $tokenSetId): JSONResponse
     {
         if ($this->tokenSetService->isValidTokenSet(tokenSetId: $tokenSetId) === false) {

--- a/lib/Service/ContentTokens.php
+++ b/lib/Service/ContentTokens.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Content Token Definitions.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-26
  */

--- a/lib/Service/CssParserService.php
+++ b/lib/Service/CssParserService.php
@@ -3,11 +3,15 @@
 /**
  * NL Design CSS Parser Service.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-27
  */
@@ -67,7 +71,7 @@ class CssParserService
             return [];
         }
 
-        $result = $this->parseDeclarations($rootMatch[1]);
+        $result = $this->parseDeclarations(content: $rootMatch[1]);
 
         if ($result !== null) {
             return $result;

--- a/lib/Service/CustomOverridesService.php
+++ b/lib/Service/CustomOverridesService.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Custom Overrides Service.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-8
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-28
@@ -144,7 +148,7 @@ class CustomOverridesService
      */
     public function write(array $tokens): void
     {
-        $validated = $this->filterEditable($tokens);
+        $validated = $this->filterEditable(tokens: $tokens);
 
         $this->writeFile(tokens: $validated);
 
@@ -227,7 +231,7 @@ class CustomOverridesService
             return $header.':root {}'.PHP_EOL;
         }
 
-        $lines = $this->buildDeclarationLines($tokens);
+        $lines = $this->buildDeclarationLines(tokens: $tokens);
 
         return $header.':root {'.PHP_EOL.implode(PHP_EOL, $lines).PHP_EOL.'}'.PHP_EOL;
     }//end buildCss()

--- a/lib/Service/DesignSystemService.php
+++ b/lib/Service/DesignSystemService.php
@@ -3,11 +3,15 @@
 /**
  * NL Design — Design System Service.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-35
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-36
@@ -90,7 +94,7 @@ class DesignSystemService
         }
 
         $path = $this->getAppPath().'/design-systems.json';
-        $this->designSystems = $this->readJsonManifest($path);
+        $this->designSystems = $this->readJsonManifest(path: $path);
 
         return $this->designSystems;
     }//end getDesignSystems()
@@ -135,8 +139,8 @@ class DesignSystemService
     public function getTokenSetMeta(string $tokenSetId): array
     {
         if ($this->tokenSetMeta === null) {
-            $path               = $this->getAppPath().'/token-sets.json';
-            $this->tokenSetMeta = $this->readJsonManifest($path);
+            $path = $this->getAppPath().'/token-sets.json';
+            $this->tokenSetMeta = $this->readJsonManifest(path: $path);
         }
 
         return $this->tokenSetMeta[$tokenSetId] ?? [];
@@ -146,6 +150,8 @@ class DesignSystemService
      * Get all design systems as a flat list (for API responses).
      *
      * @return array<array{id: string, name: string, description: string, stylesheets: string[]}> List of design systems.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-35
      */
     public function getDesignSystemsList(): array
     {

--- a/lib/Service/LoginTokens.php
+++ b/lib/Service/LoginTokens.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Login Token Definitions.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-39
  */

--- a/lib/Service/StatusTokens.php
+++ b/lib/Service/StatusTokens.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Status Token Definitions.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-40
  */

--- a/lib/Service/ThemingService.php
+++ b/lib/Service/ThemingService.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Theming Service.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-41
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-42
@@ -222,6 +226,8 @@ class ThemingService
      * Get the current Nextcloud theming image manager.
      *
      * @return ImageManager The image manager instance.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-41
      */
     public function getImageManager(): ImageManager
     {

--- a/lib/Service/TokenRegistry.php
+++ b/lib/Service/TokenRegistry.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Token Registry.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-45
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-46
@@ -46,6 +50,8 @@ class TokenRegistry implements TokenRegistryInterface
      * Values are arrays with 'tab', 'type', and 'label' keys.
      *
      * @return array<string, array{tab: string, type: string, label: string}> The token registry.
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength) - data definition; each entry is a CSS token declaration
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-45
      */
@@ -208,6 +214,8 @@ class TokenRegistry implements TokenRegistryInterface
      * Returns the set of all editable token names.
      *
      * @return array<string> List of token names.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-45
      */
     public static function getTokenNames(): array
     {

--- a/lib/Service/TokenRegistryInterface.php
+++ b/lib/Service/TokenRegistryInterface.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Token Registry Interface.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  */
 
 declare(strict_types=1);
@@ -25,6 +29,8 @@ interface TokenRegistryInterface
      * Returns the full registry of editable tokens.
      *
      * @return array<string, array{tab: string, type: string, label: string}> The token registry.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-45
      */
     public static function getTokens(): array;
 
@@ -32,6 +38,8 @@ interface TokenRegistryInterface
      * Returns the display labels for each tab.
      *
      * @return array<string, string> Map of tab id to display label.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-46
      */
     public static function getTabLabels(): array;
 
@@ -41,6 +49,8 @@ interface TokenRegistryInterface
      * @param string $tokenName The CSS custom property name.
      *
      * @return bool True if the token is in the registry.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-47
      */
     public static function isEditable(string $tokenName): bool;
 }//end interface

--- a/lib/Service/TokenSetPreviewService.php
+++ b/lib/Service/TokenSetPreviewService.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Token Set Preview Service.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-48
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-49

--- a/lib/Service/TokenSetService.php
+++ b/lib/Service/TokenSetService.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Token Set Service.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-50
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-51

--- a/lib/Service/TypographyTokens.php
+++ b/lib/Service/TypographyTokens.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Typography Token Definitions.
  *
- * @category Service
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-54
  */

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -3,11 +3,15 @@
 /**
  * NL Design Admin Settings.
  *
- * @category Settings
- * @package  OCA\NLDesign
- * @author   Conduction <info@conduction.nl>
- * @license  https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
- * @link     https://github.com/ConductionNL/nldesign
+ * @category  Settings
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   https://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0-or-later
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: Copyright (C) 2024 Conduction B.V.
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-55
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-56
@@ -24,7 +28,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\Settings\ISettings;
+use OCP\Settings\IDelegatedSettings;
 
 /**
  * Admin settings form for NL Design.
@@ -35,7 +39,7 @@ use OCP\Settings\ISettings;
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-56
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-57
  */
-class Admin implements ISettings
+class Admin implements IDelegatedSettings
 {
 
     /**
@@ -72,6 +76,41 @@ class Admin implements ISettings
         $this->l          = $l;
         $this->appManager = $appManager;
     }//end __construct()
+
+    /**
+     * Get the display name for partial admin delegation.
+     *
+     * Returns null so only the section name appears in the settings list.
+     *
+     * @return string|null Always null (no extra label needed).
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-55
+     */
+    public function getName(): ?string
+    {
+        return null;
+    }//end getName()
+
+    /**
+     * Get the authorized app config keys for delegation.
+     *
+     * Returns the nldesign app config keys that can be modified via delegated admin.
+     *
+     * @return array<string, string[]> Map of app name to allowed config key patterns.
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-55
+     */
+    public function getAuthorizedAppConfig(): array
+    {
+        return [
+            Application::APP_ID => [
+                '/token_set/',
+                '/hide_slogan/',
+                '/show_menu_labels/',
+                '/theming_syncs_total/',
+            ],
+        ];
+    }//end getAuthorizedAppConfig()
 
     /**
      * Get the settings form.

--- a/psalm.xml
+++ b/psalm.xml
@@ -85,6 +85,9 @@
                 <referencedClass name="OCP\Migration\IRepairStep"/>
                 <!-- Nextcloud server internals -->
                 <referencedClass name="OC"/>
+                <!-- Nextcloud Theming app — peer dep, loaded dynamically at runtime -->
+                <referencedClass name="OCA\Theming\ImageManager"/>
+                <referencedClass name="OCA\Theming\ThemingDefaults"/>
                 <!-- GuzzleHttp (loaded via composer at runtime) -->
                 <referencedClass name="GuzzleHttp\Client"/>
                 <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>


### PR DESCRIPTION
## Summary

- Gate-1 SPDX: Added @copyright + SPDX-FileCopyrightText to all 18 lib/ PHP files
- Gate-5 route-auth: Added #[AuthorizedAdminSetting(Admin::class)] to 11 SettingsController + 4 OverridesController routed methods; Admin now implements IDelegatedSettings
- Gate-14 route-reachability: Removed dead OverridesController::getOverrides + setOverrides (confirmed: frontend routes to settings#getOverrides/setOverrides)
- PHPCS: named-args, inline-IF, docblock alignment fixes
- PHPMD: StaticAccess suppress, rename long variable, ElseExpression fix, ExcessiveMethodLength suppress
- Psalm: OCA\\Theming\\ImageManager + ThemingDefaults baseline-suppressed in psalm.xml
- Stylelint: merged duplicate .nldesign-dialog-actions selectors

## Test plan
- [x] All 18 hydra gates GREEN
- [x] composer check:strict passes (12/12 unit tests)
- [x] npm run stylelint clean