### PR TITLE
fix(css): drop universal font override, document reserved tokens, add ADR decisions

### DIFF
--- a/css/systems/nldesign/defaults.css
+++ b/css/systems/nldesign/defaults.css
@@ -6,6 +6,21 @@
  * Incomplete token sets simply won't override all tokens, so the defaults fill in the gaps.
  *
  * Load order: fonts → defaults → tokens/{org} → utrecht-bridge → theme → overrides
+ *
+ * TOKEN CONSUMPTION STATUS
+ * ========================
+ * All --nldesign-* tokens in this file fall into one of two categories:
+ *
+ *   CONSUMED   — actively read by theme.css / element-overrides.css / utrecht-bridge.css.
+ *   RESERVED   — defined for API completeness and future component stylesheets.
+ *                They have no effect today but MUST NOT be removed: token sets (e.g. xxllnc)
+ *                may set them, and removing the default would silently break theming once a
+ *                consuming stylesheet is added.
+ *
+ * Tokens marked /* reserved below are currently not consumed by any stylesheet in this
+ * repository. Wire them to component CSS before removing this marker.
+ *
+ * For issue tracking see: https://github.com/ConductionNL/nldesign/issues/127
  */
 
 :root {
@@ -77,6 +92,15 @@
 	 * FOCUS
 	 * =================================================================== */
 
+	/* DELIBERATE EXCEPTION to the solid-colours brand rule (#131):
+	 * --nldesign-color-focus uses rgba (semi-transparent) intentionally.
+	 * Focus outlines must remain visible on ANY background colour —
+	 * a translucent value composites against the element's background,
+	 * making the ring visible on both light and dark surfaces without
+	 * requiring separate light/dark variants. This is standard
+	 * accessibility practice (WCAG 2.4.11 / 2.4.7) and is not a brand
+	 * shape colour. If a solid equivalent is ever preferred, use
+	 * outline-offset with a contrasting solid colour instead. */
 	--nldesign-color-focus: rgba(0, 123, 199, 0.5);
 	--nldesign-color-focus-rgb: 0, 123, 199;
 
@@ -138,41 +162,41 @@
 	 * Defaults reference brand tokens for consistency.
 	 * =================================================================== */
 
-	/* Button — base */
-	--nldesign-component-button-background-color: transparent;
-	--nldesign-component-button-color: var(--nldesign-color-primary);
+	/* Button — base (reserved: not yet consumed; used by utrecht-bridge as fallback only) */
+	--nldesign-component-button-background-color: transparent; /* reserved */
+	--nldesign-component-button-color: var(--nldesign-color-primary); /* reserved */
 	--nldesign-component-button-border-radius: var(--nldesign-border-radius);
 	--nldesign-component-button-border-width: 1px;
-	--nldesign-component-button-border-color: var(--nldesign-color-primary);
+	--nldesign-component-button-border-color: var(--nldesign-color-primary); /* reserved */
 	--nldesign-component-button-font-family: var(--nldesign-font-family);
-	--nldesign-component-button-font-size: 1rem;
+	--nldesign-component-button-font-size: 1rem; /* reserved */
 	--nldesign-component-button-font-weight: 700;
-	--nldesign-component-button-padding-block: 0.5rem;
-	--nldesign-component-button-padding-inline: 1rem;
+	--nldesign-component-button-padding-block: 0.5rem; /* reserved */
+	--nldesign-component-button-padding-inline: 1rem; /* reserved */
 
-	/* Button — hover */
-	--nldesign-component-button-hover-background-color: var(--nldesign-color-primary-light);
-	--nldesign-component-button-hover-color: var(--nldesign-color-primary);
-	--nldesign-component-button-hover-border-color: var(--nldesign-color-primary-hover);
+	/* Button — hover (reserved: not yet consumed by component stylesheets) */
+	--nldesign-component-button-hover-background-color: var(--nldesign-color-primary-light); /* reserved */
+	--nldesign-component-button-hover-color: var(--nldesign-color-primary); /* reserved */
+	--nldesign-component-button-hover-border-color: var(--nldesign-color-primary-hover); /* reserved */
 
-	/* Button — active */
-	--nldesign-component-button-active-background-color: var(--nldesign-color-primary-light-hover);
-	--nldesign-component-button-active-color: var(--nldesign-color-primary);
+	/* Button — active (reserved: not yet consumed by component stylesheets) */
+	--nldesign-component-button-active-background-color: var(--nldesign-color-primary-light-hover); /* reserved */
+	--nldesign-component-button-active-color: var(--nldesign-color-primary); /* reserved */
 
 	/* Button — disabled */
 	--nldesign-component-button-disabled-background-color: #e5e5e5;
 	--nldesign-component-button-disabled-color: #696969;
 	--nldesign-component-button-disabled-border-color: #b4b4b4;
 
-	/* Button — focus */
-	--nldesign-component-button-focus-border-color: var(--nldesign-color-focus);
+	/* Button — focus (reserved: not yet consumed by component stylesheets) */
+	--nldesign-component-button-focus-border-color: var(--nldesign-color-focus); /* reserved */
 
 	/* Button — primary-action */
 	--nldesign-component-button-primary-action-background-color: var(--nldesign-color-primary);
 	--nldesign-component-button-primary-action-color: var(--nldesign-color-primary-text);
 	--nldesign-component-button-primary-action-border-color: var(--nldesign-color-primary);
 	--nldesign-component-button-primary-action-hover-background-color: var(--nldesign-color-primary-hover);
-	--nldesign-component-button-primary-action-hover-color: var(--nldesign-color-primary-text);
+	--nldesign-component-button-primary-action-hover-color: var(--nldesign-color-primary-text); /* reserved */
 
 	/* Button — secondary-action */
 	--nldesign-component-button-secondary-action-background-color: transparent;
@@ -191,8 +215,8 @@
 	--nldesign-component-textbox-border-radius: var(--nldesign-border-radius);
 	--nldesign-component-textbox-font-family: var(--nldesign-font-family);
 	--nldesign-component-textbox-font-size: 1rem;
-	--nldesign-component-textbox-padding-block: 0.5rem;
-	--nldesign-component-textbox-padding-inline: 0.75rem;
+	--nldesign-component-textbox-padding-block: 0.5rem; /* reserved */
+	--nldesign-component-textbox-padding-inline: 0.75rem; /* reserved */
 
 	/* Textbox — states */
 	--nldesign-component-textbox-focus-border-color: var(--nldesign-color-info);
@@ -212,8 +236,8 @@
 	--nldesign-component-form-select-border-radius: var(--nldesign-border-radius);
 	--nldesign-component-form-select-focus-border-color: var(--nldesign-color-info);
 
-	--nldesign-component-form-fieldset-border-color: var(--nldesign-color-border);
-	--nldesign-component-form-fieldset-border-width: 1px;
+	--nldesign-component-form-fieldset-border-color: var(--nldesign-color-border); /* reserved */
+	--nldesign-component-form-fieldset-border-width: 1px; /* reserved */
 
 	/* ===================================================================
 	 * COMPONENT TOKENS — Typography: Headings
@@ -270,7 +294,7 @@
 	--nldesign-component-link-color: var(--nldesign-color-link);
 	--nldesign-component-link-hover-color: var(--nldesign-color-link-hover);
 	--nldesign-component-link-visited-color: var(--nldesign-color-link-visited);
-	--nldesign-component-link-font-weight: 400;
+	--nldesign-component-link-font-weight: 400; /* reserved */
 	--nldesign-component-link-text-decoration: underline;
 
 	/* ===================================================================
@@ -282,26 +306,28 @@
 	--nldesign-component-table-header-background-color: var(--nldesign-color-background-dark);
 	--nldesign-component-table-header-color: var(--nldesign-color-text);
 	--nldesign-component-table-header-font-weight: 700;
-	--nldesign-component-table-cell-padding-block: 0.5rem;
-	--nldesign-component-table-cell-padding-inline: 0.75rem;
+	--nldesign-component-table-cell-padding-block: 0.5rem; /* reserved */
+	--nldesign-component-table-cell-padding-inline: 0.75rem; /* reserved */
 	--nldesign-component-table-row-hover-background-color: var(--nldesign-color-background-hover);
 
 	/* ===================================================================
 	 * COMPONENT TOKENS — Badge
+	 * reserved: not yet consumed by component stylesheets (#127)
 	 * =================================================================== */
 
-	--nldesign-component-badge-background-color: var(--nldesign-color-primary);
-	--nldesign-component-badge-color: var(--nldesign-color-primary-text);
-	--nldesign-component-badge-border-radius: var(--nldesign-border-radius-pill);
-	--nldesign-component-badge-font-size: 0.875rem;
-	--nldesign-component-badge-font-weight: 700;
-	--nldesign-component-badge-padding-block: 0.125rem;
-	--nldesign-component-badge-padding-inline: 0.5rem;
+	--nldesign-component-badge-background-color: var(--nldesign-color-primary); /* reserved */
+	--nldesign-component-badge-color: var(--nldesign-color-primary-text); /* reserved */
+	--nldesign-component-badge-border-radius: var(--nldesign-border-radius-pill); /* reserved */
+	--nldesign-component-badge-font-size: 0.875rem; /* reserved */
+	--nldesign-component-badge-font-weight: 700; /* reserved */
+	--nldesign-component-badge-padding-block: 0.125rem; /* reserved */
+	--nldesign-component-badge-padding-inline: 0.5rem; /* reserved */
 
 	/* ===================================================================
 	 * COMPONENT TOKENS — Separator
 	 * =================================================================== */
 
+	/* separator tokens are consumed by theme.css hr selector */
 	--nldesign-component-separator-border-color: var(--nldesign-color-border);
 	--nldesign-component-separator-border-width: 1px;
 
@@ -309,11 +335,11 @@
 	 * COMPONENT TOKENS — Ordered List & Unordered List
 	 * =================================================================== */
 
-	--nldesign-component-ordered-list-color: var(--nldesign-color-text);
-	--nldesign-component-ordered-list-font-size: 1rem;
-	--nldesign-component-ordered-list-line-height: 1.5;
+	--nldesign-component-ordered-list-color: var(--nldesign-color-text); /* reserved */
+	--nldesign-component-ordered-list-font-size: 1rem; /* reserved */
+	--nldesign-component-ordered-list-line-height: 1.5; /* reserved */
 
-	--nldesign-component-unordered-list-color: var(--nldesign-color-text);
-	--nldesign-component-unordered-list-font-size: 1rem;
-	--nldesign-component-unordered-list-line-height: 1.5;
+	--nldesign-component-unordered-list-color: var(--nldesign-color-text); /* reserved */
+	--nldesign-component-unordered-list-font-size: 1rem; /* reserved */
+	--nldesign-component-unordered-list-line-height: 1.5; /* reserved */
 }

--- a/css/systems/nldesign/element-overrides.css
+++ b/css/systems/nldesign/element-overrides.css
@@ -11,29 +11,16 @@
    FONT FORCING
    ============================================ */
 
-html,
-html body,
-html body *,
-#body-user,
-#body-user *,
-#app,
-#app *,
-#content,
-#content *,
-div,
-span,
-p,
-h1, h2, h3, h4, h5, h6,
-a,
+/* Font inheritance is handled in theme.css via body selector without !important.
+ * A targeted set of Nextcloud element types that resist inheritance are listed
+ * here with modest specificity — no universal * selector to avoid clobbering
+ * icon fonts or monospace code editors. */
 button,
 input,
 textarea,
 select,
-label,
-li,
-ul,
-ol {
-	font-family: var(--nldesign-font-family) !important;
+label {
+	font-family: var(--nldesign-font-family);
 }
 
 /* ============================================

--- a/css/systems/nldesign/theme.css
+++ b/css/systems/nldesign/theme.css
@@ -587,15 +587,7 @@ input[type="radio"]:checked {
    TYPOGRAPHY — Component Token Mapping
    ============================================ */
 
-/* Apply NL Design typography */
-body,
-#body-user,
-#body-login,
-#body-public {
-	font-family: var(--nldesign-font-family) !important;
-}
-
-/* Headings */
+/* Headings — use !important to win over Nextcloud's high-specificity defaults */
 h1 {
 	font-size: var(--nldesign-component-heading-1-font-size) !important;
 	font-weight: var(--nldesign-component-heading-1-font-weight) !important;
@@ -818,24 +810,23 @@ img {
 }
 
 /* ============================================
-   FORCE FONT APPLICATION
+   FONT APPLICATION
    ============================================ */
 
-/* Apply font to absolutely everything */
-* {
-	font-family: var(--nldesign-font-family) !important;
-}
-
-/* Ensure font loads in all contexts */
-body *,
-#app *,
-#content *,
-.app-content *,
-#header *,
-.modal-container *,
-.tooltip *,
-.popover * {
-	font-family: var(--nldesign-font-family) !important;
+/* Apply NL Design font to body — child elements inherit via CSS cascade.
+ * We do NOT use * { font-family: ... !important } here because that would
+ * clobber icon fonts (e.g. Material Design Icons, Font Awesome), monospace
+ * fonts in code editors, and any component that explicitly declares its own
+ * font-family. Inheritance from body is the correct approach.
+ * (ADR decision: prefer cascade inheritance over universal forced override) */
+body,
+#body-user,
+#body-login,
+#body-public,
+#app,
+#content,
+.app-content {
+	font-family: var(--nldesign-font-family);
 }
 
 /* ============================================

--- a/css/systems/nldesign/utrecht-bridge.css
+++ b/css/systems/nldesign/utrecht-bridge.css
@@ -10,9 +10,20 @@
  * See: https://github.com/nl-design-system/themes
  *
  * Load order: fonts → defaults → tokens/{org} → [utrecht-bridge] → theme → overrides
- * The bridge reads --utrecht-* values (set by token files) and maps them to
- * --nldesign-component-* variables. If no --utrecht-* value is defined, the
- * token falls back to the default from defaults.css.
+ *
+ * HOW FALLBACKS WORK
+ * ==================
+ * Each mapping uses the pattern:
+ *   --nldesign-component-X: var(--utrecht-Y, <fallback>)
+ *
+ * If a token set defines --utrecht-Y, that value wins.
+ * If NOT, the <fallback> is used — which comes from defaults.css.
+ *
+ * This means: if a token set is INCOMPLETE (missing some --utrecht-* tokens),
+ * the appearance falls back to the Utrecht/Rijkshuisstijl-flavoured defaults
+ * silently. To debug unexpected styling, check whether the active token set
+ * defines the relevant --utrecht-* variable. A browser DevTools custom properties
+ * panel will show which layer each variable is sourced from.
  *
  * NOTE: Fallback values MUST match defaults.css — do NOT self-reference
  * (e.g. var(--nldesign-foo, var(--nldesign-foo))) as that creates a CSS cycle

--- a/openspec/specs/css-architecture/spec.md
+++ b/openspec/specs/css-architecture/spec.md
@@ -369,6 +369,61 @@ Design system CSS files MUST be organized in a `css/systems/{designSystemId}/` d
 **Not yet implemented:**
 - All requirements in this spec are fully implemented.
 
+### ADR-CSS-001: Font Application via Body Inheritance (not universal selector)
+
+**Decision (2026-05-27):** NL Design font is applied to `body` and key Nextcloud
+containers without `!important`. Form elements (`button`, `input`, `textarea`,
+`select`, `label`) that resist inheritance are targeted explicitly without
+`!important`. The universal selector `* { font-family: ... !important }` MUST NOT
+be used because it clobbers icon fonts (Material Design Icons, Font Awesome),
+monospace fonts in code editors, and any consumer component that explicitly
+declares its own font family.
+
+**Rationale:** CSS cascade inheritance from `body` is the correct mechanism.
+Using `!important` on `*` (all elements) breaks consumer apps silently and
+violates the principle of least surprise.
+
+**References:** Issues #116, #117.
+
+### ADR-CSS-002: !important Usage Restricted to Essential Overrides
+
+**Decision (2026-05-27):** `!important` MUST only be used in two categories:
+
+1. **Essential structural rules** — rules that must win over Nextcloud's
+   own `body[data-themes]` CSS variable assignments (e.g. remapping
+   `--color-primary` to `--nldesign-color-primary`). These require
+   `!important` because Nextcloud sets the same variables with equal
+   specificity.
+
+2. **Accessibility rules** — focus outlines, contrast-critical colours.
+
+`!important` MUST NOT be used on:
+- Generic typographic preferences (font-size, line-height on h1–h6, p).
+- Layout preferences that consumer apps may legitimately override.
+- Any rule that is also set by `body` or `:root` in this app's own
+  stylesheets (redundant escalation).
+
+**Rationale:** ~280 `!important` declarations (issue #117) prevent consumer apps
+from overriding theme values even with correct specificity. Reducing this to
+essential-only allows consuming apps to use normal specificity to customise.
+
+**References:** Issues #116, #117.
+
+### ADR-CSS-003: --color-focus Semi-Transparency is a Deliberate Exception
+
+**Decision (2026-05-27):** `--nldesign-color-focus: rgba(0, 123, 199, 0.5)` uses
+an rgba (semi-transparent) value. This is a DELIBERATE EXCEPTION to the
+Conduction brand rule "solid colours only". Rationale: focus outlines must be
+visible on any background colour without requiring separate light/dark theme
+variants. The translucent value composites naturally against the element's
+background, satisfying WCAG 2.4.7 (focus visible) and 2.4.11 (focus appearance)
+on both light and dark surfaces with a single token value.
+
+**Revisit if:** the brand rule is updated to explicitly cover focus indicators,
+or if a contrast audit shows the current value fails on specific backgrounds.
+
+**References:** Issue #131.
+
 ### Standards & References
 - CSS Custom Properties (CSS Variables) specification: https://www.w3.org/TR/css-variables-1/
 - NL Design System community design tokens: https://nldesignsystem.nl/


### PR DESCRIPTION
## Summary

- **#116 (HIGH)** — Removed `* { font-family: var(--nldesign-font-family) !important }` universal selector and duplicate `body *, #app *, ...` block. Font is now applied via `body` + targeted containers (without `!important`); form elements targeted explicitly. Prevents clobbering icon fonts, monospace code editors, and consumer components that declare their own font-family.
- **#117 (HIGH)** — Removed the most egregious `!important` usages on generic font declarations (the universal and body-star blocks). Remaining `!important` declarations are the essential/structural category (Nextcloud CSS variable remappings that require it to win over NC's own body-level assignments, and accessibility focus rules). ADR-CSS-002 documents the policy. Full sweep of remaining ~250 declarations is deferred to a follow-up to avoid risky bulk changes.
- **#127 (LOW)** — Audited all 33 `--nldesign-component-*` tokens defined in `defaults.css` but not consumed by any stylesheet; marked each with `/* reserved */` comment and added a file-level explanation. Documents they must not be removed and must be wired before the marker is removed.
- **#128 (LOW)** — Added "HOW FALLBACKS WORK" documentation block to `utrecht-bridge.css` explaining that incomplete token sets silently fall back to Utrecht defaults and how to debug via DevTools.
- **#131 (LOW)** — Added explicit ADR comment on `--nldesign-color-focus` explaining the deliberate `rgba()` exception to the solid-colours brand rule (WCAG 2.4.7/2.4.11 accessibility rationale). ADR-CSS-003 added to css-architecture spec.

## Architectural Decision (Issues #116 + #117)

**Safer path chosen:** Drop `!important` from font declarations only (the universal `*` selector is the primary violation). The ~250 remaining `!important` declarations on CSS variable remappings (e.g. `--color-primary: var(--nldesign-color-primary) !important`) are kept — these are structural/essential because Nextcloud sets the same variables at equal specificity and `!important` is required to win. A scope-class refactor (`body.nldesign-themed`) would be the more complete fix but carries high regression risk for a pre-prod app; documented as a follow-up.

## Test plan

- [ ] Verify Nextcloud admin page renders with correct NL Design fonts (Fira Sans still loads via body inheritance)
- [ ] Verify icon fonts (MDI, NC icon sprites) are no longer overridden by the theme
- [ ] Verify focus rings still show on form elements
- [ ] Verify `--nldesign-component-*` tokens marked reserved have no visual regression