### PR TITLE
fix(php): DI injection, public endpoints, JSON encoding, MIME validation, dynamic preview

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -25,23 +25,37 @@ function nldesignAdminMain() {
 		console.error('Failed to parse token sets data:', e);
 	}
 
-	// Token set color mappings for preview
-	var tokenSetColors = {
-		nextcloud: { primary: '#0082c9', primaryHover: '#006fad', primaryText: '#ffffff' },
-		rijkshuisstijl: { primary: '#154273', primaryHover: '#162f50', primaryText: '#ffffff' },
-		utrecht: { primary: '#24578F', primaryHover: '#1F4B7A', primaryText: '#ffffff' },
-		amsterdam: { primary: '#004699', primaryHover: '#003677', primaryText: '#ffffff' },
-		denhaag: { primary: '#1a7a3e', primaryHover: '#156633', primaryText: '#ffffff' },
-		rotterdam: { primary: '#00811f', primaryHover: '#006E32', primaryText: '#ffffff' },
-		vng: { primary: '#003865', primaryHover: '#026596', primaryText: '#ffffff' },
-		leiden: { primary: '#d62410', primaryHover: '#b01d0d', primaryText: '#ffffff' },
-		noaberkracht: { primary: '#4376fc', primaryHover: '#2b5fd4', primaryText: '#ffffff' }
-	};
+	/**
+	 * Derive preview colors dynamically from the token set's theming metadata
+	 * (primary_color field in token-sets.json, already passed in data-token-sets).
+	 * Falls back to a neutral dark if no data is available.
+	 * This replaces the old hardcoded 9-entry palette (issue #123).
+	 */
+	function getPreviewColors(tokenSetId) {
+		var ts = tokenSetsData[tokenSetId];
+		var primary = (ts && ts.theming && ts.theming.primary_color) ? ts.theming.primary_color : '#333333';
+		// Compute a simple hover by darkening the hex value ~10%
+		var primaryHover = darkenHex(primary, 0.1);
+		return { primary: primary, primaryHover: primaryHover, primaryText: '#ffffff' };
+	}
+
+	/**
+	 * Darken a hex colour by the given fraction (0–1).
+	 * Returns the original colour if parsing fails.
+	 */
+	function darkenHex(hex, fraction) {
+		var m = /^#([0-9a-fA-F]{6})$/.exec(hex);
+		if (m === null) { return hex; }
+		var r = Math.max(0, Math.round(parseInt(m[1].substring(0, 2), 16) * (1 - fraction)));
+		var g = Math.max(0, Math.round(parseInt(m[1].substring(2, 4), 16) * (1 - fraction)));
+		var b = Math.max(0, Math.round(parseInt(m[1].substring(4, 6), 16) * (1 - fraction)));
+		return '#' + ('0' + r.toString(16)).slice(-2) + ('0' + g.toString(16)).slice(-2) + ('0' + b.toString(16)).slice(-2);
+	}
 
 	// Update preview when token set changes
 	function updatePreview(tokenSet) {
-		var colors = tokenSetColors[tokenSet];
-		if (!colors || !previewBox) return;
+		var colors = getPreviewColors(tokenSet);
+		if (!previewBox) return;
 
 		var header = previewBox.querySelector('.nldesign-preview-header');
 		var primaryButton = previewBox.querySelector('.nldesign-preview-button.primary');

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace OCA\NLDesign\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
@@ -58,6 +59,7 @@ class HealthController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-3
      */
+    #[PublicPage]
     public function index(): JSONResponse
     {
         $checks = [];

--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -25,6 +25,7 @@ use OCA\NLDesign\AppInfo\Application;
 use OCA\NLDesign\Service\CustomOverridesService;
 use OCA\NLDesign\Service\TokenSetService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\TextPlainResponse;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -70,6 +71,7 @@ class MetricsController extends Controller
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-4
      */
+    #[PublicPage]
     public function index(): TextPlainResponse
     {
         $lines = [];

--- a/lib/Controller/OverridesController.php
+++ b/lib/Controller/OverridesController.php
@@ -215,6 +215,23 @@ class OverridesController extends Controller
             return new JSONResponse(['error' => 'File exceeds the 256 KB size limit'], 413);
         }
 
+        // Validate file extension.
+        $originalName = $file['name'] ?? '';
+        $extension    = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+        if ($extension !== 'css') {
+            return new JSONResponse(['error' => 'Only .css files are accepted'], 415);
+        }
+
+        // Validate MIME type via server-side detection (ignore client-provided type).
+        $tmpName  = $file['tmp_name'];
+        $mimeType = mime_content_type($tmpName);
+        // Accept text/css, text/plain (editors often send this for .css), and
+        // application/octet-stream (generic fallback from some browsers).
+        $allowedMimes = ['text/css', 'text/plain', 'application/octet-stream'];
+        if (in_array($mimeType, $allowedMimes, true) === false) {
+            return new JSONResponse(['error' => 'File does not appear to be a CSS file'], 415);
+        }
+
         return null;
     }//end validateUploadedFile()
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -35,7 +35,6 @@ use OCA\NLDesign\Service\ThemingService;
 use OCA\NLDesign\Service\TokenSetPreviewService;
 use OCA\NLDesign\Service\TokenSetService;
 use OCA\NLDesign\Settings\Admin;
-use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\JSONResponse;
@@ -72,13 +71,6 @@ class SettingsController extends Controller
     private IConfig $config;
 
     /**
-     * The app manager.
-     *
-     * @var IAppManager
-     */
-    private IAppManager $appManager;
-
-    /**
      * The token set service.
      *
      * @var TokenSetService
@@ -105,7 +97,6 @@ class SettingsController extends Controller
      * @param string                 $appName         The app name.
      * @param IRequest               $request         The request object.
      * @param IConfig                $config          The config service.
-     * @param IAppManager            $appManager      The app manager.
      * @param TokenSetService        $tokenSetService The token set service.
      * @param ThemingService         $themingService  The theming service.
      * @param TokenSetPreviewService $previewService  The token set preview service.
@@ -114,14 +105,12 @@ class SettingsController extends Controller
         string $appName,
         IRequest $request,
         IConfig $config,
-        IAppManager $appManager,
         TokenSetService $tokenSetService,
         ThemingService $themingService,
         TokenSetPreviewService $previewService
     ) {
         parent::__construct(appName: $appName, request: $request);
         $this->config          = $config;
-        $this->appManager      = $appManager;
         $this->tokenSetService = $tokenSetService;
         $this->themingService  = $themingService;
         $this->previewService  = $previewService;
@@ -139,8 +128,7 @@ class SettingsController extends Controller
     #[AuthorizedAdminSetting(Admin::class)]
     public function setTokenSet(string $tokenSet): JSONResponse
     {
-        $tokenSetService = new TokenSetService(appManager: $this->appManager);
-        if ($tokenSetService->isValidTokenSet(tokenSetId: $tokenSet) === false) {
+        if ($this->tokenSetService->isValidTokenSet(tokenSetId: $tokenSet) === false) {
             return new JSONResponse(['error' => 'Invalid token set'], 400);
         }
 

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -9,7 +9,7 @@ style('nldesign', 'admin');
 ?>
 
 <div id="nldesign-settings" class="section"
-	 data-token-sets="<?php p(json_encode($_['tokenSets'])); ?>"
+	 data-token-sets="<?php p(json_encode($_['tokenSets'], JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT)); ?>"
 	 data-current-token-set="<?php p($_['currentTokenSet']); ?>">
 	<div class="nldesign-settings-header">
 		<h2><?php p($l->t('NL Design System Theme')); ?></h2>


### PR DESCRIPTION
## Summary

- **#122 (MEDIUM)** — `SettingsController::setTokenSet` was instantiating a new `TokenSetService` via `new TokenSetService(appManager:)` instead of using the already-injected `$this->tokenSetService`. Removed ad-hoc `new` call and the now-unused `IAppManager` constructor parameter.
- **#126 (MEDIUM)** — `MetricsController` and `HealthController` carried `@NoCSRFRequired` but not `@PublicPage`; Prometheus scrapers and uptime monitors received 401. Added `#[PublicPage]` attribute to both `index()` methods.
- **#123 (MEDIUM)** — `admin.js` had a hardcoded 9-entry preview palette, leaving ~31 token sets with a stale preview. Replaced with `getPreviewColors()` which reads `primary_color` from the already-parsed `tokenSetsData` (sourced from `token-sets.json` via `data-token-sets` attribute). Removed hardcoded map entirely.
- **#129 (LOW)** — `data-token-sets` JSON in `admin.php` was rendered without safe HTML encoding flags; replaced `json_encode()` with `json_encode(..., JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT)`.
- **#130 (LOW)** — `importOverrides()` lacked extension and MIME-type validation; added explicit `.css` extension check and server-side `mime_content_type()` validation in `validateUploadedFile()`.

## Test plan

- [ ] Verify admin token-set selector saves correctly (setTokenSet DI fix)
- [ ] Verify `GET /apps/nldesign/metrics` returns 200 without credentials
- [ ] Verify `GET /apps/nldesign/health` returns 200 without credentials
- [ ] Verify admin preview updates colour correctly for all ~40 token sets (not just the old hardcoded 9)
- [ ] Verify uploading a non-CSS file to the import endpoint returns 415 (MIME validation)
- [ ] Verify uploading a PHP file returns 415 (extension check)