### PR TITLE
fix: harden CSS sanitizer, fix DI, and dedup parser logic (M1+L1+L2+L3)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,7 +23,6 @@ namespace OCA\NLDesign\AppInfo;
 use OCA\NLDesign\Service\CustomOverridesService;
 use OCA\NLDesign\Service\DesignSystemService;
 use OCA\NLDesign\Themes\NLDesignTheme;
-use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -101,8 +100,7 @@ class Application extends App implements IBootstrap
         $showMenuLabels = $config->getAppValue(self::APP_ID, 'show_menu_labels', '0') === '1';
 
         // 1. Resolve which design system this token set uses.
-        $appManager     = $serverContainer->get(IAppManager::class);
-        $dsService      = new DesignSystemService(appManager: $appManager);
+        $dsService      = $serverContainer->get(DesignSystemService::class);
         $tokenSetMeta   = $dsService->getTokenSetMeta($tokenSet);
         $designSystemId = $tokenSetMeta['design_system'] ?? 'nldesign';
         $designSystem   = $dsService->getDesignSystem($designSystemId);
@@ -119,7 +117,7 @@ class Application extends App implements IBootstrap
         }
 
         // 4. Custom overrides — admin-defined token overrides, always loaded last.
-        $customOverridesSvc = new CustomOverridesService(appManager: $appManager);
+        $customOverridesSvc = $serverContainer->get(CustomOverridesService::class);
         $customOverridesSvc->ensureExists();
         \OCP\Util::addStyle(application: self::APP_ID, file: 'custom-overrides');
 

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -22,6 +22,7 @@ namespace OCA\NLDesign\Controller;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
 
@@ -38,11 +39,13 @@ class HealthController extends Controller
      * @param string          $appName The app name.
      * @param IRequest        $request The request object.
      * @param LoggerInterface $logger  Logger for error reporting.
+     * @param IConfig         $config  The Nextcloud config service.
      */
     public function __construct(
         string $appName,
         IRequest $request,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly IConfig $config
     ) {
         parent::__construct(appName: $appName, request: $request);
 
@@ -55,8 +58,6 @@ class HealthController extends Controller
      *
      * @NoCSRFRequired
      *
-     * @SuppressWarnings(PHPMD.StaticAccess) - \OCP\Server::get() is the Nextcloud API for container access
-     *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-3
      */
     #[PublicPage]
@@ -68,8 +69,7 @@ class HealthController extends Controller
         // NL Design is CSS-only, no database tables.
         // Check that the token set config is accessible.
         try {
-            $config   = \OCP\Server::get(\OCP\IConfig::class);
-            $tokenSet = $config->getAppValue('nldesign', 'token_set', 'rijkshuisstijl');
+            $tokenSet = $this->config->getAppValue('nldesign', 'token_set', 'rijkshuisstijl');
             $checks['configuration'] = 'degraded';
             if ($tokenSet !== '') {
                 $checks['configuration'] = 'ok';

--- a/lib/Service/CustomOverridesService.php
+++ b/lib/Service/CustomOverridesService.php
@@ -68,13 +68,22 @@ class CustomOverridesService
     private IAppManager $appManager;
 
     /**
+     * The CSS parser service (shared :root-block parsing, avoids duplication).
+     *
+     * @var CssParserService
+     */
+    private CssParserService $cssParser;
+
+    /**
      * Constructor.
      *
-     * @param IAppManager $appManager The app manager.
+     * @param IAppManager      $appManager The app manager.
+     * @param CssParserService $cssParser  CSS parser for :root block extraction.
      */
-    public function __construct(IAppManager $appManager)
+    public function __construct(IAppManager $appManager, CssParserService $cssParser)
     {
         $this->appManager = $appManager;
+        $this->cssParser  = $cssParser;
     }//end __construct()
 
     /**
@@ -248,7 +257,12 @@ class CustomOverridesService
     {
         $lines = [];
         foreach ($tokens as $name => $value) {
-            $safeValue = str_replace(["\n", "\r", ';'], '', $value);
+            // Reject any value containing CSS injection characters.
+            if (preg_match('/[{};]|\/\*|\*\//', $value) === 1) {
+                continue;
+            }
+
+            $safeValue = str_replace(["\n", "\r", ';', '{', '}', '/*', '*/'], '', $value);
             $safeName  = preg_replace('/[^a-zA-Z0-9\-]/', '', $name);
             $lines[]   = '  '.$safeName.': '.$safeValue.';';
         }
@@ -259,6 +273,8 @@ class CustomOverridesService
     /**
      * Parse CSS custom property declarations from a :root {} block.
      *
+     * Delegates to CssParserService to avoid duplicating the parse logic.
+     *
      * @param string $css The raw CSS string.
      *
      * @return array<string, string> Map of token name => value.
@@ -267,22 +283,7 @@ class CustomOverridesService
      */
     private function parseDeclarations(string $css): array
     {
-        $tokens = [];
-
-        // Extract the :root block.
-        if (preg_match('/:root\s*\{([^}]*)\}/s', $css, $rootMatch) !== 1) {
-            return $tokens;
-        }
-
-        $block = $rootMatch[1];
-
-        // Match each declaration: --name: value.
-        preg_match_all('/^\s*(--[\w-]+)\s*:\s*([^;]+);/m', $block, $matches, PREG_SET_ORDER);
-        foreach ($matches as $match) {
-            $tokens[trim($match[1])] = trim($match[2]);
-        }
-
-        return $tokens;
+        return $this->cssParser->parseRootBlock(css: $css);
     }//end parseDeclarations()
 
     /**

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -63,17 +63,26 @@ class Admin implements ISettings
     private IAppManager $appManager;
 
     /**
+     * The token set service.
+     *
+     * @var TokenSetService
+     */
+    private TokenSetService $tokenSetService;
+
+    /**
      * Constructor.
      *
-     * @param IConfig     $config     The config service.
-     * @param IL10N       $l          The localization service.
-     * @param IAppManager $appManager The app manager.
+     * @param IConfig         $config          The config service.
+     * @param IL10N           $l               The localization service.
+     * @param IAppManager     $appManager      The app manager.
+     * @param TokenSetService $tokenSetService The token set service.
      */
-    public function __construct(IConfig $config, IL10N $l, IAppManager $appManager)
+    public function __construct(IConfig $config, IL10N $l, IAppManager $appManager, TokenSetService $tokenSetService)
     {
-        $this->config     = $config;
-        $this->l          = $l;
-        $this->appManager = $appManager;
+        $this->config          = $config;
+        $this->l               = $l;
+        $this->appManager      = $appManager;
+        $this->tokenSetService = $tokenSetService;
     }//end __construct()
 
     /**
@@ -85,8 +94,7 @@ class Admin implements ISettings
      */
     public function getForm(): TemplateResponse
     {
-        $tokenSetService = new TokenSetService(appManager: $this->appManager);
-        $tokenSets       = $tokenSetService->getAvailableTokenSets();
+        $tokenSets = $this->tokenSetService->getAvailableTokenSets();
 
         $currentTokenSet = $this->config->getAppValue(
             Application::APP_ID,


### PR DESCRIPTION
## Summary

- **M1** `buildDeclarationLines`: reject values matching `/[{};]|\/\*|\*\//` before output, preventing CSS injection through admin token overrides; also extended the `str_replace` strip-set.
- **L1** `Admin::getForm` injects `TokenSetService` via constructor (NC DI); `Application::injectThemeCSS` fetches `DesignSystemService` and `CustomOverridesService` from the server container instead of constructing them manually.
- **L2** `HealthController::index` uses injected `IConfig` instead of `\OCP\Server::get(IConfig::class)` static service-locator.
- **L3** `CustomOverridesService::parseDeclarations` now delegates to injected `CssParserService::parseRootBlock` — duplicate `:root {}`-block parse logic removed.

## Test plan

- [ ] Health endpoint responds 200 with token set name
- [ ] Admin settings page loads token sets correctly
- [ ] Custom overrides write rejects values with `{` / `}` / `;` / `/*` / `*/`
- [ ] `composer check:strict` passes