### PR TITLE
fix(security): wave-3 critical fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Build artifacts
 /js/
+!/js/admin.js
 /build/
 /dist/
 

--- a/css/tokens/dinkelland.css
+++ b/css/tokens/dinkelland.css
@@ -94,10 +94,10 @@
 	--nldesign-conduction-download-card-border-radius: 0px;
 	--nldesign-conduction-logo-header-inline-size: 150px;
 	--nldesign-conduction-logo-header-block-size: 30px;
-	--nldesign-conduction-logo-header-background-image: url('https://www.dinkelland.nl/sites/all/themes/dinkelland/logo.svg');
+	--nldesign-conduction-logo-header-background-image: url('../../../img/logos/dinkelland.svg');
 	--nldesign-conduction-logo-navbar-inline-size: 150px;
 	--nldesign-conduction-logo-navbar-block-size: 40px;
-	--nldesign-conduction-logo-navbar-background-image: url('https://www.dinkelland.nl/sites/all/themes/dinkelland/logo.svg');
+	--nldesign-conduction-logo-navbar-background-image: url('../../../img/logos/dinkelland.svg');
 	--nldesign-conduction-primary-top-nav-current-background-color: unset;
 	/* TODO: unresolved Style-Dictionary ref — needs upstream sync: --nldesign-conduction-primary-top-nav-current-box-shadow: inset 0 -4px {dinkelland.color.primary}; */
 	/* TODO: unresolved Style-Dictionary ref — needs upstream sync: --nldesign-conduction-primary-top-nav-current-mobile-box-shadow: inset 4px 0 {dinkelland.color.primary}; */
@@ -199,7 +199,7 @@
 	--nldesign-component-unordered-list-padding-inline-start: 2ch;
 	--nldesign-component-unordered-list-item-padding-inline-start: 1ch;
 	--nldesign-component-page-footer-background-color: unset;
-	--nldesign-component-page-footer-background-image: url(https://www.dinkelland.nl/sites/all/themes/dinkelland/dist/assets/img/footer-bg.svg);
+	--nldesign-component-page-footer-background-image: unset; /* External footer-bg.svg removed (privacy/availability). Replace with a locally-bundled asset under img/themes/dinkelland/ if needed. */
 	--nldesign-component-page-max-inline-size: 1140px;
 	--nldesign-component-paragraph-line-height: 1.5em;
 	--nldesign-component-radio-button-icon-size: 5px;

--- a/css/tokens/leiden.css
+++ b/css/tokens/leiden.css
@@ -93,13 +93,13 @@
 	--nldesign-conduction-download-card-border-radius: 0px;
 	--nldesign-conduction-logo-header-inline-size: 80px;
 	--nldesign-conduction-logo-header-block-size: 37px;
-	--nldesign-conduction-logo-header-background-image: url('https://gemeente.leiden.nl/typo3conf/ext/leiden_template/Resources/Public/Images/logo_leiden.svg');
+	--nldesign-conduction-logo-header-background-image: url('../../../img/logos/leiden.svg');
 	--nldesign-conduction-logo-footer-inline-size: 120px;
 	--nldesign-conduction-logo-footer-block-size: 100px;
-	--nldesign-conduction-logo-footer-background-image: url('https://gemeente.leiden.nl/typo3conf/ext/leiden_template/Resources/Public/Images/logo_leiden.svg');
+	--nldesign-conduction-logo-footer-background-image: url('../../../img/logos/leiden.svg');
 	--nldesign-conduction-logo-navbar-inline-size: 80px;
 	--nldesign-conduction-logo-navbar-block-size: 45px;
-	--nldesign-conduction-logo-navbar-background-image: url('https://gemeente.leiden.nl/typo3conf/ext/leiden_template/Resources/Public/Images/logo_leiden.svg');
+	--nldesign-conduction-logo-navbar-background-image: url('../../../img/logos/leiden.svg');
 	/* TODO: unresolved Style-Dictionary ref — needs upstream sync: --nldesign-conduction-primary-top-nav-current-box-shadow: inset 0 -4px {leiden.color.white.100}; */
 	/* TODO: unresolved Style-Dictionary ref — needs upstream sync: --nldesign-conduction-primary-top-nav-current-mobile-box-shadow: inset 4px 0 {leiden.color.white.100}; */
 	--nldesign-conduction-primary-top-nav-item-padding: 18px;

--- a/css/tokens/noaberkracht.css
+++ b/css/tokens/noaberkracht.css
@@ -99,13 +99,13 @@
 	--nldesign-conduction-download-card-border-radius: 22px;
 	--nldesign-conduction-logo-header-inline-size: 130px;
 	--nldesign-conduction-logo-header-block-size: 75px;
-	--nldesign-conduction-logo-header-background-image: url('https://werkenbijnoaberkracht.nl/assets/img/base/logo.png');
+	--nldesign-conduction-logo-header-background-image: url('../../../img/logos/noaberkracht.svg');
 	--nldesign-conduction-logo-footer-inline-size: 150px;
 	--nldesign-conduction-logo-footer-block-size: 87px;
-	--nldesign-conduction-logo-footer-background-image: url('https://werkenbijnoaberkracht.nl/assets/img/base/logo.png');
+	--nldesign-conduction-logo-footer-background-image: url('../../../img/logos/noaberkracht.svg');
 	--nldesign-conduction-logo-navbar-inline-size: 69px;
 	--nldesign-conduction-logo-navbar-block-size: 43px;
-	--nldesign-conduction-logo-navbar-background-image: url('https://werkenbijnoaberkracht.nl/assets/img/base/logo.png');
+	--nldesign-conduction-logo-navbar-background-image: url('../../../img/logos/noaberkracht.svg');
 	/* TODO: unresolved Style-Dictionary ref — needs upstream sync: --nldesign-conduction-primary-top-nav-current-box-shadow: inset 0 -4px {noaberkracht.color.yellow.47}; */
 	/* TODO: unresolved Style-Dictionary ref — needs upstream sync: --nldesign-conduction-primary-top-nav-current-mobile-box-shadow: inset 4px 0 {noaberkracht.color.yellow.47}; */
 	--nldesign-conduction-primary-top-nav-dropdown-border-style: solid;

--- a/css/tokens/tubbergen.css
+++ b/css/tokens/tubbergen.css
@@ -97,10 +97,10 @@
 	--nldesign-conduction-download-card-border-radius: 0px;
 	--nldesign-conduction-logo-header-inline-size: 150px;
 	--nldesign-conduction-logo-header-block-size: 36px;
-	--nldesign-conduction-logo-header-background-image: url('https://www.tubbergen.nl/sites/all/themes/tubbergen/logo.svg');
+	--nldesign-conduction-logo-header-background-image: url('../../../img/logos/tubbergen.svg');
 	--nldesign-conduction-logo-navbar-inline-size: 150px;
 	--nldesign-conduction-logo-navbar-block-size: 50px;
-	--nldesign-conduction-logo-navbar-background-image: url('https://www.tubbergen.nl/sites/all/themes/tubbergen/logo.svg');
+	--nldesign-conduction-logo-navbar-background-image: url('../../../img/logos/tubbergen.svg');
 	--nldesign-conduction-primary-top-nav-current-background-color: unset;
 	/* TODO: unresolved Style-Dictionary ref — needs upstream sync: --nldesign-conduction-primary-top-nav-current-box-shadow: inset 0 -4px {tubbergen.color.primary}; */
 	/* TODO: unresolved Style-Dictionary ref — needs upstream sync: --nldesign-conduction-primary-top-nav-current-mobile-box-shadow: inset 4px 0 {tubbergen.color.primary}; */

--- a/img/logos/dinkelland.svg
+++ b/img/logos/dinkelland.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <!-- Gemeente Dinkelland logo placeholder — replace with official asset when redistribution is permitted -->
+  <rect width="200" height="60" fill="#005da0"/>
+  <text x="100" y="38" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#ffffff" text-anchor="middle">Gemeente Dinkelland</text>
+</svg>

--- a/img/logos/noaberkracht.svg
+++ b/img/logos/noaberkracht.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <!-- Noaberkracht logo placeholder — replace with official asset when redistribution is permitted -->
+  <rect width="200" height="60" fill="#012c9d"/>
+  <text x="100" y="38" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#ffffff" text-anchor="middle">Noaberkracht</text>
+</svg>

--- a/img/logos/tubbergen.svg
+++ b/img/logos/tubbergen.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 60">
+  <!-- Gemeente Tubbergen logo placeholder — replace with official asset when redistribution is permitted -->
+  <rect width="200" height="60" fill="#067432"/>
+  <text x="100" y="38" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#ffffff" text-anchor="middle">Gemeente Tubbergen</text>
+</svg>


### PR DESCRIPTION
## Summary

Fixes wave-3 CRITICAL findings from `/tmp/triage-nldesign-nctemplate.md`.

**C1 — Bundle external logo URLs locally (privacy regression fix)**

Four municipality token-set CSS files referenced external HTTP URLs that leaked every authenticated user's IP address, referrer, and page-load timing to third-party municipal origins on every Nextcloud page-load:

- `css/tokens/noaberkracht.css` — 3 references to `werkenbijnoaberkracht.nl`
- `css/tokens/dinkelland.css` — 2 logo references + 1 footer background to `dinkelland.nl`
- `css/tokens/leiden.css` — 3 references to `gemeente.leiden.nl` (local `img/logos/leiden.svg` already existed)
- `css/tokens/tubbergen.css` — 2 references to `tubbergen.nl`

Fix: Replace all external `url('https://...')` references with relative paths pointing to locally-bundled SVGs under `img/logos/`. Placeholder SVGs created for noaberkracht, dinkelland, and tubbergen (leiden was already bundled). The placeholder SVGs use each municipality's brand primary colour with a text label and include a comment to replace them with official assets when redistribution is permitted.

**C2 — Fix git clean footgun in .gitignore**

`/js/` was listed under build artifacts in `.gitignore`, but `js/admin.js` (979 lines, hand-authored) is tracked. Any contributor running `git clean -fdx` from a fresh checkout would silently lose the file.

Fix: Add `!/js/admin.js` exception line immediately after `/js/`.

## Test plan

- [ ] Verify token-set CSS files contain no `url('https://` patterns: `grep -rn "url('https://" css/tokens/`
- [ ] Confirm new placeholder SVGs render in browser (background-image token applied)
- [ ] Confirm `git clean -fdx` preview no longer lists `js/admin.js` as deletable
- [ ] CI gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)