### PR TITLE
fix(security): reject semicolon/comment-marker CSS injection in custom token set uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Security
+- Hardened `CustomTokenSetValidator::isForbiddenValue()` to reject declaration values containing a semicolon (`;`) or a CSS comment marker (`/*`, `*/`), closing a CSS-injection gap where a single accepted `--nldesign-*`/`--{slug}-*` declaration's value could smuggle an arbitrary extra declaration (e.g. `background: url(...)`) past the name whitelist into the `:root {}` block served to every anonymous visitor (login page, share links). Applies to both the CSS upload path and the W3C Design Tokens JSON path (`CustomTokenSetController::mapFromJson()`), which shares the same gate. Only new uploads are affected — a custom token set uploaded before this fix is not retroactively re-validated; the served `custom-*.css` file for an existing set is unchanged until it is re-uploaded. See `openspec/changes/harden-custom-token-set-value-validation/`.
+
 ### Fixed
 - Corrected the declared licence in `appinfo/info.xml` from `agpl` to `eupl` (EUPL-1.2) to match the bundled `LICENSE`, the SPDX headers, and the rest of the Conduction fleet. Adopters may key compliance on the declared licence, so the App Store listing now states the correct EUPL-1.2 licence.
 - Documentation corrected to describe the real bundled, self-hosted Fira Sans delivery (no external CDN) and the true token-set count derived from `token-sets.json`.

--- a/lib/Service/CustomTokenSetValidator.php
+++ b/lib/Service/CustomTokenSetValidator.php
@@ -182,13 +182,7 @@ class CustomTokenSetValidator
      */
     public function isForbiddenValue(string $value): bool
     {
-        $lower = strtolower($value);
-
-        if (str_contains($lower, '@import') === true
-            || str_contains($lower, 'expression(') === true
-            || str_contains($lower, 'javascript:') === true
-            || str_contains($value, '<') === true
-        ) {
+        if ($this->containsDangerousKeyword(value: $value) === true) {
             return true;
         }
 
@@ -198,36 +192,87 @@ class CustomTokenSetValidator
         // terminator.
         $withoutUrlPayloads = preg_replace('/url\(\s*([\'"]?).*?\1\s*\)/i', '', $value);
 
-        if (str_contains($withoutUrlPayloads, '{') === true
-            || str_contains($withoutUrlPayloads, '}') === true
-            || str_contains($withoutUrlPayloads, ';') === true
-            || str_contains($withoutUrlPayloads, '/*') === true
-            || str_contains($withoutUrlPayloads, '*/') === true
-        ) {
+        if ($this->containsInjectionCharacter(value: $withoutUrlPayloads) === true) {
             return true;
         }
 
-        // Inspect every url(...) occurrence.
-        if (preg_match_all('/url\(\s*([\'"]?)(.*?)\1\s*\)/i', $value, $urls, PREG_SET_ORDER) > 0) {
-            foreach ($urls as $url) {
-                $target = trim($url[2]);
+        return $this->hasDisallowedUrlTarget(value: $value);
+    }//end isForbiddenValue()
 
-                // Data image URIs (svg+xml, png, …) are allowed.
-                if (preg_match('#^data:image/(svg\+xml|png|jpeg|gif|webp)#i', $target) === 1) {
-                    continue;
-                }
+    /**
+     * Determine whether a value contains a keyword-based dangerous construct:
+     * `@import`, `expression(`, `javascript:`, or raw markup (`<`).
+     *
+     * @param string $value The declaration value.
+     *
+     * @return bool True when a dangerous keyword is present.
+     *
+     * @spec openspec/changes/harden-custom-token-set-value-validation/tasks.md#task-1
+     */
+    private function containsDangerousKeyword(string $value): bool
+    {
+        $lower = strtolower($value);
 
-                // A scheme or protocol-relative or host reference is forbidden.
-                if (preg_match('#^([a-z][a-z0-9+.-]*:|//)#i', $target) === 1) {
-                    return true;
-                }
+        return str_contains($lower, '@import') === true
+            || str_contains($lower, 'expression(') === true
+            || str_contains($lower, 'javascript:') === true
+            || str_contains($value, '<') === true;
+    }//end containsDangerousKeyword()
 
-                // Bare relative paths (../img/..., img/...) are allowed.
+    /**
+     * Determine whether a value (with any url(...) payload already stripped)
+     * contains a CSS injection character: `{`, `}`, `;`, `/*`, or `*​/`.
+     *
+     * @param string $value The value with url(...) payloads stripped.
+     *
+     * @return bool True when an injection character is present.
+     *
+     * @spec openspec/changes/harden-custom-token-set-value-validation/tasks.md#task-1
+     */
+    private function containsInjectionCharacter(string $value): bool
+    {
+        return str_contains($value, '{') === true
+            || str_contains($value, '}') === true
+            || str_contains($value, ';') === true
+            || str_contains($value, '/*') === true
+            || str_contains($value, '*/') === true;
+    }//end containsInjectionCharacter()
+
+    /**
+     * Determine whether any url(...) occurrence in the value targets a
+     * disallowed scheme, protocol-relative reference, or host. Relative
+     * paths and permitted data:image/* URIs are not disallowed.
+     *
+     * @param string $value The declaration value.
+     *
+     * @return bool True when a url(...) target is disallowed.
+     *
+     * @spec openspec/changes/custom-token-set-upload/tasks.md#task-1.1
+     */
+    private function hasDisallowedUrlTarget(string $value): bool
+    {
+        if (preg_match_all('/url\(\s*([\'"]?)(.*?)\1\s*\)/i', $value, $urls, PREG_SET_ORDER) === 0) {
+            return false;
+        }
+
+        foreach ($urls as $url) {
+            $target = trim($url[2]);
+
+            // Data image URIs (svg+xml, png, …) are allowed.
+            if (preg_match('#^data:image/(svg\+xml|png|jpeg|gif|webp)#i', $target) === 1) {
+                continue;
             }
+
+            // A scheme or protocol-relative or host reference is forbidden.
+            if (preg_match('#^([a-z][a-z0-9+.-]*:|//)#i', $target) === 1) {
+                return true;
+            }
+
+            // Bare relative paths (../img/..., img/...) are allowed.
         }
 
         return false;
-    }//end isForbiddenValue()
+    }//end hasDisallowedUrlTarget()
 
     /**
      * Re-serialise accepted declarations into a canonical CSS file body.

--- a/openspec/changes/harden-custom-token-set-value-validation/tasks.md
+++ b/openspec/changes/harden-custom-token-set-value-validation/tasks.md
@@ -1,37 +1,64 @@
 ## 1. Harden the value gate
 
-- [ ] 1.1 In `lib/Service/CustomTokenSetValidator.php::isForbiddenValue()`, add `;`, `/*`, and `*/`
+- [x] 1.1 In `lib/Service/CustomTokenSetValidator.php::isForbiddenValue()`, add `;`, `/*`, and `*/`
       to the rejected-substring checks (alongside the existing `@import`, `expression(`,
       `javascript:`, `<` checks), matching `CustomOverridesService::buildDeclarationLines()`'s
       `preg_match('/[{};]|\/\*|\*\//', $value)` guard.
-- [ ] 1.2 In `lib/Service/CustomTokenSetValidator.php::serialize()`, keep the existing `trim($value)`
+      (Already present on `development` at HEAD — the `;`/`/*`/`*/` checks and the `@spec` tag for
+      this change were carried in commit `1b22d95` "wip: preserve uncommitted work"; verified by
+      reading the current source. Additionally refactored `isForbiddenValue()` in this session,
+      extracting `containsDangerousKeyword()` / `containsInjectionCharacter()` /
+      `hasDisallowedUrlTarget()` private helpers — pure decomposition, no behaviour change — since
+      the added checks had pushed the method's PHPMD CyclomaticComplexity to 14 against a threshold
+      of 10; all 98 unit tests (incl. the new ones) still pass unchanged after the split.)
+- [x] 1.2 In `lib/Service/CustomTokenSetValidator.php::serialize()`, keep the existing `trim($value)`
       but confirm (via the new tests in task 2) that a rejected value can never reach this method —
       `serialize()` is defense-in-depth, not the primary gate.
+      (`trim($value)` already present in `serialize()`; task 2.3's `validateDeclarations()`
+      end-to-end test confirms the smuggling payload never survives past the gate to reach
+      `serialize()`.)
 
 ## 2. Tests
 
-- [ ] 2.1 Add a test to `tests/Unit/Service/CustomTokenSetValidatorTest.php` asserting
+- [x] 2.1 Add a test to `tests/Unit/Service/CustomTokenSetValidatorTest.php` asserting
       `isForbiddenValue('red; background: url(https://evil.example/x.png)')` returns `true`.
-- [ ] 2.2 Add a test asserting a value containing a bare CSS comment marker
+      (`testSemicolonSmuggledBackgroundDeclarationIsForbidden`)
+- [x] 2.2 Add a test asserting a value containing a bare CSS comment marker
       (`isForbiddenValue('red /* } */')`) returns `true`.
-- [ ] 2.3 Add a `validateDeclarations()`-level test (not just `isForbiddenValue()`) proving a
+      (`testBareCommentMarkerValueIsForbidden`)
+- [x] 2.3 Add a `validateDeclarations()`-level test (not just `isForbiddenValue()`) proving a
       declaration set containing the semicolon-smuggling payload is rejected end-to-end with a 422
       `lastError`, not silently split into accepted/skipped.
-- [ ] 2.4 Confirm the JSON upload path (`CustomTokenSetController::mapFromJson()`) is covered too —
+      (`testValidateDeclarationsRejectsSemicolonSmugglingEndToEnd`)
+- [x] 2.4 Confirm the JSON upload path (`CustomTokenSetController::mapFromJson()`) is covered too —
       it reuses `isForbiddenValue()` per token (`lib/Controller/CustomTokenSetController.php:222`),
       so the same fixture (crafted as a W3C Design Tokens JSON value) must be rejected there as
       well. Add or extend a controller-level test if one exists for `mapFromJson()`.
+      (No controller test existed for this controller; added
+      `tests/Unit/Controller/CustomTokenSetControllerTest.php` — a new file — exercising `upload()`
+      end-to-end with a real `CustomTokenSetValidator`/`DesignTokensMapper` and a mocked
+      `IRequest`/`IL10N`/`CustomTokenSetService`: semicolon smuggling rejected, comment-marker
+      smuggling rejected, and a clean mapped value still accepted/stored — no regression.)
 
 ## 3. Regression check on already-stored sets (follow-up note, not blocking)
 
-- [ ] 3.1 Document in `CHANGELOG.md` that this hardening only affects new uploads; any
+- [x] 3.1 Document in `CHANGELOG.md` that this hardening only affects new uploads; any
       already-stored `custom-*.css` file uploaded before this fix is not retroactively
       re-validated. File a follow-up issue if a migration/re-scan is later deemed necessary — out
       of scope for this change.
+      (Added a `### Security` entry under `## Unreleased` in `CHANGELOG.md`. No follow-up issue
+      filed — a re-scan migration is not deemed necessary per the proposal's own scoping: this is
+      a defense-in-depth gap requiring the admin role that already owns the upload pipeline.)
 
 ## 4. Verify
 
-- [ ] 4.1 Run `composer test:unit` (or the project's PHPUnit target) and confirm the new tests pass
+- [x] 4.1 Run `composer test:unit` (or the project's PHPUnit target) and confirm the new tests pass
       and no existing `CustomTokenSetValidatorTest` / `CustomTokenSetControllerTest` cases regress.
+      (Ran via `phpunit -c phpunit-unit.xml` in the `nextcloud:34.0.0-apache` container — see PR
+      description / builder report for the exact pass count.)
 - [ ] 4.2 Manually upload a CSS token set containing the semicolon payload via the admin panel and
       confirm the upload is rejected with a 422 and a user-facing error, not silently accepted.
+      (deferred to post-merge live verification — requires the live 8080 instance, per builder
+      brief instructions; the equivalent assertion is covered by
+      `testValidateDeclarationsRejectsSemicolonSmugglingEndToEnd` and
+      `testJsonUploadWithSemicolonSmugglingIsRejected` at the unit level.)

--- a/tests/Unit/Controller/CustomTokenSetControllerTest.php
+++ b/tests/Unit/Controller/CustomTokenSetControllerTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/**
+ * Unit tests for CustomTokenSetController.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @author  Conduction <info@conduction.nl>
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @spec openspec/changes/harden-custom-token-set-value-validation/tasks.md#task-2.4
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit\Controller;
+
+use OCA\NLDesign\Controller\CustomTokenSetController;
+use OCA\NLDesign\Service\CssParserService;
+use OCA\NLDesign\Service\CustomTokenSetService;
+use OCA\NLDesign\Service\CustomTokenSetValidator;
+use OCA\NLDesign\Service\DesignTokensMapper;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the upload controller's W3C Design Tokens JSON path.
+ *
+ * Covers harden-custom-token-set-value-validation/tasks.md#task-2.4: proves
+ * the same isForbiddenValue() gate that blocks semicolon/comment-marker
+ * smuggling on the CSS upload path also blocks it when the value arrives via
+ * a mapped DTCG JSON token — mapFromJson() is private, so it is exercised
+ * indirectly through the public upload() entry point, wired with the real
+ * (unmocked) CustomTokenSetValidator and DesignTokensMapper so the gate
+ * itself is under test, not a stand-in.
+ */
+class CustomTokenSetControllerTest extends TestCase
+{
+
+    /**
+     * Temp upload files created during a test, cleaned up in tearDown().
+     *
+     * @var string[]
+     */
+    private array $tempFiles = [];
+
+    /**
+     * Remove any temp upload files created by a test.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        foreach ($this->tempFiles as $path) {
+            if (file_exists($path) === true) {
+                unlink($path);
+            }
+        }
+
+        $this->tempFiles = [];
+        parent::tearDown();
+    }//end tearDown()
+
+    /**
+     * Build a controller wired with the real validator/mapper/CSS parser and
+     * a request mock that serves the given JSON body as an uploaded
+     * `.tokens.json` file.
+     *
+     * @param string                        $jsonBody The raw JSON upload content.
+     * @param CustomTokenSetService|null    $service  A pre-configured service mock, or null for a bare one.
+     *
+     * @return CustomTokenSetController The wired controller.
+     */
+    private function buildControllerWithJsonUpload(string $jsonBody, ?CustomTokenSetService $service = null): CustomTokenSetController
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'nldesign-test-');
+        file_put_contents($tmpFile, $jsonBody);
+        $this->tempFiles[] = $tmpFile;
+
+        $request = $this->createMock(IRequest::class);
+        $request->method('getParam')->willReturnMap(
+            [
+                ['name', '', 'Gemeente Voorbeeld'],
+                ['description', '', ''],
+            ]
+        );
+        $request->method('getUploadedFile')->with('file')->willReturn(
+            [
+                'tmp_name' => $tmpFile,
+                'size'     => strlen($jsonBody),
+                'name'     => 'upload.tokens.json',
+            ]
+        );
+
+        if ($service === null) {
+            $service = $this->createMock(CustomTokenSetService::class);
+            $service->method('slugify')->willReturn('gemeente-voorbeeld');
+        }
+
+        $l = $this->createMock(IL10N::class);
+        $l->method('t')->willReturnCallback(
+            static function (string $text, $parameters = []): string {
+                return (empty($parameters) === true) ? $text : vsprintf($text, (array) $parameters);
+            }
+        );
+
+        return new CustomTokenSetController(
+            appName: 'nldesign',
+            request: $request,
+            service: $service,
+            validator: new CustomTokenSetValidator(),
+            cssParser: new CssParserService(),
+            mapper: new DesignTokensMapper(),
+            l: $l
+        );
+    }//end buildControllerWithJsonUpload()
+
+    /**
+     * A semicolon-smuggled value mapped from a DTCG JSON token is rejected by
+     * the same isForbiddenValue() gate the CSS path uses — the injection is
+     * not limited to the CSS upload format.
+     *
+     * @return void
+     */
+    public function testJsonUploadWithSemicolonSmugglingIsRejected(): void
+    {
+        $json = json_encode(
+            [
+                'color' => [
+                    'primary' => [
+                        '$type'  => 'color',
+                        '$value' => 'red; --nldesign-evil: url(javascript:alert(1))',
+                    ],
+                ],
+            ]
+        );
+
+        $controller = $this->buildControllerWithJsonUpload(jsonBody: $json);
+        $response   = $controller->upload();
+
+        $this->assertSame(expected: 422, actual: $response->getStatus());
+        $this->assertArrayHasKey(key: 'error', array: $response->getData());
+        $this->assertStringContainsString(
+            needle: 'forbidden value',
+            haystack: $response->getData()['error']
+        );
+    }//end testJsonUploadWithSemicolonSmugglingIsRejected()
+
+    /**
+     * A comment-marker-smuggled value mapped from a DTCG JSON token is
+     * rejected the same way.
+     *
+     * @return void
+     */
+    public function testJsonUploadWithCommentMarkerSmugglingIsRejected(): void
+    {
+        $json = json_encode(
+            [
+                'color' => [
+                    'primary' => [
+                        '$type'  => 'color',
+                        '$value' => 'red */ .evil { color: red',
+                    ],
+                ],
+            ]
+        );
+
+        $controller = $this->buildControllerWithJsonUpload(jsonBody: $json);
+        $response   = $controller->upload();
+
+        $this->assertSame(expected: 422, actual: $response->getStatus());
+        $this->assertArrayHasKey(key: 'error', array: $response->getData());
+    }//end testJsonUploadWithCommentMarkerSmugglingIsRejected()
+
+    /**
+     * A legitimate mapped value (no injection characters) is accepted and
+     * stored — no regression for benign W3C Design Tokens uploads, matching
+     * the spec delta's "Legitimate values ... still succeed" scenario.
+     *
+     * @return void
+     */
+    public function testJsonUploadWithCleanValueIsAccepted(): void
+    {
+        $json = json_encode(
+            [
+                'color' => [
+                    'primary' => [
+                        '$type'  => 'color',
+                        '$value' => '#154273',
+                    ],
+                ],
+            ]
+        );
+
+        $service = $this->createMock(CustomTokenSetService::class);
+        $service->method('slugify')->willReturn('gemeente-voorbeeld');
+        $service->expects($this->once())
+            ->method('store')
+            ->with(
+                $this->equalTo('Gemeente Voorbeeld'),
+                $this->equalTo(''),
+                $this->equalTo(['--nldesign-color-primary' => '#154273'])
+            )
+            ->willReturn(
+                [
+                    'id'       => 'custom-gemeente-voorbeeld',
+                    'warnings' => [],
+                ]
+            );
+
+        $controller = $this->buildControllerWithJsonUpload(jsonBody: $json, service: $service);
+        $response   = $controller->upload();
+
+        $this->assertSame(expected: 200, actual: $response->getStatus());
+        $this->assertSame(expected: 'custom-gemeente-voorbeeld', actual: $response->getData()['id']);
+        $this->assertSame(expected: 1, actual: $response->getData()['imported']);
+    }//end testJsonUploadWithCleanValueIsAccepted()
+}//end class

--- a/tests/Unit/Service/CustomTokenSetValidatorTest.php
+++ b/tests/Unit/Service/CustomTokenSetValidatorTest.php
@@ -10,6 +10,7 @@
  * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  *
  * @spec openspec/changes/custom-token-set-upload/tasks.md#task-5.1
+ * @spec openspec/changes/harden-custom-token-set-value-validation/tasks.md#task-2
  */
 
 declare(strict_types=1);
@@ -24,7 +25,10 @@ use PHPUnit\Framework\TestCase;
  *
  * Covers the payload corpus called out in tasks.md#task-5.1: selector
  * smuggling, external url(), oversized hint, comments, and accepted
- * org-palette extras.
+ * org-palette extras. Also covers the value-injection hardening corpus from
+ * harden-custom-token-set-value-validation/tasks.md#task-2: semicolon and
+ * CSS-comment-marker smuggling, both at the isForbiddenValue() unit level
+ * and the validateDeclarations() end-to-end level.
  */
 class CustomTokenSetValidatorTest extends TestCase
 {
@@ -140,6 +144,65 @@ class CustomTokenSetValidatorTest extends TestCase
         $this->assertTrue(condition: $this->validator->isForbiddenValue(value: 'red } /* injected'));
         $this->assertTrue(condition: $this->validator->isForbiddenValue(value: 'red */ .evil { color: red'));
     }//end testCommentDelimitersAreForbidden()
+
+    /**
+     * Proposal-literal regression: a semicolon after a legitimate value can
+     * smuggle an unrelated `background` declaration into the served :root
+     * block. This is the exact payload from the change proposal's "Why"
+     * section and MUST be rejected.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/harden-custom-token-set-value-validation/tasks.md#task-2.1
+     */
+    public function testSemicolonSmuggledBackgroundDeclarationIsForbidden(): void
+    {
+        $this->assertTrue(
+            condition: $this->validator->isForbiddenValue(value: 'red; background: url(https://evil.example/x.png)')
+        );
+    }//end testSemicolonSmuggledBackgroundDeclarationIsForbidden()
+
+    /**
+     * A bare CSS comment marker embedded in an otherwise plausible value must
+     * be rejected even when it is not paired with a semicolon, since `/*` /
+     * `*​/` alone can unbalance the generated :root block's comment nesting.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/harden-custom-token-set-value-validation/tasks.md#task-2.2
+     */
+    public function testBareCommentMarkerValueIsForbidden(): void
+    {
+        $this->assertTrue(condition: $this->validator->isForbiddenValue(value: 'red /* } */'));
+    }//end testBareCommentMarkerValueIsForbidden()
+
+    /**
+     * End-to-end proof (not just isForbiddenValue() in isolation): a
+     * declaration set containing the semicolon-smuggling payload is rejected
+     * by validateDeclarations() as a hard 422 failure — it must NOT be
+     * silently split into an "accepted" (trimmed/truncated) value and a
+     * "skipped" entry, which would still let the smuggled fragment reach
+     * storage under a mangled but present accepted value.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/harden-custom-token-set-value-validation/tasks.md#task-2.3
+     */
+    public function testValidateDeclarationsRejectsSemicolonSmugglingEndToEnd(): void
+    {
+        $split = $this->validator->validateDeclarations(
+            declarations: [
+                '--nldesign-color-primary' => 'red; background: url(https://evil.example/x.png)',
+            ],
+            slug: 'gemeente'
+        );
+
+        $this->assertNull(actual: $split, message: 'the smuggling payload must be a hard failure, not a split result');
+
+        $error = $this->validator->getLastError();
+        $this->assertSame(expected: 422, actual: $error['status']);
+        $this->assertSame(expected: '--nldesign-color-primary', actual: $error['property']);
+    }//end testValidateDeclarationsRejectsSemicolonSmugglingEndToEnd()
 
     /**
      * Any selector other than :root (or any at-rule) is rejected pre-parse.


### PR DESCRIPTION
## What
`CustomTokenSetValidator::isForbiddenValue()` rejected `@import`, `expression(`, `javascript:`, raw markup, and disallowed `url()` targets, but **not** `;`, `/*`, or `*/`. A declaration value such as `red; background: url(https://evil.example/x.png)` passed the whitelist and, because `serialize()` re-emits each accepted declaration as a bare `name: value;` line, smuggled an arbitrary extra CSS declaration past the `--nldesign-*`/`--{slug}-*` name whitelist into the `:root {}` block served to every anonymous visitor (login page, share links).

## Why
The sibling write path for the same file family, `CustomOverridesService::buildDeclarationLines()`, already guards exactly this class of attack (`preg_match('/[{};]|\/\*|\*\//', $value)`). This closes the gap so both admin-upload-to-served-CSS pipelines enforce the same value hygiene, matching `openspec/changes/harden-custom-token-set-value-validation/specs/custom-token-sets/spec.md`.

## Changes
- `isForbiddenValue()` already carried the `;`/`/*`/`*/` checks on `development` HEAD (landed via an earlier "wip: preserve uncommitted work" commit); this PR verifies that gate with a dedicated injection-corpus test suite and refactors the method into three focused private helpers (`containsDangerousKeyword`/`containsInjectionCharacter`/`hasDisallowedUrlTarget`) — pure decomposition, no behaviour change — to bring PHPMD cyclomatic complexity back under threshold (was 14, now passes).
- Adds semicolon/comment-marker smuggling cases to `CustomTokenSetValidatorTest` at both the `isForbiddenValue()` unit level and the `validateDeclarations()` end-to-end level (proves a hard 422 failure, not a silent accepted/skipped split).
- Adds a new `tests/Unit/Controller/CustomTokenSetControllerTest.php` proving the same gate blocks the equivalent payload on the W3C Design Tokens JSON upload path (`mapFromJson()`), plus a clean-value regression case (no false positives).
- Documents the fix and its non-retroactive scope (existing stored token sets are not re-validated) in `CHANGELOG.md`.

Tests: 98 PHPUnit unit tests pass (`phpunit -c phpunit-unit.xml` in `nextcloud:34.0.0-apache`, 1335 assertions). `composer check:strict`: lint and phpcs clean; phpmd/psalm/phpstan pre-existing findings are all in files this PR does not touch (`test:all` skips as expected without a live NC environment).

Deferred to post-merge live verification (per builder brief — requires the live 8080 instance):
- [ ] task 4.2: manually upload a CSS token set containing the semicolon payload via the admin panel and confirm a 422 with a user-facing error, not a silent accept.