### PR TITLE
fix(security): admin-only auth on /api/metrics, tests + spec catch-up

### DIFF
--- a/lib/Controller/MetricsController.php
+++ b/lib/Controller/MetricsController.php
@@ -78,7 +78,7 @@ class MetricsController extends Controller
      * @NoCSRFRequired
      *
      * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-4
-     * @spec openspec/changes/metrics-endpoint-admin-auth/tasks.md#task-1
+     * @spec openspec/specs/prometheus-metrics/spec.md
      */
     public function index(): TextPlainResponse
     {

--- a/openspec/changes/metrics-endpoint-admin-auth/tasks.md
+++ b/openspec/changes/metrics-endpoint-admin-auth/tasks.md
@@ -1,36 +1,63 @@
 ## 1. Fix the auth posture
 
-- [ ] 1.1 Remove `#[PublicPage]` from `MetricsController::index()`
+- [x] 1.1 Remove `#[PublicPage]` from `MetricsController::index()`
       (`lib/Controller/MetricsController.php:75`). Keep `#[NoCSRFRequired]` / `@NoCSRFRequired`.
-- [ ] 1.2 Remove the now-inaccurate docblock line above `index()` that implies public,
+      (Already landed on `development` prior to this change — verified via `git diff
+      origin/development -- lib/Controller/MetricsController.php` = empty; no `#[PublicPage]`
+      attribute or import present, `@NoCSRFRequired` docblock annotation retained.)
+- [x] 1.2 Remove the now-inaccurate docblock line above `index()` that implies public,
       unauthenticated access, and replace it with the ADR-006 admin-auth rationale (mirror the
       wording style used in `pipelinq/lib/Controller/MetricsController.php:13-14` and
       `docudesk/lib/Controller/MetricsController.php:38`).
+      (Already landed alongside 1.1 — `index()`'s docblock reads "Deliberately NOT a
+      #[PublicPage]: ... the Nextcloud SecurityMiddleware default applies — admin-only".)
 
 ## 2. Update the spec
 
-- [ ] 2.1 In `openspec/specs/prometheus-metrics/spec.md`, reword the `REQ-PROM-001` scenario
+- [x] 2.1 In `openspec/specs/prometheus-metrics/spec.md`, reword the `REQ-PROM-001` scenario
       "Metrics endpoint is publicly accessible without CSRF" to state the endpoint requires an
       admin session (SecurityMiddleware default, no `#[NoAdminRequired]`/`#[PublicPage]`) and is
       merely CSRF-exempt for scraper convenience — not unauthenticated.
-- [ ] 2.2 Update the spec's "Current Implementation Status" section to match the new auth
-      posture.
+      (Already landed — scenario is now titled "Metrics endpoint requires an authenticated admin
+      session"; also updated the stale e2e-coverage anchor in
+      `tests/e2e/spec-coverage/prometheus-metrics.spec.ts` that still pointed at the old
+      scenario title.)
+- [x] 2.2 Update the spec's "Current Implementation Status" section to match the new auth
+      posture. (Added an explicit line documenting the absent `#[PublicPage]`/`#[NoAdminRequired]`
+      attributes and the retained `@NoCSRFRequired` annotation.)
 
 ## 3. Tests
 
-- [ ] 3.1 Add/update a controller test asserting a request to `metrics#index` without an admin
+- [x] 3.1 Add/update a controller test asserting a request to `metrics#index` without an admin
       session is rejected (401/redirect per Nextcloud's SecurityMiddleware behavior for
       non-admin-authenticated requests), mirroring how `pipelinq`/`docudesk` test their metrics
       controllers' admin-only posture (if an equivalent test pattern exists there — otherwise add
       a minimal PHPUnit case using the standard OCP SecurityMiddleware test harness for this app).
-- [ ] 3.2 Confirm `HealthController` behavior is unaffected (still public) — no code change
+      (Neither pipelinq nor docudesk has a MetricsController test to mirror. Added
+      `tests/Unit/Controller/MetricsControllerTest.php`: this standalone PHPUnit harness has no
+      live `SecurityMiddleware`/route-dispatch layer to assert a real 401 against, so the test
+      asserts the statically-verifiable precondition the admin-only default depends on —
+      `index()` carries neither `#[PublicPage]` nor `#[NoAdminRequired]` (via `ReflectionMethod`
+      + real OCP attribute classes, mounted from the Nextcloud checkout in the docker phpunit
+      run) — plus confirms `@NoCSRFRequired` is retained and the method still returns a correct
+      `TextPlainResponse` body. The literal unauthenticated-401 assertion is covered by the
+      deferred manual curl check in 4.2.)
+- [x] 3.2 Confirm `HealthController` behavior is unaffected (still public) — no code change
       expected, but re-run its existing test to confirm no regression.
+      (No code change: `git diff origin/development -- lib/Controller/HealthController.php` is
+      empty. No dedicated HealthController unit test exists or can safely be added in this
+      harness — `HealthController` extends OpenRegister's `GenericHealthController`, an optional
+      soft dependency not present in nldesign's own `vendor/` tree, so reflecting/instantiating
+      the class here would fail to autoload the parent. Its `#[PublicPage]` + `#[NoCSRFRequired]`
+      posture and behavior are engine-owned and exercised by OpenRegister's own test suite; this
+      change touches neither the controller nor the manifest health-check config.)
 
 ## 4. Verify
 
-- [ ] 4.1 Run the PHPUnit suite (`composer test:unit` / project's PHPUnit target) and confirm all
-      MetricsController and HealthController tests pass.
+- [x] 4.1 Run the PHPUnit suite (`composer test:unit` / project's PHPUnit target) and confirm all
+      MetricsController and HealthController tests pass. (Ran via the docker phpunit-unit
+      command from the builder brief — see PR body for the exact pass count/tail.)
 - [ ] 4.2 Manually curl `/index.php/apps/nldesign/api/metrics` unauthenticated against a running
       dev instance and confirm it now returns 401 (not the metrics body), and confirm an
       authenticated admin session (or Basic auth with an admin app-password) still returns the
-      metrics body.
+      metrics body. (deferred to post-merge live verification — requires the live 8080 instance)

--- a/openspec/specs/prometheus-metrics/spec.md
+++ b/openspec/specs/prometheus-metrics/spec.md
@@ -289,7 +289,10 @@ The MetricsController MUST receive all required dependencies via constructor inj
 ## Current Implementation Status
 
 **Fully implemented:**
-- MetricsController at `lib/Controller/MetricsController.php` with `@NoCSRFRequired` annotation
+- MetricsController at `lib/Controller/MetricsController.php` carries neither `#[PublicPage]` nor
+  `#[NoAdminRequired]`, so the Nextcloud `SecurityMiddleware` admin-only default applies
+  (ADR-006); `@NoCSRFRequired` remains so a Prometheus scraper authenticating as an admin (e.g.
+  via an app password) is not also required to present a CSRF token
 - Info gauge: `nldesign_info` with version, php_version, nextcloud_version labels
 - Up gauge: `nldesign_up` always 1
 - Token sets total: `nldesign_token_sets_total` via `TokenSetService::getAvailableTokenSets()` with try/catch fallback to 0

--- a/tests/Unit/Controller/MetricsControllerTest.php
+++ b/tests/Unit/Controller/MetricsControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Unit tests for MetricsController's admin-only auth posture.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @spec openspec/specs/prometheus-metrics/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit\Controller;
+
+use OCA\NLDesign\Controller\MetricsController;
+use OCA\NLDesign\Service\CustomOverridesService;
+use OCA\NLDesign\Service\TokenSetService;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\TextPlainResponse;
+use OCP\IConfig;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+
+/**
+ * Verifies `metrics#index` falls through to the Nextcloud
+ * `SecurityMiddleware` admin-only default (ADR-006), per
+ * `openspec/specs/prometheus-metrics/spec.md` REQ-PROM-001
+ * "Metrics endpoint requires an authenticated admin session".
+ *
+ * There is no real `SecurityMiddleware`/route-dispatch layer available in
+ * this standalone PHPUnit harness (no live Nextcloud server), so a live
+ * 401-on-unauthenticated-request assertion is not possible here — that is
+ * covered by the deferred manual curl check in tasks.md#task-4.2. What IS
+ * statically verifiable and regression-proof in this harness is the
+ * precondition the admin-only default depends on: `index()` must carry
+ * neither `#[PublicPage]` nor `#[NoAdminRequired]`. If either attribute is
+ * ever (re)added, Nextcloud's `SecurityMiddleware` would bypass the
+ * admin-only check entirely — so asserting their absence is the correct,
+ * fast-failing proxy for the auth posture.
+ */
+class MetricsControllerTest extends TestCase
+{
+
+    /**
+     * The controller under test.
+     *
+     * @var MetricsController
+     */
+    private MetricsController $controller;
+
+    /**
+     * Set up the controller with mocked dependencies.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $config = $this->createMock(IConfig::class);
+        $config->method('getAppValue')->willReturn('0');
+        $config->method('getSystemValueString')->willReturn('29.0.0');
+
+        $tokenSetService = $this->createMock(TokenSetService::class);
+        $tokenSetService->method('getAvailableTokenSets')->willReturn([]);
+
+        $overridesService = $this->createMock(CustomOverridesService::class);
+        $overridesService->method('read')->willReturn([]);
+
+        $this->controller = new MetricsController(
+            'nldesign',
+            $this->createMock(\OCP\IRequest::class),
+            $config,
+            $tokenSetService,
+            $overridesService,
+            $this->createMock(LoggerInterface::class)
+        );
+    }//end setUp()
+
+    /**
+     * `index()` MUST NOT carry `#[PublicPage]` — its presence would make the
+     * endpoint reachable by any unauthenticated caller, defeating the
+     * admin-auth requirement (ADR-006 / REQ-PROM-001).
+     */
+    public function testIndexHasNoPublicPageAttribute(): void
+    {
+        $method = new ReflectionMethod(MetricsController::class, 'index');
+
+        $this->assertCount(
+            0,
+            $method->getAttributes(PublicPage::class),
+            '#[PublicPage] must be absent so the SecurityMiddleware admin-only default applies.'
+        );
+    }//end testIndexHasNoPublicPageAttribute()
+
+    /**
+     * `index()` MUST NOT carry `#[NoAdminRequired]` — its presence would
+     * allow any authenticated (non-admin) user through, still short of the
+     * admin-only requirement (ADR-006 / REQ-PROM-001).
+     */
+    public function testIndexHasNoNoAdminRequiredAttribute(): void
+    {
+        $method = new ReflectionMethod(MetricsController::class, 'index');
+
+        $this->assertCount(
+            0,
+            $method->getAttributes(NoAdminRequired::class),
+            '#[NoAdminRequired] must be absent so the SecurityMiddleware admin-only default applies.'
+        );
+    }//end testIndexHasNoNoAdminRequiredAttribute()
+
+    /**
+     * The CSRF exemption is orthogonal to the admin-auth requirement and
+     * MUST remain — a Prometheus scraper authenticates via HTTP Basic/an
+     * app-password and cannot present a CSRF token.
+     */
+    public function testIndexDeclaresNoCsrfRequired(): void
+    {
+        $method = new ReflectionMethod(MetricsController::class, 'index');
+
+        $this->assertStringContainsString(
+            '@NoCSRFRequired',
+            (string) $method->getDocComment(),
+            'index() must remain CSRF-exempt even though it now requires an admin session.'
+        );
+    }//end testIndexDeclaresNoCsrfRequired()
+
+    /**
+     * Sanity/regression check: removing `#[PublicPage]` only changes the
+     * auth posture enforced by middleware, never invoked when calling the
+     * method directly — the metrics body itself must still be produced
+     * unchanged.
+     */
+    public function testIndexStillReturnsMetricsBody(): void
+    {
+        $response = $this->controller->index();
+
+        $this->assertInstanceOf(TextPlainResponse::class, $response);
+        $this->assertStringContainsString('nldesign_up 1', $response->render());
+    }//end testIndexStillReturnsMetricsBody()
+}//end class

--- a/tests/e2e/spec-coverage/prometheus-metrics.spec.ts
+++ b/tests/e2e/spec-coverage/prometheus-metrics.spec.ts
@@ -14,8 +14,11 @@
 // @e2e exclude openspec/specs/prometheus-metrics/spec.md#metrics-endpoint-returns-correct-content-type
 // API response header assertion — not DOM-testable.
 
-// @e2e exclude openspec/specs/prometheus-metrics/spec.md#metrics-endpoint-is-publicly-accessible-without-csrf
-// @NoCSRFRequired annotation — not DOM-testable (and must NOT add @NoCSRFRequired to test).
+// @e2e exclude openspec/specs/prometheus-metrics/spec.md#metrics-endpoint-requires-an-authenticated-admin-session
+// SecurityMiddleware admin-auth default + @NoCSRFRequired annotation — not DOM-testable
+// (and must NOT add @NoCSRFRequired to test); covered by
+// tests/Unit/Controller/MetricsControllerTest.php (attribute-absence assertions) and the
+// deferred manual curl check in openspec/changes/metrics-endpoint-admin-auth/tasks.md#task-4.2.
 
 // @e2e exclude openspec/specs/prometheus-metrics/spec.md#metrics-endpoint-returns-all-metric-families
 // API response body format — not DOM-testable.


### PR DESCRIPTION
## What / why

Hydra ADR-006 requires `/api/metrics` to be admin-auth (`SecurityMiddleware` default —
no `#[PublicPage]`/`#[NoAdminRequired]`), matching pipelinq/docudesk. On inspection,
`MetricsController::index()`'s `#[PublicPage]` had **already been removed** on
`development` and `openspec/specs/prometheus-metrics/spec.md`'s REQ-PROM-001 scenario
had already been reworded to match (both landed via an earlier commit, before this
change's proposal/tasks were authored) — `git diff origin/development` on both files
is empty. This PR finishes the remaining gaps in
`openspec/changes/metrics-endpoint-admin-auth/tasks.md`:

- Adds `tests/Unit/Controller/MetricsControllerTest.php` — the auth posture had **zero**
  test coverage before this PR. Asserts `index()` carries neither `#[PublicPage]` nor
  `#[NoAdminRequired]` (via `ReflectionMethod` + real OCP attribute classes), keeps
  `@NoCSRFRequired`, and still returns a correct `TextPlainResponse` metrics body.
- Points `index()`'s `@spec` tag at the canonical `openspec/specs/prometheus-metrics/spec.md`
  instead of a `changes/` path.
- Documents the admin-only posture explicitly in the spec's "Current Implementation Status".
- Fixes the stale e2e-coverage anchor in
  `tests/e2e/spec-coverage/prometheus-metrics.spec.ts` for the renamed REQ-PROM-001 scenario.

No functional/behavioral code change — `lib/Controller/MetricsController.php`'s only
diff is the `@spec` tag.

## Tests

- `docker run --rm -v <worktree>:/app -w /app <mounts> nextcloud:34.0.0-apache php vendor/bin/phpunit -c phpunit-unit.xml`
  → **OK (96 tests, 1326 assertions)** (includes the 4 new MetricsControllerTest cases).
- `composer check:strict` → phpcs 25/25 clean; phpmd/psalm/phpstan pre-existing
  environment-only findings unrelated to touched files; `test:all` skips as expected
  (no live NC env) → **ALL CHECKS PASSED**.
- JS: not touched, vitest not run.

## Deferred (post-merge live verification)

- tasks.md#4.2 — manual curl of `/index.php/apps/nldesign/api/metrics` unauthenticated
  (expect 401) vs. authenticated as admin (expect metrics body) against the live 8080
  instance.