### PR TITLE
feat: expose active huisstijl as a public capability (IPublicCapability)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace OCA\NLDesign\AppInfo;
 
+use OCA\NLDesign\Capabilities;
 use OCA\NLDesign\Service\AppThemingService;
 use OCA\NLDesign\Service\CustomOverridesService;
 use OCA\NLDesign\Service\DesignSystemService;
@@ -53,29 +54,33 @@ class Application extends App implements IBootstrap
     /**
      * Register services and providers.
      *
-     * No bootstrap-time service registration is required: the `/api/health`
-     * endpoint is served by the thin `Controller\HealthController` subclass of
-     * the OpenRegister AppHost engine's GenericHealthController (ADR-040). The
-     * subclass is autoloaded only when the route is dispatched, never at
-     * bootstrap, so OpenRegister is a SOFT/optional dependency for health only
-     * — Nextcloud still boots and nldesign still themes when OpenRegister is
-     * absent (a request to /api/health would then degrade rather than fatal
-     * the app). The declarative checks live in `src/manifest.json` and use only
-     * the OR-independent primitives (database, filesystem, appEnabled) — never
-     * orAvailable, and no OR-object metrics.
+     * No bootstrap-time service registration is required for health: the
+     * `/api/health` endpoint is served by the thin `Controller\HealthController`
+     * subclass of the OpenRegister AppHost engine's GenericHealthController
+     * (ADR-040). The subclass is autoloaded only when the route is dispatched,
+     * never at bootstrap, so OpenRegister is a SOFT/optional dependency for
+     * health only — Nextcloud still boots and nldesign still themes when
+     * OpenRegister is absent (a request to /api/health would then degrade
+     * rather than fatal the app). The declarative checks live in
+     * `src/manifest.json` and use only the OR-independent primitives
+     * (database, filesystem, appEnabled) — never orAvailable, and no OR-object
+     * metrics. The `Capabilities` class IS registered here — it is the app's
+     * first real `register()`-time registration — so the huisstijl is exposed
+     * on every capabilities document without any request-time cost.
      *
      * @param IRegistrationContext $context The registration context.
      *
      * @return void
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) - required by IBootstrap interface
-     *
      * @spec openspec/changes/adopt-apphost-2026-06-16/tasks.md#task-2
+     * @spec openspec/specs/theming-capability/spec.md
      */
     public function register(IRegistrationContext $context): void
     {
         // Health endpoint served by the thin Controller\HealthController
         // subclass of the AppHost engine — no explicit registration needed.
+        // Public huisstijl capability — see lib/Capabilities.php.
+        $context->registerCapability(Capabilities::class);
     }//end register()
 
     /**

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -1,0 +1,312 @@
+<?php
+
+/**
+ * NL Design — Theming Capability.
+ *
+ * Contributes an `nldesign` entry to the Nextcloud capabilities document
+ * (`/ocs/v2.php/cloud/capabilities`) describing the instance's active huisstijl:
+ * the active token set, resolved design system, audited WCAG contrast level,
+ * available logo variants, and the slogan/menu-label presentation toggles.
+ * Implements `IPublicCapability` (not merely `ICapability`) so unauthenticated
+ * clients — login pages, portals, mobile/desktop clients pre-session — can read
+ * it, mirroring core `apps/theming`'s public capability. Everything exposed
+ * here is already visible to anyone loading the themed login page.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Capabilities
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/nldesign
+ *
+ * @spec openspec/specs/theming-capability/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign;
+
+use OCA\NLDesign\AppInfo\Application;
+use OCA\NLDesign\Service\DesignSystemService;
+use OCA\NLDesign\Service\ShippedTokenSetAuditService;
+use OCA\NLDesign\Service\TokenSetService;
+use OCP\App\IAppManager;
+use OCP\Capabilities\IPublicCapability;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+use stdClass;
+
+/**
+ * Advertises the active huisstijl as a public Nextcloud capability.
+ *
+ * @spec openspec/specs/theming-capability/spec.md
+ */
+class Capabilities implements IPublicCapability
+{
+
+    /**
+     * TTL (seconds) for the cached WCAG audit level — at most one hour so the
+     * capabilities endpoint never re-parses token CSS per request.
+     */
+    private const WCAG_CACHE_TTL = 3600;
+
+    /**
+     * Distributed cache for the resolved WCAG level, keyed by active token set id.
+     *
+     * @var ICache
+     */
+    private ICache $cache;
+
+    /**
+     * Constructor.
+     *
+     * @param IConfig                     $config              Reads the app's appconfig toggles.
+     * @param IAppManager                 $appManager          Resolves the app version and app path.
+     * @param IURLGenerator               $urlGenerator        Resolves logo asset web paths.
+     * @param DesignSystemService         $designSystemService Resolves the active set's design system.
+     * @param TokenSetService             $tokenSetService     Resolves the active set's display name/version.
+     * @param ShippedTokenSetAuditService $auditService        Computes the WCAG contrast verdict.
+     * @param ICacheFactory               $cacheFactory        Creates the distributed WCAG-level cache.
+     */
+    public function __construct(
+        private readonly IConfig $config,
+        private readonly IAppManager $appManager,
+        private readonly IURLGenerator $urlGenerator,
+        private readonly DesignSystemService $designSystemService,
+        private readonly TokenSetService $tokenSetService,
+        private readonly ShippedTokenSetAuditService $auditService,
+        ICacheFactory $cacheFactory
+    ) {
+        $this->cache = $cacheFactory->createDistributed(prefix: 'nldesign_wcag_level');
+    }//end __construct()
+
+    /**
+     * Return the `nldesign` capability payload.
+     *
+     * MUST NEVER throw: the Nextcloud capabilities endpoint aggregates every
+     * app's capability, so one throwing provider breaks the document for every
+     * client. Any internal failure degrades to a minimal payload instead of
+     * propagating.
+     *
+     * @return array<string, array<string, mixed>> The capabilities document fragment.
+     *
+     * @spec openspec/specs/theming-capability/spec.md
+     */
+    public function getCapabilities(): array
+    {
+        try {
+            return ['nldesign' => $this->buildPayload()];
+        } catch (\Throwable $exception) {
+            return ['nldesign' => $this->minimalPayload()];
+        }
+    }//end getCapabilities()
+
+    /**
+     * Build the full seven-key payload from live appconfig + manifest state.
+     *
+     * @return array<string, mixed> The payload (allowlisted to exactly seven keys).
+     *
+     * @spec openspec/specs/theming-capability/spec.md
+     */
+    private function buildPayload(): array
+    {
+        $tokenSetId     = $this->config->getAppValue(appName: Application::APP_ID, key: 'token_set', default: 'nextcloud');
+        $hideSlogan     = $this->config->getAppValue(appName: Application::APP_ID, key: 'hide_slogan', default: '0') === '1';
+        $showMenuLabels = $this->config->getAppValue(appName: Application::APP_ID, key: 'show_menu_labels', default: '0') === '1';
+
+        $tokenSetMeta   = $this->designSystemService->getTokenSetMeta(tokenSetId: $tokenSetId);
+        $designSystemId = ($tokenSetMeta['design_system'] ?? 'nldesign');
+
+        return [
+            'version'        => $this->appManager->getAppVersion(appId: Application::APP_ID),
+            'tokenSet'       => $this->buildTokenSet(tokenSetId: $tokenSetId),
+            'designSystem'   => $designSystemId,
+            'wcagLevel'      => $this->computeWcagLevel(tokenSetId: $tokenSetId, tokenSetMeta: $tokenSetMeta),
+            'logos'          => $this->buildLogos(tokenSetMeta: $tokenSetMeta),
+            'hideSlogan'     => $hideSlogan,
+            'showMenuLabels' => $showMenuLabels,
+        ];
+    }//end buildPayload()
+
+    /**
+     * Resolve the active token set's `{ id, name, version }` triple.
+     *
+     * `name` falls back to the id and `version` is null when the active set has
+     * no entry in `TokenSetService::getAvailableTokenSets()` (custom/unknown set).
+     *
+     * @param string $tokenSetId The active token set id (appconfig `token_set`).
+     *
+     * @return array{id: string, name: string, version: string|null} The token set descriptor.
+     *
+     * @spec openspec/specs/theming-capability/spec.md
+     */
+    private function buildTokenSet(string $tokenSetId): array
+    {
+        $available = $this->tokenSetService->getAvailableTokenSets();
+        $byId      = array_column($available, null, 'id');
+        $entry     = ($byId[$tokenSetId] ?? null);
+
+        return [
+            'id'      => $tokenSetId,
+            'name'    => ($entry['name'] ?? $tokenSetId),
+            'version' => ($entry['version'] ?? null),
+        ];
+    }//end buildTokenSet()
+
+    /**
+     * Resolve the available logo variants for the active set.
+     *
+     * Today only the `default` variant exists (from `theming.logo` in the set's
+     * manifest entry). Empty when the set declares no logo — always an empty
+     * object, never `[]`, so it serializes as JSON `{}`.
+     *
+     * @param array<string, mixed> $tokenSetMeta The active set's manifest entry (empty for custom/unknown sets).
+     *
+     * @return array<string, string>|stdClass The logo variant map.
+     *
+     * @spec openspec/specs/theming-capability/spec.md
+     */
+    private function buildLogos(array $tokenSetMeta): array|stdClass
+    {
+        $logoPath = ($tokenSetMeta['theming']['logo'] ?? null);
+        if (is_string($logoPath) === false || $logoPath === '') {
+            return new stdClass();
+        }
+
+        // Theming.logo is stored app-relative (e.g. "img/logos/x.svg");
+        // IURLGenerator::imagePath() prepends "img/" itself.
+        $relative = $logoPath;
+        if (str_starts_with(haystack: $relative, needle: 'img/') === true) {
+            $relative = substr($relative, 4);
+        }
+
+        return ['default' => $this->urlGenerator->imagePath(appName: Application::APP_ID, file: $relative)];
+    }//end buildLogos()
+
+    /**
+     * Compute the audited WCAG contrast level for the active token set, cached.
+     *
+     * Null for a stock (`none` design system) or custom/unknown set — the audit
+     * has nothing to evaluate or cannot cover it, and the capability MUST NOT
+     * fabricate a conformance claim. Otherwise resolves via
+     * `ShippedTokenSetAuditService::auditSet()`, cached per active set id.
+     *
+     * @param string               $tokenSetId   The active token set id.
+     * @param array<string, mixed> $tokenSetMeta The active set's manifest entry (empty for custom/unknown sets).
+     *
+     * @return string|null One of `AAA`, `AA`, `fail`, or null.
+     *
+     * @spec openspec/specs/theming-capability/spec.md
+     */
+    private function computeWcagLevel(string $tokenSetId, array $tokenSetMeta): ?string
+    {
+        $designSystemId = ($tokenSetMeta['design_system'] ?? null);
+        if (empty($tokenSetMeta) === true || $designSystemId === 'none') {
+            return null;
+        }
+
+        $cacheKey = 'level-'.$tokenSetId;
+        $cached   = $this->cache->get(key: $cacheKey);
+        if (is_string($cached) === true) {
+            return $cached;
+        }
+
+        $level = $this->auditWcagLevel(tokenSetId: $tokenSetId, tokenSetMeta: $tokenSetMeta, designSystemId: (string) $designSystemId);
+        $this->cache->set(key: $cacheKey, value: $level, ttl: self::WCAG_CACHE_TTL);
+
+        return $level;
+    }//end computeWcagLevel()
+
+    /**
+     * Run the contrast audit(s) for a set known to have a real design system.
+     *
+     * @param string               $tokenSetId     The active token set id.
+     * @param array<string, mixed> $tokenSetMeta   The active set's manifest entry.
+     * @param string               $designSystemId The set's resolved design system id.
+     *
+     * @return string One of `AAA`, `AA`, or `fail`.
+     *
+     * @spec openspec/specs/theming-capability/spec.md
+     */
+    private function auditWcagLevel(string $tokenSetId, array $tokenSetMeta, string $designSystemId): string
+    {
+        $appPath = $this->appManager->getAppPath(appId: Application::APP_ID);
+        $theming = ($tokenSetMeta['theming'] ?? []);
+
+        $declaresAaa = ($designSystemId === 'high-contrast' || ($tokenSetMeta['contrast_level'] ?? null) === 'AAA');
+
+        $passesAa = $this->auditService->auditSet(
+            appPath: $appPath,
+            id: $tokenSetId,
+            theming: $theming,
+            aaa: false
+        )['verdict'] === 'pass';
+
+        if ($declaresAaa === true) {
+            $passesAaa = $this->auditService->auditSet(
+                appPath: $appPath,
+                id: $tokenSetId,
+                theming: $theming,
+                aaa: true
+            )['verdict'] === 'pass';
+
+            if ($passesAaa === true) {
+                return 'AAA';
+            }
+        }
+
+        if ($passesAa === true) {
+            return 'AA';
+        }
+
+        return 'fail';
+    }//end auditWcagLevel()
+
+    /**
+     * The degraded minimal payload returned when `buildPayload()` throws.
+     *
+     * `version` and `tokenSet.id` are re-derived from raw appconfig (best
+     * effort — a nested failure here still falls back to a safe literal rather
+     * than propagating); `name` falls back to the id; every other field is
+     * `null`, `{}`, or `false`. Never includes exception details.
+     *
+     * @return array<string, mixed> The minimal payload.
+     *
+     * @spec openspec/specs/theming-capability/spec.md
+     */
+    private function minimalPayload(): array
+    {
+        $version = 'unknown';
+        try {
+            $version = $this->appManager->getAppVersion(appId: Application::APP_ID);
+        } catch (\Throwable $exception) {
+            // Fall through to the safe literal — the degrade path must not itself throw.
+        }
+
+        $tokenSetId = 'nextcloud';
+        try {
+            $tokenSetId = $this->config->getAppValue(appName: Application::APP_ID, key: 'token_set', default: 'nextcloud');
+        } catch (\Throwable $exception) {
+            // Fall through to the safe literal.
+        }
+
+        return [
+            'version'        => $version,
+            'tokenSet'       => [
+                'id'      => $tokenSetId,
+                'name'    => $tokenSetId,
+                'version' => null,
+            ],
+            'designSystem'   => null,
+            'wcagLevel'      => null,
+            'logos'          => new stdClass(),
+            'hideSlogan'     => false,
+            'showMenuLabels' => false,
+        ];
+    }//end minimalPayload()
+}//end class

--- a/openspec/changes/theming-capability-api/tasks.md
+++ b/openspec/changes/theming-capability-api/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Capability class
 
-- [ ] 1.1 Create `lib/Capabilities.php` (`OCA\NLDesign\Capabilities`) implementing
+- [x] 1.1 Create `lib/Capabilities.php` (`OCA\NLDesign\Capabilities`) implementing
       `OCP\Capabilities\IPublicCapability` with full SPDX `@license`/`@copyright` docblock.
       Constructor-inject `IConfig`, `IAppManager` (app version), `IURLGenerator` (logo web
       paths), `DesignSystemService`, `TokenSetService`, `ShippedTokenSetAuditService`, and
       `ICacheFactory`.
-- [ ] 1.2 Implement `getCapabilities(): array` returning
+- [x] 1.2 Implement `getCapabilities(): array` returning
       `['nldesign' => ['version', 'tokenSet' => ['id','name','version'], 'designSystem',
       'wcagLevel', 'logos', 'hideSlogan', 'showMenuLabels']]` exactly as specced in
       `specs/theming-capability/spec.md`:
@@ -18,20 +18,20 @@
         `IURLGenerator` (`{ "default": <path> }`, `{}` when absent);
       - `hideSlogan`/`showMenuLabels` from appconfig `hide_slogan`/`show_menu_labels` `'1'`
         comparisons (same semantics as `Application::injectThemeCSS()`).
-- [ ] 1.3 Implement `wcagLevel` computation: for a shipped set, run
+- [x] 1.3 Implement `wcagLevel` computation: for a shipped set, run
       `ShippedTokenSetAuditService::auditSet()` — `"AAA"` when the set declares
       `contrast_level: "AAA"` and passes at AAA thresholds, else `"AA"` when it passes at AA,
       else `"fail"`; `null` for custom/unknown sets. Cache the resolved level in an
       `ICacheFactory` distributed cache keyed by active token set id (TTL ≤ 1 hour) so
       capabilities requests never re-parse token CSS; a cache miss computes and stores.
-- [ ] 1.4 Wrap the whole payload computation in a try/catch: on any Throwable, return the minimal
+- [x] 1.4 Wrap the whole payload computation in a try/catch: on any Throwable, return the minimal
       payload (`version` + `tokenSet.id` from raw appconfig, remaining fields `null`/`{}`/`false`)
       — the capabilities endpoint aggregates all apps and one throwing capability breaks it for
       every client. Never expose exception details.
 
 ## 2. Registration
 
-- [ ] 2.1 In `lib/AppInfo/Application.php` `register()`, add
+- [x] 2.1 In `lib/AppInfo/Application.php` `register()`, add
       `$context->registerCapability(Capabilities::class);` with the corresponding `use` import,
       and update the method docblock (it currently claims no bootstrap-time registration is
       required — keep the AppHost/health paragraph, add the capability sentence). Add `@spec`
@@ -39,7 +39,7 @@
 
 ## 3. Tests
 
-- [ ] 3.1 New `tests/Unit/CapabilitiesTest.php` covering:
+- [x] 3.1 New `tests/Unit/CapabilitiesTest.php` covering:
       - full payload shape and key presence for a shipped set (mock config `token_set` =
         `rijkshuisstijl`): id/name echo the manifest, `designSystem` resolved, `logos.default`
         is the manifest logo web path, toggles reflect config;
@@ -51,21 +51,32 @@
         (mock expects exactly one `auditSet` call);
       - degradation: a throwing injected service yields the minimal payload, no exception
         escapes `getCapabilities()`.
-- [ ] 3.2 Run the PHP suite in the nextcloud:34 container
+- [x] 3.2 Run the PHP suite in the nextcloud:34 container
       (`docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit -c phpunit-unit.xml`)
       and `composer check:strict`; both green.
+      (phpunit: 99/99 green in-container. `composer check:strict`: lint/phpcs/phpmd all green
+      for the touched files and repo-wide; phpstan/psalm/test:all cannot run in this worktree —
+      the shared `vendor/nextcloud/ocp/OCP/` stub directory is empty on the host [`OCP.bak/`
+      alongside it holds the real 931 stub files], a pre-existing environment defect in the
+      SHARED main-checkout vendor, reproducible identically on files never touched by this
+      change — not something this change introduced or can fix without touching the shared
+      main-checkout vendor, which is out of scope per the ground rules.)
 
 ## 4. Verify
 
 - [ ] 4.1 Deploy to the 8080 dev instance (respect bind-mount topology; restart apache so
       opcache picks up the new class: `apachectl -k restart` in the container if needed).
+      (deferred to post-merge live verification — requires the shared 8080 dev instance)
 - [ ] 4.2 Live curl, authenticated:
       `curl -s -u admin:admin -H "OCS-APIRequest: true" "http://localhost:8080/ocs/v2.php/cloud/capabilities?format=json" | jq '.ocs.data.capabilities.nldesign'`
       → object present with all seven keys and values matching the current admin-panel state.
+      (deferred to post-merge live verification)
 - [ ] 4.3 Live curl, unauthenticated (IPublicCapability contract):
       `curl -s -H "OCS-APIRequest: true" "http://localhost:8080/ocs/v2.php/cloud/capabilities?format=json" | jq '.ocs.data.capabilities.nldesign'`
       → same object present without credentials.
+      (deferred to post-merge live verification)
 - [ ] 4.4 Flip state and re-read: switch the active token set in the admin panel (browser-1,
       `/settings/admin/nldesign`), toggle hide-slogan, re-run the curl from 4.2 and confirm
       `tokenSet.id`, `wcagLevel`, `logos`, and `hideSlogan` all changed accordingly (proves the
       audit cache invalidates on token-set change).
+      (deferred to post-merge live verification)

--- a/tests/Unit/CapabilitiesTest.php
+++ b/tests/Unit/CapabilitiesTest.php
@@ -1,0 +1,391 @@
+<?php
+
+/**
+ * Unit tests for the public theming Capabilities class.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @spec openspec/changes/theming-capability-api/tasks.md#task-3.1
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit;
+
+use OCA\NLDesign\AppInfo\Application;
+use OCA\NLDesign\Capabilities;
+use OCA\NLDesign\Service\DesignSystemService;
+use OCA\NLDesign\Service\ShippedTokenSetAuditService;
+use OCA\NLDesign\Service\TokenSetService;
+use OCP\App\IAppManager;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers tasks.md#task-3.1: full payload shape, default config, custom/unknown
+ * degrade, WCAG cache behaviour, and exception-swallowing.
+ */
+class CapabilitiesTest extends TestCase
+{
+
+    /**
+     * The seven-key allowlist the payload MUST match exactly.
+     *
+     * @var array<int, string>
+     */
+    private const ALLOWED_KEYS = [
+        'version',
+        'tokenSet',
+        'designSystem',
+        'wcagLevel',
+        'logos',
+        'hideSlogan',
+        'showMenuLabels',
+    ];
+
+    /**
+     * In-memory fake backing an ICache mock so get()/set() persist across
+     * sequential getCapabilities() calls within one test.
+     *
+     * @param IConfig                                    $config
+     * @param IAppManager|\PHPUnit\Framework\MockObject\MockObject $appManager
+     * @param IURLGenerator|\PHPUnit\Framework\MockObject\MockObject $urlGenerator
+     * @param DesignSystemService|\PHPUnit\Framework\MockObject\MockObject $designSystemService
+     * @param TokenSetService|\PHPUnit\Framework\MockObject\MockObject $tokenSetService
+     * @param ShippedTokenSetAuditService|\PHPUnit\Framework\MockObject\MockObject $auditService
+     *
+     * @return Capabilities
+     */
+    private function buildCapabilities(
+        IConfig $config,
+        IAppManager $appManager,
+        IURLGenerator $urlGenerator,
+        DesignSystemService $designSystemService,
+        TokenSetService $tokenSetService,
+        ShippedTokenSetAuditService $auditService
+    ): Capabilities {
+        $store = [];
+
+        $cache = $this->createMock(ICache::class);
+        $cache->method('get')->willReturnCallback(
+            static function (string $key) use (&$store) {
+                return ($store[$key] ?? null);
+            }
+        );
+        $cache->method('set')->willReturnCallback(
+            static function (string $key, $value, int $ttl = 0) use (&$store): bool {
+                $store[$key] = $value;
+                return true;
+            }
+        );
+
+        $cacheFactory = $this->createMock(ICacheFactory::class);
+        $cacheFactory->method('createDistributed')->willReturn($cache);
+
+        return new Capabilities(
+            $config,
+            $appManager,
+            $urlGenerator,
+            $designSystemService,
+            $tokenSetService,
+            $auditService,
+            $cacheFactory
+        );
+    }//end buildCapabilities()
+
+    /**
+     * Build an IConfig mock returning fixed values for the three appconfig
+     * reads Capabilities performs, falling back to the caller-supplied default
+     * for any other key (mirrors real getAppValue() semantics).
+     *
+     * @param array<string, string> $values Key => value overrides.
+     *
+     * @return IConfig&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function configWith(array $values): IConfig
+    {
+        $config = $this->createMock(IConfig::class);
+        $config->method('getAppValue')->willReturnCallback(
+            static fn (string $appName, string $key, $default = '') => ($values[$key] ?? $default)
+        );
+
+        return $config;
+    }//end configWith()
+
+    /**
+     * Full payload shape + key allowlist for an active shipped set.
+     */
+    public function testFullPayloadShapeForShippedSet(): void
+    {
+        $config = $this->configWith(
+            [
+                'token_set'        => 'rijkshuisstijl',
+                'hide_slogan'      => '1',
+                'show_menu_labels' => '0',
+            ]
+        );
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppVersion')->willReturn('3.4.0');
+        $appManager->method('getAppPath')->willReturn('/app');
+
+        $urlGenerator = $this->createMock(IURLGenerator::class);
+        $urlGenerator->method('imagePath')->with(Application::APP_ID, 'logos/rijkshuisstijl.svg')
+            ->willReturn('https://cloud.example/apps/nldesign/img/logos/rijkshuisstijl.svg');
+
+        $designSystemService = $this->createMock(DesignSystemService::class);
+        $designSystemService->method('getTokenSetMeta')->with('rijkshuisstijl')->willReturn(
+            [
+                'id'            => 'rijkshuisstijl',
+                'design_system' => 'nldesign',
+                'theming'       => ['logo' => 'img/logos/rijkshuisstijl.svg'],
+            ]
+        );
+
+        $tokenSetService = $this->createMock(TokenSetService::class);
+        $tokenSetService->method('getAvailableTokenSets')->willReturn(
+            [['id' => 'rijkshuisstijl', 'name' => 'Rijkshuisstijl', 'description' => '']]
+        );
+
+        $auditService = $this->createMock(ShippedTokenSetAuditService::class);
+        $auditService->method('auditSet')->willReturn(['verdict' => 'pass']);
+
+        $capabilities = $this->buildCapabilities($config, $appManager, $urlGenerator, $designSystemService, $tokenSetService, $auditService);
+        $payload      = $capabilities->getCapabilities();
+
+        $this->assertArrayHasKey('nldesign', $payload);
+        $nldesign = $payload['nldesign'];
+
+        $this->assertSame(self::ALLOWED_KEYS, array_keys($nldesign), 'Payload must contain exactly the seven allowlisted keys, in shape.');
+        $this->assertSame('3.4.0', $nldesign['version']);
+        $this->assertSame(['id' => 'rijkshuisstijl', 'name' => 'Rijkshuisstijl', 'version' => null], $nldesign['tokenSet']);
+        $this->assertSame('nldesign', $nldesign['designSystem']);
+        $this->assertSame('https://cloud.example/apps/nldesign/img/logos/rijkshuisstijl.svg', $nldesign['logos']['default']);
+        $this->assertTrue($nldesign['hideSlogan']);
+        $this->assertFalse($nldesign['showMenuLabels']);
+        $this->assertSame('AA', $nldesign['wcagLevel']);
+    }//end testFullPayloadShapeForShippedSet()
+
+    /**
+     * No `token_set` appconfig value → stock Nextcloud defaults, no audit call.
+     */
+    public function testDefaultConfigNoTokenSet(): void
+    {
+        $config = $this->configWith([]);
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppVersion')->willReturn('3.4.0');
+        $appManager->method('getAppPath')->willReturn('/app');
+
+        $urlGenerator = $this->createMock(IURLGenerator::class);
+
+        $designSystemService = $this->createMock(DesignSystemService::class);
+        $designSystemService->method('getTokenSetMeta')->with('nextcloud')->willReturn(
+            [
+                'id'            => 'nextcloud',
+                'design_system' => 'none',
+                'theming'       => ['primary_color' => '#0082c9', 'background_color' => '#FFFFFF'],
+            ]
+        );
+
+        $tokenSetService = $this->createMock(TokenSetService::class);
+        $tokenSetService->method('getAvailableTokenSets')->willReturn(
+            [['id' => 'nextcloud', 'name' => 'Nextcloud (default)', 'description' => '']]
+        );
+
+        $auditService = $this->createMock(ShippedTokenSetAuditService::class);
+        $auditService->expects($this->never())->method('auditSet');
+
+        $capabilities = $this->buildCapabilities($config, $appManager, $urlGenerator, $designSystemService, $tokenSetService, $auditService);
+        $nldesign     = $capabilities->getCapabilities()['nldesign'];
+
+        $this->assertSame('nextcloud', $nldesign['tokenSet']['id']);
+        $this->assertSame('none', $nldesign['designSystem']);
+        $this->assertEquals(new \stdClass(), $nldesign['logos']);
+        $this->assertSame('{}', json_encode($nldesign['logos']), 'Empty logos must serialize as a JSON object, never an array.');
+        $this->assertNull($nldesign['wcagLevel']);
+        $this->assertFalse($nldesign['hideSlogan']);
+        $this->assertFalse($nldesign['showMenuLabels']);
+    }//end testDefaultConfigNoTokenSet()
+
+    /**
+     * A custom/unknown token set id degrades name/version/wcagLevel, never lies.
+     */
+    public function testCustomOrUnknownTokenSetDegradesButNeverLies(): void
+    {
+        $config = $this->configWith(['token_set' => 'custom-onbekend']);
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppVersion')->willReturn('3.4.0');
+        $appManager->method('getAppPath')->willReturn('/app');
+
+        $urlGenerator = $this->createMock(IURLGenerator::class);
+
+        $designSystemService = $this->createMock(DesignSystemService::class);
+        // Not in token-sets.json (shipped manifest) — empty array, matching
+        // DesignSystemService::getTokenSetMeta()'s real not-found return value.
+        $designSystemService->method('getTokenSetMeta')->with('custom-onbekend')->willReturn([]);
+
+        $tokenSetService = $this->createMock(TokenSetService::class);
+        // Not discovered on disk either — absent from the available-sets list.
+        $tokenSetService->method('getAvailableTokenSets')->willReturn([]);
+
+        $auditService = $this->createMock(ShippedTokenSetAuditService::class);
+        $auditService->expects($this->never())->method('auditSet');
+
+        $capabilities = $this->buildCapabilities($config, $appManager, $urlGenerator, $designSystemService, $tokenSetService, $auditService);
+        $nldesign     = $capabilities->getCapabilities()['nldesign'];
+
+        $this->assertSame('custom-onbekend', $nldesign['tokenSet']['id']);
+        $this->assertSame('custom-onbekend', $nldesign['tokenSet']['name']);
+        $this->assertNull($nldesign['tokenSet']['version']);
+        $this->assertNull($nldesign['wcagLevel']);
+    }//end testCustomOrUnknownTokenSetDegradesButNeverLies()
+
+    /**
+     * The WCAG level is cached — a second call within the TTL never re-invokes
+     * the audit service, and both calls report the same level.
+     */
+    public function testWcagLevelIsCachedAcrossCalls(): void
+    {
+        $config = $this->configWith(['token_set' => 'rijkshuisstijl']);
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppVersion')->willReturn('3.4.0');
+        $appManager->method('getAppPath')->willReturn('/app');
+
+        $urlGenerator = $this->createMock(IURLGenerator::class);
+
+        $designSystemService = $this->createMock(DesignSystemService::class);
+        $designSystemService->method('getTokenSetMeta')->willReturn(
+            ['id' => 'rijkshuisstijl', 'design_system' => 'nldesign', 'theming' => []]
+        );
+
+        $tokenSetService = $this->createMock(TokenSetService::class);
+        $tokenSetService->method('getAvailableTokenSets')->willReturn(
+            [['id' => 'rijkshuisstijl', 'name' => 'Rijkshuisstijl']]
+        );
+
+        $auditService = $this->createMock(ShippedTokenSetAuditService::class);
+        $auditService->expects($this->once())->method('auditSet')->willReturn(['verdict' => 'pass']);
+
+        $capabilities = $this->buildCapabilities($config, $appManager, $urlGenerator, $designSystemService, $tokenSetService, $auditService);
+
+        $first  = $capabilities->getCapabilities()['nldesign']['wcagLevel'];
+        $second = $capabilities->getCapabilities()['nldesign']['wcagLevel'];
+
+        $this->assertSame('AA', $first);
+        $this->assertSame($first, $second);
+    }//end testWcagLevelIsCachedAcrossCalls()
+
+    /**
+     * A high-contrast set declaring `contrast_level: AAA` and passing AAA
+     * thresholds reports `AAA`.
+     */
+    public function testHighContrastSetReportsAaa(): void
+    {
+        $config = $this->configWith(['token_set' => 'hoog-contrast']);
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppVersion')->willReturn('3.4.0');
+        $appManager->method('getAppPath')->willReturn('/app');
+
+        $urlGenerator = $this->createMock(IURLGenerator::class);
+
+        $designSystemService = $this->createMock(DesignSystemService::class);
+        $designSystemService->method('getTokenSetMeta')->willReturn(
+            ['id' => 'hoog-contrast', 'design_system' => 'high-contrast', 'contrast_level' => 'AAA', 'theming' => []]
+        );
+
+        $tokenSetService = $this->createMock(TokenSetService::class);
+        $tokenSetService->method('getAvailableTokenSets')->willReturn(
+            [['id' => 'hoog-contrast', 'name' => 'Hoog Contrast']]
+        );
+
+        $auditService = $this->createMock(ShippedTokenSetAuditService::class);
+        $auditService->method('auditSet')->willReturn(['verdict' => 'pass']);
+
+        $capabilities = $this->buildCapabilities($config, $appManager, $urlGenerator, $designSystemService, $tokenSetService, $auditService);
+        $nldesign     = $capabilities->getCapabilities()['nldesign'];
+
+        $this->assertSame('AAA', $nldesign['wcagLevel']);
+    }//end testHighContrastSetReportsAaa()
+
+    /**
+     * A shipped set failing its audit reports `fail`, never a fabricated pass.
+     */
+    public function testFailingShippedSetReportsFail(): void
+    {
+        $config = $this->configWith(['token_set' => 'noaberkracht']);
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppVersion')->willReturn('3.4.0');
+        $appManager->method('getAppPath')->willReturn('/app');
+
+        $urlGenerator = $this->createMock(IURLGenerator::class);
+
+        $designSystemService = $this->createMock(DesignSystemService::class);
+        $designSystemService->method('getTokenSetMeta')->willReturn(
+            ['id' => 'noaberkracht', 'design_system' => 'nldesign', 'theming' => []]
+        );
+
+        $tokenSetService = $this->createMock(TokenSetService::class);
+        $tokenSetService->method('getAvailableTokenSets')->willReturn(
+            [['id' => 'noaberkracht', 'name' => 'Noaberkracht']]
+        );
+
+        $auditService = $this->createMock(ShippedTokenSetAuditService::class);
+        $auditService->method('auditSet')->willReturn(['verdict' => 'fail']);
+
+        $capabilities = $this->buildCapabilities($config, $appManager, $urlGenerator, $designSystemService, $tokenSetService, $auditService);
+        $nldesign     = $capabilities->getCapabilities()['nldesign'];
+
+        $this->assertSame('fail', $nldesign['wcagLevel']);
+    }//end testFailingShippedSetReportsFail()
+
+    /**
+     * A throwing injected dependency degrades to the minimal payload — no
+     * exception escapes getCapabilities(), and no exception detail leaks.
+     */
+    public function testThrowingDependencyDegradesGracefully(): void
+    {
+        $config = $this->configWith(['token_set' => 'rijkshuisstijl']);
+
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppVersion')->willReturn('3.4.0');
+
+        $urlGenerator = $this->createMock(IURLGenerator::class);
+
+        $designSystemService = $this->createMock(DesignSystemService::class);
+        $designSystemService->method('getTokenSetMeta')->willThrowException(new \RuntimeException('manifest unreadable: /secret/path'));
+
+        $tokenSetService = $this->createMock(TokenSetService::class);
+        $auditService     = $this->createMock(ShippedTokenSetAuditService::class);
+        $auditService->expects($this->never())->method('auditSet');
+
+        $capabilities = $this->buildCapabilities($config, $appManager, $urlGenerator, $designSystemService, $tokenSetService, $auditService);
+
+        $payload = $capabilities->getCapabilities();
+
+        $this->assertArrayHasKey('nldesign', $payload);
+        $nldesign = $payload['nldesign'];
+
+        $this->assertSame(self::ALLOWED_KEYS, array_keys($nldesign));
+        $this->assertSame('3.4.0', $nldesign['version']);
+        $this->assertSame('rijkshuisstijl', $nldesign['tokenSet']['id']);
+        $this->assertSame('rijkshuisstijl', $nldesign['tokenSet']['name']);
+        $this->assertNull($nldesign['tokenSet']['version']);
+        $this->assertNull($nldesign['designSystem']);
+        $this->assertNull($nldesign['wcagLevel']);
+        $this->assertEquals(new \stdClass(), $nldesign['logos']);
+        $this->assertFalse($nldesign['hideSlogan']);
+        $this->assertFalse($nldesign['showMenuLabels']);
+
+        $encoded = (string) json_encode($payload);
+        $this->assertStringNotContainsString('secret', $encoded, 'No exception detail must leak into the payload.');
+    }//end testThrowingDependencyDegradesGracefully()
+}//end class


### PR DESCRIPTION
## What / why

nldesign holds the instance's huisstijl (active token set, design system, WCAG
posture, logo, slogan/menu-label toggles) but exposed none of it
programmatically — every existing read surface (`lib/Settings/*`) is
admin-only. This adds `lib/Capabilities.php` implementing
`OCP\Capabilities\IPublicCapability`, registered in `Application::register()`,
contributing an `nldesign` entry to `/ocs/v2.php/cloud/capabilities`:
`{ version, tokenSet: {id,name,version}, designSystem, wcagLevel, logos,
hideSlogan, showMenuLabels }`.

This unblocks the flagged, dormant `openbuild/src/dialogs/ThemePickerDialog.vue`
non-admin path (documented in that file as waiting on exactly this), and
mirrors core `apps/theming`'s public capability precedent. `wcagLevel` is
derived from the existing `ShippedTokenSetAuditService` and cached
(`ICacheFactory`, TTL 1h, keyed by active token set id) so the capabilities
endpoint never re-parses token CSS per request. `getCapabilities()` wraps the
whole computation in a try/catch and degrades to a minimal payload on any
`Throwable` — one throwing capability would otherwise break the capabilities
document for every app. No new routes, no Vue, purely additive.

Implements the new canonical spec `theming-capability` (delta in this change).

## Tests

- `docker run --rm ... nextcloud:34.0.0-apache php vendor/bin/phpunit -c phpunit-unit.xml`: **OK (99 tests, 1364 assertions)** — includes the 7 new `tests/Unit/CapabilitiesTest.php` cases (full payload shape/allowlist, default config, custom/unknown degrade, cache behaviour, AAA/fail verdicts, exception-swallowing).
- `composer lint` / `composer phpcs` / `composer phpmd`: green, repo-wide, on the touched files.
- `composer check:strict` (phpstan/psalm/test:all steps): **cannot run in this worktree** — the shared main-checkout `vendor/nextcloud/ocp/OCP/` stub directory is empty (0 files) on this host; the real 931 stub files sit untouched in a sibling `OCP.bak/`. This is a pre-existing environment defect in the SHARED vendor (reproduced identically against files this change never touched, e.g. `DesignSystemService.php`, `TokenSetService.php`) — not introduced by or fixable from this worktree without touching the shared main-checkout vendor, which is out of scope for a single-change PR. Flagging for whoever owns the shared dev environment.

## Deferred (post-merge live verification, requires the shared 8080 dev instance)

- [ ] Deploy to 8080, restart apache/opcache
- [ ] Authenticated curl of `/ocs/v2.php/cloud/capabilities` → `nldesign` object present
- [ ] Unauthenticated curl (IPublicCapability contract) → same object present
- [ ] Flip active token set + hide-slogan in the admin panel, re-curl → `tokenSet.id`, `wcagLevel`, `logos`, `hideSlogan` all reflect the change