### PR TITLE
feat(mail): brand system email with NL Design token set + compliance footer

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -41,5 +41,8 @@ return [
 		['name' => 'customTokenSet#list', 'url' => '/settings/tokensets/custom', 'verb' => 'GET'],
 		['name' => 'customTokenSet#export', 'url' => '/settings/tokensets/custom/{id}/export', 'verb' => 'GET'],
 		['name' => 'customTokenSet#delete', 'url' => '/settings/tokensets/custom/{id}', 'verb' => 'DELETE'],
+		// Email template theming — admin toggle + compliance footer config.
+		['name' => 'settings#getEmailTheming', 'url' => '/settings/email-theming', 'verb' => 'GET'],
+		['name' => 'settings#setEmailTheming', 'url' => '/settings/email-theming', 'verb' => 'POST'],
 	],
 ];

--- a/js/admin.js
+++ b/js/admin.js
@@ -1539,5 +1539,143 @@ function nldesignAdminMain() {
 	// Initialise the custom token set panel on page load.
 	initCustomTokenSets();
 
+	/* ==========================================================================
+	 * EMAIL TEMPLATE THEMING — mail_template_class toggle + compliance footer
+	 * ========================================================================== */
+
+	// Re-render the panel from a { state, footer } payload (shared by the
+	// initial GET and every subsequent POST response).
+	function renderEmailTheming(state, footer) {
+		var root = document.getElementById('nldesign-email-theming');
+		var checkbox = document.getElementById('nldesign-email-theming-enabled');
+		var occHint = document.getElementById('nldesign-email-occ-hint');
+		if (root === null || checkbox === null) {
+			return;
+		}
+
+		if (state) {
+			root.setAttribute('data-state', state.state || 'disabled');
+			root.setAttribute('data-config-read-only', state.configReadOnly ? '1' : '0');
+			root.setAttribute('data-foreign-class', state.foreignClass || '');
+			checkbox.checked = state.state === 'enabled';
+			checkbox.disabled = state.state === 'foreign';
+		}
+
+		if (footer) {
+			var orgInput = document.getElementById('nldesign-email-footer-org-name');
+			var a11yInput = document.getElementById('nldesign-email-footer-accessibility-url');
+			var privacyInput = document.getElementById('nldesign-email-footer-privacy-url');
+			if (orgInput !== null) { orgInput.value = footer.orgName || ''; }
+			if (a11yInput !== null) { a11yInput.value = footer.accessibilityUrl || ''; }
+			if (privacyInput !== null) { privacyInput.value = footer.privacyUrl || ''; }
+		}
+
+		if (occHint !== null) {
+			occHint.style.display = 'none';
+		}
+	}
+
+	function initEmailTheming() {
+		var root = document.getElementById('nldesign-email-theming');
+		var saveBtn = document.getElementById('nldesign-email-theming-save');
+		if (root === null || saveBtn === null) {
+			return;
+		}
+
+		fetch(OC.generateUrl('/apps/nldesign/settings/email-theming'), {
+			headers: { 'requesttoken': OC.requestToken }
+		})
+		.then(function(r) { return r.json(); })
+		.then(function(data) {
+			renderEmailTheming(data && data.state, data && data.footer);
+		})
+		.catch(function(err) {
+			console.error('Error loading email theming:', err);
+		});
+
+		saveBtn.addEventListener('click', saveEmailTheming);
+	}
+
+	function saveEmailTheming() {
+		var checkbox = document.getElementById('nldesign-email-theming-enabled');
+		var orgInput = document.getElementById('nldesign-email-footer-org-name');
+		var a11yInput = document.getElementById('nldesign-email-footer-accessibility-url');
+		var privacyInput = document.getElementById('nldesign-email-footer-privacy-url');
+		var feedback = document.getElementById('nldesign-email-theming-feedback');
+		var occHint = document.getElementById('nldesign-email-occ-hint');
+		var foreignNote = document.querySelector('.nldesign-email-foreign-note');
+		if (checkbox === null) {
+			return;
+		}
+
+		var payload = {
+			enabled: checkbox.checked,
+			orgName: orgInput !== null ? orgInput.value : '',
+			accessibilityUrl: a11yInput !== null ? a11yInput.value : '',
+			privacyUrl: privacyInput !== null ? privacyInput.value : ''
+		};
+
+		fetch(OC.generateUrl('/apps/nldesign/settings/email-theming'), {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'requesttoken': OC.requestToken
+			},
+			body: JSON.stringify(payload)
+		})
+		.then(function(r) { return r.json().then(function(data) { return { ok: r.ok, data: data }; }); })
+		.then(function(result) {
+			var data = result.data;
+
+			if (result.ok === true && data && data.status === 'ok') {
+				renderEmailTheming(data.state, data.footer);
+				if (feedback !== null) {
+					feedback.textContent = t('nldesign', 'Email template settings saved.');
+				}
+				OC.Notification.showTemporary(t('nldesign', 'Email template settings saved.'));
+				return;
+			}
+
+			if (data && data.error === 'config_read_only') {
+				checkbox.checked = false;
+				renderEmailTheming(null, data.footer);
+				if (occHint !== null) {
+					occHint.style.display = '';
+					var enableCode = document.getElementById('nldesign-email-occ-enable');
+					var disableCode = document.getElementById('nldesign-email-occ-disable');
+					if (enableCode !== null && data.occEnable) { enableCode.textContent = data.occEnable; }
+					if (disableCode !== null && data.occDisable) { disableCode.textContent = data.occDisable; }
+				}
+				OC.Notification.showTemporary(t('nldesign', 'config.php is read-only; run the shown occ command manually.'));
+				return;
+			}
+
+			if (data && data.error === 'foreign_mail_template_class') {
+				checkbox.checked = false;
+				checkbox.disabled = true;
+				renderEmailTheming(null, data.footer);
+				if (foreignNote !== null) {
+					foreignNote.textContent = t('nldesign', 'A different mail template class is already configured ({class}); nldesign will not overwrite it.', { class: data.class });
+				}
+				OC.Notification.showTemporary(t('nldesign', 'A different mail template class is already configured.'));
+				return;
+			}
+
+			if (data && data.error === 'invalid_footer') {
+				OC.Notification.showTemporary(t('nldesign', 'Invalid footer URL — use an http:// or https:// address.'));
+				return;
+			}
+
+			OC.Notification.showTemporary(t('nldesign', 'Failed to save email template settings.'));
+		})
+		.catch(function(err) {
+			console.error('Error saving email theming:', err);
+			OC.Notification.showTemporary(t('nldesign', 'Failed to save email template settings.'));
+		});
+	}
+
+	// Initialise the email theming panel on page load.
+	initEmailTheming();
+
 }
 })();

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -94,7 +94,23 @@
         "{themed} of {total} apps themed": "{themed} of {total} apps themed",
         "Search apps": "Search apps",
         "Search apps…": "Search apps…",
-        "Reset {label} to default": "Reset {label} to default"
+        "Reset {label} to default": "Reset {label} to default",
+        "Email template": "Email template",
+        "Brand password-reset, share-notification, and other system emails with the active token set's color and logo. If nldesign is later disabled, Nextcloud automatically falls back to the stock email template — mail is never blocked by this setting.": "Brand password-reset, share-notification, and other system emails with the active token set's color and logo. If nldesign is later disabled, Nextcloud automatically falls back to the stock email template — mail is never blocked by this setting.",
+        "A different mail template class is already configured ({class}); nldesign will not overwrite it.": "A different mail template class is already configured ({class}); nldesign will not overwrite it.",
+        "Use NL Design email template": "Use NL Design email template",
+        "Organization name": "Organization name",
+        "Accessibility statement URL": "Accessibility statement URL",
+        "Privacy statement URL": "Privacy statement URL",
+        "Save email template settings": "Save email template settings",
+        "config.php is read-only. Run one of the following commands manually to enable or disable the email template:": "config.php is read-only. Run one of the following commands manually to enable or disable the email template:",
+        "Email template settings saved.": "Email template settings saved.",
+        "config.php is read-only; run the shown occ command manually.": "config.php is read-only; run the shown occ command manually.",
+        "A different mail template class is already configured.": "A different mail template class is already configured.",
+        "Invalid footer URL — use an http:// or https:// address.": "Invalid footer URL — use an http:// or https:// address.",
+        "Failed to save email template settings.": "Failed to save email template settings.",
+        "Accessibility statement": "Accessibility statement",
+        "Privacy statement": "Privacy statement"
     },
     "plurals": {}
 }

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -94,7 +94,23 @@
         "{themed} of {total} apps themed": "{themed} of {total} apps themed",
         "Search apps": "Search apps",
         "Search apps…": "Search apps…",
-        "Reset {label} to default": "Reset {label} to default"
+        "Reset {label} to default": "Reset {label} to default",
+        "Email template": "E-mailsjabloon",
+        "Brand password-reset, share-notification, and other system emails with the active token set's color and logo. If nldesign is later disabled, Nextcloud automatically falls back to the stock email template — mail is never blocked by this setting.": "Voorzie wachtwoord-reset, deelmeldingen en andere systeem-e-mails van de kleur en het logo van de actieve tokenset. Als nldesign later wordt uitgeschakeld, valt Nextcloud automatisch terug op het standaard e-mailsjabloon — e-mail wordt door deze instelling nooit geblokkeerd.",
+        "A different mail template class is already configured ({class}); nldesign will not overwrite it.": "Er is al een andere e-mailsjabloonklasse geconfigureerd ({class}); nldesign overschrijft deze niet.",
+        "Use NL Design email template": "NL Design e-mailsjabloon gebruiken",
+        "Organization name": "Organisatienaam",
+        "Accessibility statement URL": "URL toegankelijkheidsverklaring",
+        "Privacy statement URL": "URL privacyverklaring",
+        "Save email template settings": "E-mailsjabloon-instellingen opslaan",
+        "config.php is read-only. Run one of the following commands manually to enable or disable the email template:": "config.php is alleen-lezen. Voer een van de volgende commando's handmatig uit om het e-mailsjabloon in of uit te schakelen:",
+        "Email template settings saved.": "E-mailsjabloon-instellingen opgeslagen.",
+        "config.php is read-only; run the shown occ command manually.": "config.php is alleen-lezen; voer het getoonde occ-commando handmatig uit.",
+        "A different mail template class is already configured.": "Er is al een andere e-mailsjabloonklasse geconfigureerd.",
+        "Invalid footer URL — use an http:// or https:// address.": "Ongeldige URL in de voettekst — gebruik een http:// of https://-adres.",
+        "Failed to save email template settings.": "Opslaan van e-mailsjabloon-instellingen mislukt.",
+        "Accessibility statement": "Toegankelijkheidsverklaring",
+        "Privacy statement": "Privacyverklaring"
     },
     "plurals": {}
 }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -33,6 +33,10 @@ namespace OCA\NLDesign\Controller;
 
 use OCA\NLDesign\AppInfo\Application;
 use OCA\NLDesign\Service\AppThemingService;
+use OCA\NLDesign\Service\EmailThemingService;
+use OCA\NLDesign\Service\Exception\ConfigReadOnlyException;
+use OCA\NLDesign\Service\Exception\FooterValidationException;
+use OCA\NLDesign\Service\Exception\ForeignMailTemplateClassException;
 use OCA\NLDesign\Service\ThemingService;
 use OCA\NLDesign\Service\TokenSetPreviewService;
 use OCA\NLDesign\Service\TokenSetService;
@@ -101,15 +105,23 @@ class SettingsController extends Controller
     private AppThemingService $appThemingService;
 
     /**
+     * The email theming service.
+     *
+     * @var EmailThemingService
+     */
+    private EmailThemingService $emailThemingService;
+
+    /**
      * Constructor.
      *
-     * @param string                 $appName           The app name.
-     * @param IRequest               $request           The request object.
-     * @param IConfig                $config            The config service.
-     * @param TokenSetService        $tokenSetService   The token set service.
-     * @param ThemingService         $themingService    The theming service.
-     * @param TokenSetPreviewService $previewService    The token set preview service.
-     * @param AppThemingService      $appThemingService The per-app theming service.
+     * @param string                 $appName             The app name.
+     * @param IRequest               $request             The request object.
+     * @param IConfig                $config              The config service.
+     * @param TokenSetService        $tokenSetService     The token set service.
+     * @param ThemingService         $themingService      The theming service.
+     * @param TokenSetPreviewService $previewService      The token set preview service.
+     * @param AppThemingService      $appThemingService   The per-app theming service.
+     * @param EmailThemingService    $emailThemingService The email theming service.
      */
     public function __construct(
         string $appName,
@@ -118,7 +130,8 @@ class SettingsController extends Controller
         TokenSetService $tokenSetService,
         ThemingService $themingService,
         TokenSetPreviewService $previewService,
-        AppThemingService $appThemingService
+        AppThemingService $appThemingService,
+        EmailThemingService $emailThemingService
     ) {
         parent::__construct(appName: $appName, request: $request);
         $this->config            = $config;
@@ -126,6 +139,7 @@ class SettingsController extends Controller
         $this->themingService    = $themingService;
         $this->previewService    = $previewService;
         $this->appThemingService = $appThemingService;
+        $this->emailThemingService = $emailThemingService;
     }//end __construct()
 
     /**
@@ -369,4 +383,99 @@ class SettingsController extends Controller
             ]
         );
     }//end setAppTheming()
+
+    /**
+     * Get the email template toggle state and compliance footer config.
+     *
+     * @return JSONResponse The state, footer config, and manual occ commands.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    #[AuthorizedAdminSetting(Admin::class)]
+    public function getEmailTheming(): JSONResponse
+    {
+        return new JSONResponse(
+            [
+                'state'      => $this->emailThemingService->getState(),
+                'footer'     => $this->emailThemingService->getFooterConfig(),
+                'occEnable'  => EmailThemingService::OCC_ENABLE_COMMAND,
+                'occDisable' => EmailThemingService::OCC_DISABLE_COMMAND,
+            ]
+        );
+    }//end getEmailTheming()
+
+    /**
+     * Save the compliance footer config and toggle the email template.
+     *
+     * The footer config is always applied first (app config, always
+     * writable) and independently reported, so it saves successfully even
+     * when the system-config toggle write fails (read-only config.php or a
+     * foreign `mail_template_class`).
+     *
+     * @param bool   $enabled          Whether the branded template should be enabled.
+     * @param string $orgName          The organization name.
+     * @param string $accessibilityUrl The toegankelijkheidsverklaring URL.
+     * @param string $privacyUrl       The privacy statement URL.
+     *
+     * @return JSONResponse The result, or a structured 409/422 error.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    #[AuthorizedAdminSetting(Admin::class)]
+    public function setEmailTheming(
+        bool $enabled,
+        string $orgName='',
+        string $accessibilityUrl='',
+        string $privacyUrl=''
+    ): JSONResponse {
+        try {
+            $this->emailThemingService->setFooterConfig($orgName, $accessibilityUrl, $privacyUrl);
+        } catch (FooterValidationException $e) {
+            return new JSONResponse(
+                [
+                    'error'   => 'invalid_footer',
+                    'field'   => $e->getField(),
+                    'message' => $e->getMessage(),
+                ],
+                422
+            );
+        }
+
+        try {
+            if ($enabled === true) {
+                $this->emailThemingService->enable();
+            }
+
+            if ($enabled === false) {
+                $this->emailThemingService->disable();
+            }
+        } catch (ConfigReadOnlyException $e) {
+            return new JSONResponse(
+                [
+                    'error'      => 'config_read_only',
+                    'occEnable'  => $e->getOccEnableCommand(),
+                    'occDisable' => $e->getOccDisableCommand(),
+                    'footer'     => $this->emailThemingService->getFooterConfig(),
+                ],
+                409
+            );
+        } catch (ForeignMailTemplateClassException $e) {
+            return new JSONResponse(
+                [
+                    'error'  => 'foreign_mail_template_class',
+                    'class'  => $e->getForeignClass(),
+                    'footer' => $this->emailThemingService->getFooterConfig(),
+                ],
+                409
+            );
+        }//end try
+
+        return new JSONResponse(
+            [
+                'status' => 'ok',
+                'state'  => $this->emailThemingService->getState(),
+                'footer' => $this->emailThemingService->getFooterConfig(),
+            ]
+        );
+    }//end setEmailTheming()
 }//end class

--- a/lib/Mail/NLDesignEMailTemplate.php
+++ b/lib/Mail/NLDesignEMailTemplate.php
@@ -1,0 +1,430 @@
+<?php
+
+/**
+ * NL Design Email Template.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Mail
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/nldesign
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Mail;
+
+use OC\Mail\EMailTemplate;
+use OCA\NLDesign\Service\EmailThemingService;
+
+/**
+ * Branded email template — extends the server's private EMailTemplate.
+ *
+ * Registered via the `mail_template_class` system config, read by
+ * `OC\Mail\Mailer::makeTemplate()` (server checkout, `lib/private/Mail/Mailer.php`),
+ * which is the platform's own sanctioned hook for deep mail branding: it
+ * instantiates any class satisfying `is_a($class, \OC\Mail\EMailTemplate::class,
+ * true)` and falls back to the stock template whenever the configured class
+ * does not exist (app disabled, manifest missing) — extending the
+ * private-namespace parent is therefore not a hack, it is the mechanism the
+ * server provides and guards.
+ *
+ * The server constructs this class with a FIXED argument list (Defaults,
+ * IURLGenerator, l10n IFactory, logo dimensions, emailId, data) — the
+ * constructor is intentionally left untouched (inherited as-is). All
+ * nldesign service resolution happens lazily inside the render methods, and
+ * every resolution is wrapped so ANY failure (nldesign disabled mid-request,
+ * unreadable manifest, DI failure) degrades to the parent's stock rendering
+ * — a theming failure must never prevent an email from being built or sent.
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+class NLDesignEMailTemplate extends EMailTemplate
+{
+    /**
+     * Lazily resolve the email theming service.
+     *
+     * Returns null on ANY failure so callers fall back to stock rendering.
+     * This resolver gates presentation fallback only (branded vs. stock mail
+     * markup) — it is never used for an authorization decision, so it is not
+     * subject to the unsafe-auth-resolver concern (a null return here can
+     * never widen access; at most it removes branding).
+     *
+     * Protected (not private) so unit tests can override this single seam to
+     * inject a stubbed EmailThemingService, instead of touching the live
+     * \OCP\Server container that the server calls this constructor from.
+     *
+     * @return EmailThemingService|null The service, or null on any failure.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    protected function getEmailThemingService(): ?EmailThemingService
+    {
+        try {
+            $service = \OCP\Server::get(EmailThemingService::class);
+            if ($service instanceof EmailThemingService === false) {
+                return null;
+            }
+
+            return $service;
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end getEmailThemingService()
+
+    /**
+     * Resolve the active token set's email theme, or null if unavailable.
+     *
+     * @return array{primaryColor: string, primaryTextColor: string, logoUrl: ?string}|null
+     *         The resolved theme, or null when no service/active theme is available.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function resolveTheme(): ?array
+    {
+        $service = $this->getEmailThemingService();
+        if ($service === null) {
+            return null;
+        }
+
+        try {
+            return $service->getActiveEmailTheme();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end resolveTheme()
+
+    /**
+     * Resolve the configured compliance footer, or null if unavailable.
+     *
+     * @return array{orgName: string, accessibilityUrl: string, privacyUrl: string}|null
+     *         The footer config, or null when no service is available.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function resolveFooterConfig(): ?array
+    {
+        $service = $this->getEmailThemingService();
+        if ($service === null) {
+            return null;
+        }
+
+        try {
+            return $service->getFooterConfig();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end resolveFooterConfig()
+
+    /**
+     * Whether a resolved footer config has at least one non-empty value.
+     *
+     * @param array{orgName: string, accessibilityUrl: string, privacyUrl: string} $footerConfig The footer config.
+     *
+     * @return bool True when at least one field is non-empty.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function hasFooterValues(array $footerConfig): bool
+    {
+        return ($footerConfig['orgName'] ?? '') !== ''
+            || ($footerConfig['accessibilityUrl'] ?? '') !== ''
+            || ($footerConfig['privacyUrl'] ?? '') !== '';
+    }//end hasFooterValues()
+
+    /**
+     * Adds a header to the email.
+     *
+     * Branded with the active token set's primary color and logo when
+     * available; falls back to the parent's stock header (theme colors)
+     * otherwise.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function addHeader(): void
+    {
+        if ($this->headerAdded === true) {
+            return;
+        }
+
+        $theme = $this->resolveTheme();
+        if ($theme === null) {
+            parent::addHeader();
+            return;
+        }
+
+        $this->headerAdded = true;
+
+        $logoSizeDimensions = '';
+        if ($this->logoWidth !== null && $this->logoHeight !== null) {
+            // Provide a logo size when we have the dimensions so it displays
+            // nicely in Outlook — mirrors the parent's behaviour exactly.
+            $logoSizeDimensions = ' width="'.$this->logoWidth.'" height="'.$this->logoHeight.'"';
+        }
+
+        $logoUrl = $theme['logoUrl'] ?? null;
+        if ($logoUrl === null || $logoUrl === '') {
+            $logoUrl = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo(false));
+        }
+
+        $this->htmlBody .= vsprintf(
+            $this->header,
+            [
+                $theme['primaryColor'],
+                $logoUrl,
+                $this->themingDefaults->getName(),
+                $logoSizeDimensions,
+            ]
+        );
+    }//end addHeader()
+
+    /**
+     * Adds a button to the body of the email.
+     *
+     * Branded with the active token set's primary color/text color when
+     * available; falls back to the parent's stock button otherwise. Reuses
+     * the parent's `$button` HEREDOC markup unchanged — only the substituted
+     * color values change.
+     *
+     * @param string       $text      Text of button (HTML-escaped unless $plainText given).
+     * @param string       $url       URL of button.
+     * @param string|false $plainText Text of button in plain text version, or false to omit.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function addBodyButton(string $text, string $url, $plainText=''): void
+    {
+        $theme = $this->resolveTheme();
+        if ($theme === null) {
+            parent::addBodyButton(text: $text, url: $url, plainText: $plainText);
+            return;
+        }
+
+        if ($this->footerAdded === true) {
+            return;
+        }
+
+        $this->ensureBodyIsOpened();
+        $this->ensureBodyListClosed();
+
+        if ($plainText === '') {
+            $plainText = $text;
+            $text      = htmlspecialchars($text);
+        }
+
+        $color           = $theme['primaryColor'];
+        $textColor       = $theme['primaryTextColor'];
+        $this->htmlBody .= vsprintf($this->button, [$color, $color, $url, $color, $textColor, $textColor, $text]);
+
+        if ($plainText !== false) {
+            $this->plainBody .= $plainText.': ';
+        }
+
+        $this->plainBody .= $url.PHP_EOL;
+    }//end addBodyButton()
+
+    /**
+     * Adds a button group of two buttons to the body of the email.
+     *
+     * Branded analogously to addBodyButton() — the primary (left) button
+     * uses the token set's color/text color; the secondary (right) button
+     * keeps the parent's neutral styling.
+     *
+     * @param string $textLeft       Text of left button.
+     * @param string $urlLeft        URL of left button.
+     * @param string $textRight      Text of right button.
+     * @param string $urlRight       URL of right button.
+     * @param string $plainTextLeft  Plain-text override for the left button.
+     * @param string $plainTextRight Plain-text override for the right button.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function addBodyButtonGroup(
+        string $textLeft,
+        string $urlLeft,
+        string $textRight,
+        string $urlRight,
+        string $plainTextLeft='',
+        string $plainTextRight=''
+    ): void {
+        $theme = $this->resolveTheme();
+        if ($theme === null) {
+            parent::addBodyButtonGroup(
+                textLeft: $textLeft,
+                urlLeft: $urlLeft,
+                textRight: $textRight,
+                urlRight: $urlRight,
+                plainTextLeft: $plainTextLeft,
+                plainTextRight: $plainTextRight
+            );
+            return;
+        }
+
+        if ($this->footerAdded === true) {
+            return;
+        }
+
+        if ($plainTextLeft === '') {
+            $plainTextLeft = $textLeft;
+            $textLeft      = htmlspecialchars($textLeft);
+        }
+
+        if ($plainTextRight === '') {
+            $plainTextRight = $textRight;
+            $textRight      = htmlspecialchars($textRight);
+        }
+
+        $this->ensureBodyIsOpened();
+        $this->ensureBodyListClosed();
+
+        $color     = $theme['primaryColor'];
+        $textColor = $theme['primaryTextColor'];
+
+        $this->htmlBody  .= vsprintf(
+            $this->buttonGroup,
+            [$color, $color, $urlLeft, $color, $textColor, $textColor, $textLeft, $urlRight, $textRight]
+        );
+        $this->plainBody .= PHP_EOL.$plainTextLeft.': '.$urlLeft.PHP_EOL;
+        $this->plainBody .= $plainTextRight.': '.$urlRight.PHP_EOL.PHP_EOL;
+    }//end addBodyButtonGroup()
+
+    /**
+     * Adds a logo and text to the footer, then appends the configured
+     * compliance block (organization name, accessibility statement link,
+     * privacy statement link) when at least one value is configured.
+     *
+     * Always calls the parent implementation first — when no footer values
+     * are configured (or the service is unavailable), the output is
+     * byte-identical to stock. When values ARE configured, the compliance
+     * block is spliced in BEFORE the parent's closing `$tail` (which closes
+     * `</body></html>`), so the appended markup stays inside a valid HTML
+     * document instead of trailing after the closing tag.
+     *
+     * @param string      $text The footer text override (parent semantics unchanged).
+     * @param string|null $lang The language override (parent semantics unchanged).
+     *
+     * @return void
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function addFooter(string $text='', ?string $lang=null): void
+    {
+        if ($this->footerAdded === true) {
+            return;
+        }
+
+        parent::addFooter(text: $text, lang: $lang);
+
+        $footerConfig = $this->resolveFooterConfig();
+        if ($footerConfig === null || $this->hasFooterValues(footerConfig: $footerConfig) === false) {
+            return;
+        }
+
+        $complianceHtml = $this->renderComplianceFooterHtml(footerConfig: $footerConfig, lang: $lang);
+        $tailFound      = str_ends_with($this->htmlBody, $this->tail);
+        if ($tailFound === true) {
+            $this->htmlBody = substr($this->htmlBody, 0, -strlen($this->tail)).$complianceHtml.$this->tail;
+        }
+
+        if ($tailFound === false) {
+            // Defensive: parent's tail marker not found verbatim (should not
+            // happen given the current server implementation) — append
+            // rather than silently drop the compliance block.
+            $this->htmlBody .= $complianceHtml;
+        }
+
+        $this->plainBody .= $this->renderComplianceFooterPlain(footerConfig: $footerConfig, lang: $lang);
+    }//end addFooter()
+
+    /**
+     * Render the compliance footer block as HTML, output-encoded.
+     *
+     * @param array{orgName: string, accessibilityUrl: string, privacyUrl: string} $footerConfig The footer config.
+     * @param string|null                                                          $lang         The language override.
+     *
+     * @return string The HTML block (a standalone table, valid inside `<body>`).
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function renderComplianceFooterHtml(array $footerConfig, ?string $lang): string
+    {
+        $l10n = $this->l10nFactory->get('nldesign', $lang);
+
+        $lines = [];
+        if ($footerConfig['orgName'] !== '') {
+            $lines[] = htmlspecialchars($footerConfig['orgName']);
+        }
+
+        if ($footerConfig['accessibilityUrl'] !== '') {
+            $lines[] = '<a href="'.htmlspecialchars($footerConfig['accessibilityUrl']).'" style="color:#C8C8C8;text-decoration:underline">'
+                .htmlspecialchars($l10n->t('Accessibility statement')).'</a>';
+        }
+
+        if ($footerConfig['privacyUrl'] !== '') {
+            $lines[] = '<a href="'.htmlspecialchars($footerConfig['privacyUrl']).'" style="color:#C8C8C8;text-decoration:underline">'
+                .htmlspecialchars($l10n->t('Privacy statement')).'</a>';
+        }
+
+        if (empty($lines) === true) {
+            return '';
+        }
+
+        $paragraphs = '';
+        foreach ($lines as $line) {
+            $paragraphs .= '<p class="text-center float-center" align="center" style="Margin:0;Margin-bottom:4px;'
+                .'color:#C8C8C8;font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Roboto,Oxygen-Sans,Ubuntu,'
+                .'Cantarell,\'Helvetica Neue\',Arial,sans-serif;font-size:12px;font-weight:400;line-height:16px;'
+                .'margin:0;margin-bottom:4px;padding:0;text-align:center">'.$line.'</p>';
+        }
+
+        return '<table align="center" class="wrapper footer float-center nldesign-compliance-footer" '
+            .'style="Margin:0 auto;border-collapse:collapse;border-spacing:0;float:none;margin:0 auto;padding:0;'
+            .'text-align:center;vertical-align:top;width:100%">'
+            .'<tr style="padding:0;text-align:left;vertical-align:top">'
+            .'<td class="wrapper-inner" style="Margin:0;padding:0;text-align:left;vertical-align:top">'
+            .'<center data-parsed="" style="min-width:580px;width:100%">'.$paragraphs.'</center>'
+            .'</td></tr></table>';
+    }//end renderComplianceFooterHtml()
+
+    /**
+     * Render the compliance footer block as plain text lines.
+     *
+     * @param array{orgName: string, accessibilityUrl: string, privacyUrl: string} $footerConfig The footer config.
+     * @param string|null                                                          $lang         The language override.
+     *
+     * @return string The plain-text lines, each terminated with PHP_EOL.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function renderComplianceFooterPlain(array $footerConfig, ?string $lang): string
+    {
+        $l10n = $this->l10nFactory->get('nldesign', $lang);
+
+        $plain = '';
+        if ($footerConfig['orgName'] !== '') {
+            $plain .= $footerConfig['orgName'].PHP_EOL;
+        }
+
+        if ($footerConfig['accessibilityUrl'] !== '') {
+            $plain .= $l10n->t('Accessibility statement').': '.$footerConfig['accessibilityUrl'].PHP_EOL;
+        }
+
+        if ($footerConfig['privacyUrl'] !== '') {
+            $plain .= $l10n->t('Privacy statement').': '.$footerConfig['privacyUrl'].PHP_EOL;
+        }
+
+        return $plain;
+    }//end renderComplianceFooterPlain()
+}//end class

--- a/lib/Service/EmailThemingService.php
+++ b/lib/Service/EmailThemingService.php
@@ -1,0 +1,446 @@
+<?php
+
+/**
+ * NL Design Email Theming Service.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/nldesign
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Service;
+
+use OCA\NLDesign\AppInfo\Application;
+use OCA\NLDesign\Mail\NLDesignEMailTemplate;
+use OCA\NLDesign\Service\Exception\ConfigReadOnlyException;
+use OCA\NLDesign\Service\Exception\FooterValidationException;
+use OCA\NLDesign\Service\Exception\ForeignMailTemplateClassException;
+use OCP\HintException;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+
+/**
+ * Reads/writes the email-theming compliance footer, reports and toggles the
+ * `mail_template_class` system config, and resolves the active token set's
+ * email theme (primary color, primary text color, absolute logo URL).
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+class EmailThemingService
+{
+
+    /**
+     * The system config key the server's Mailer reads to select the template class.
+     *
+     * @var string
+     */
+    public const MAIL_TEMPLATE_CLASS_KEY = 'mail_template_class';
+
+    /**
+     * The occ command to enable the branded template manually.
+     *
+     * @var string
+     */
+    public const OCC_ENABLE_COMMAND = 'occ config:system:set mail_template_class --value "OCA\\NLDesign\\Mail\\NLDesignEMailTemplate"';
+
+    /**
+     * The occ command to disable the branded template manually.
+     *
+     * @var string
+     */
+    public const OCC_DISABLE_COMMAND = 'occ config:system:delete mail_template_class';
+
+    /**
+     * The appconfig key for the compliance footer organization name.
+     *
+     * @var string
+     */
+    private const FOOTER_ORG_NAME_KEY = 'email_footer_org_name';
+
+    /**
+     * The appconfig key for the compliance footer accessibility statement URL.
+     *
+     * @var string
+     */
+    private const FOOTER_ACCESSIBILITY_URL_KEY = 'email_footer_accessibility_url';
+
+    /**
+     * The appconfig key for the compliance footer privacy statement URL.
+     *
+     * @var string
+     */
+    private const FOOTER_PRIVACY_URL_KEY = 'email_footer_privacy_url';
+
+    /**
+     * The maximum stored length for a footer value.
+     *
+     * @var int
+     */
+    private const MAX_FOOTER_VALUE_LENGTH = 2048;
+
+    /**
+     * The application configuration service.
+     *
+     * @var IConfig
+     */
+    private IConfig $config;
+
+    /**
+     * The token set service, used to read shipped theming metadata.
+     *
+     * @var TokenSetService
+     */
+    private TokenSetService $tokenSetService;
+
+    /**
+     * The token set preview service, used as the resolved-color fallback.
+     *
+     * @var TokenSetPreviewService
+     */
+    private TokenSetPreviewService $previewService;
+
+    /**
+     * The URL generator, used to build the absolute logo URL.
+     *
+     * @var IURLGenerator
+     */
+    private IURLGenerator $urlGenerator;
+
+    /**
+     * Constructor.
+     *
+     * @param IConfig                $config          The config service.
+     * @param TokenSetService        $tokenSetService The token set service.
+     * @param TokenSetPreviewService $previewService  The token set preview service.
+     * @param IURLGenerator          $urlGenerator    The URL generator.
+     */
+    public function __construct(
+        IConfig $config,
+        TokenSetService $tokenSetService,
+        TokenSetPreviewService $previewService,
+        IURLGenerator $urlGenerator
+    ) {
+        $this->config          = $config;
+        $this->tokenSetService = $tokenSetService;
+        $this->previewService  = $previewService;
+        $this->urlGenerator    = $urlGenerator;
+    }//end __construct()
+
+    /**
+     * Get the configured compliance footer values.
+     *
+     * @return array{orgName: string, accessibilityUrl: string, privacyUrl: string} The footer config.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function getFooterConfig(): array
+    {
+        return [
+            'orgName'          => $this->config->getAppValue(Application::APP_ID, self::FOOTER_ORG_NAME_KEY, ''),
+            'accessibilityUrl' => $this->config->getAppValue(Application::APP_ID, self::FOOTER_ACCESSIBILITY_URL_KEY, ''),
+            'privacyUrl'       => $this->config->getAppValue(Application::APP_ID, self::FOOTER_PRIVACY_URL_KEY, ''),
+        ];
+    }//end getFooterConfig()
+
+    /**
+     * Set the compliance footer values.
+     *
+     * Empty values are accepted (omit that line). Non-empty URL values MUST
+     * use the `http://` or `https://` scheme and stay within the maximum
+     * stored length; anything else (including `javascript:` and non-URL
+     * junk) throws before anything is persisted.
+     *
+     * @param string $orgName          The organization name.
+     * @param string $accessibilityUrl The toegankelijkheidsverklaring URL.
+     * @param string $privacyUrl       The privacy statement URL.
+     *
+     * @return array{orgName: string, accessibilityUrl: string, privacyUrl: string} The persisted footer config.
+     *
+     * @throws FooterValidationException When a value fails validation.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function setFooterConfig(string $orgName, string $accessibilityUrl, string $privacyUrl): array
+    {
+        if (strlen($orgName) > self::MAX_FOOTER_VALUE_LENGTH) {
+            throw new FooterValidationException(field: 'orgName', message: 'Organization name exceeds the maximum length.');
+        }
+
+        $this->validateUrl(field: 'accessibilityUrl', url: $accessibilityUrl);
+        $this->validateUrl(field: 'privacyUrl', url: $privacyUrl);
+
+        $this->config->setAppValue(Application::APP_ID, self::FOOTER_ORG_NAME_KEY, $orgName);
+        $this->config->setAppValue(Application::APP_ID, self::FOOTER_ACCESSIBILITY_URL_KEY, $accessibilityUrl);
+        $this->config->setAppValue(Application::APP_ID, self::FOOTER_PRIVACY_URL_KEY, $privacyUrl);
+
+        return $this->getFooterConfig();
+    }//end setFooterConfig()
+
+    /**
+     * Validate a footer URL value. Empty values are always valid (omitted).
+     *
+     * @param string $field The field name, for the exception.
+     * @param string $url   The URL value.
+     *
+     * @return void
+     *
+     * @throws FooterValidationException When the value is non-empty and invalid.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function validateUrl(string $field, string $url): void
+    {
+        if ($url === '') {
+            return;
+        }
+
+        if (strlen($url) > self::MAX_FOOTER_VALUE_LENGTH) {
+            throw new FooterValidationException(field: $field, message: 'URL exceeds the maximum length.');
+        }
+
+        if (preg_match('#^https?://#i', $url) !== 1) {
+            throw new FooterValidationException(field: $field, message: 'URL must use the http:// or https:// scheme.');
+        }
+    }//end validateUrl()
+
+    /**
+     * Resolve the active token set's email theme.
+     *
+     * Reads `theming.primary_color` / `theming.logo` from the token set's
+     * `token-sets.json` metadata first; falls back to
+     * `TokenSetPreviewService::getResolvedColors()` for a set without
+     * explicit theming metadata. Returns null when the active set is
+     * `nextcloud` (stock, unthemed) or unresolvable.
+     *
+     * @return array{primaryColor: string, primaryTextColor: string, logoUrl: ?string}|null
+     *         The resolved theme, or null when there is no active theme.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function getActiveEmailTheme(): ?array
+    {
+        $tokenSetId = $this->config->getAppValue(Application::APP_ID, 'token_set', 'nextcloud');
+        if ($tokenSetId === '' || $tokenSetId === 'nextcloud') {
+            return null;
+        }
+
+        $entry = $this->findTokenSetEntry(tokenSetId: $tokenSetId);
+        if ($entry === null) {
+            return null;
+        }
+
+        $theming = [];
+        if (is_array($entry['theming'] ?? null) === true) {
+            $theming = $entry['theming'];
+        }
+
+        $colors = $this->resolveThemeColors(theming: $theming, tokenSetId: $tokenSetId);
+        if ($colors === null) {
+            return null;
+        }
+
+        return [
+            'primaryColor'     => $colors['primaryColor'],
+            'primaryTextColor' => $colors['primaryTextColor'],
+            'logoUrl'          => $this->resolveLogoUrl(logoPath: ($theming['logo'] ?? null)),
+        ];
+    }//end getActiveEmailTheme()
+
+    /**
+     * Resolve the primary color / primary text color for a token set,
+     * falling back to `TokenSetPreviewService::getResolvedColors()` for any
+     * value not present in the manifest `theming` metadata.
+     *
+     * @param array<string, mixed> $theming    The manifest `theming` block (possibly empty).
+     * @param string               $tokenSetId The active token set identifier.
+     *
+     * @return array{primaryColor: string, primaryTextColor: string}|null
+     *         The resolved colors, or null when no primary color can be resolved at all.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function resolveThemeColors(array $theming, string $tokenSetId): ?array
+    {
+        $primaryColor     = $theming['primary_color'] ?? null;
+        $primaryTextColor = $theming['primary_text_color'] ?? null;
+
+        if ($primaryColor === null || $primaryTextColor === null) {
+            $resolved         = $this->previewService->getResolvedColors(tokenSetId: $tokenSetId);
+            $primaryColor     = $primaryColor ?? ($resolved['--color-primary'] ?? null);
+            $primaryTextColor = $primaryTextColor ?? ($resolved['--color-primary-text'] ?? null);
+        }
+
+        if ($primaryColor === null) {
+            return null;
+        }
+
+        return [
+            'primaryColor'     => $primaryColor,
+            'primaryTextColor' => ($primaryTextColor ?? '#ffffff'),
+        ];
+    }//end resolveThemeColors()
+
+    /**
+     * Find a token set's metadata entry by id.
+     *
+     * @param string $tokenSetId The token set identifier.
+     *
+     * @return array<string, mixed>|null The entry, or null when not found.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function findTokenSetEntry(string $tokenSetId): ?array
+    {
+        foreach ($this->tokenSetService->getAvailableTokenSets() as $tokenSet) {
+            if ($tokenSet['id'] === $tokenSetId) {
+                return $tokenSet;
+            }
+        }
+
+        return null;
+    }//end findTokenSetEntry()
+
+    /**
+     * Resolve a token set's logo path to an absolute URL.
+     *
+     * @param string|null $logoPath The logo path from token-sets.json (e.g. 'img/logos/amsterdam.svg').
+     *
+     * @return string|null The absolute URL, or null when unresolvable.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    private function resolveLogoUrl(?string $logoPath): ?string
+    {
+        if ($logoPath === null || $logoPath === '') {
+            return null;
+        }
+
+        // IURLGenerator::imagePath() resolves relative to the app's img/
+        // directory itself, so a stored path already prefixed with 'img/'
+        // must have that prefix stripped before being passed in.
+        $relative = $logoPath;
+        if (str_starts_with($relative, 'img/') === true) {
+            $relative = substr($relative, 4);
+        }
+
+        try {
+            return $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath(Application::APP_ID, $relative));
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }//end resolveLogoUrl()
+
+    /**
+     * Whether the nldesign branded template is the configured mail template.
+     *
+     * @return bool True when `mail_template_class` names the nldesign template.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function isEnabled(): bool
+    {
+        return $this->config->getSystemValue(self::MAIL_TEMPLATE_CLASS_KEY, '') === NLDesignEMailTemplate::class;
+    }//end isEnabled()
+
+    /**
+     * Get the current toggle state.
+     *
+     * @return array{state: string, configReadOnly: bool, foreignClass: ?string} The state:
+     *         `state` is one of `disabled`/`enabled`/`foreign`; `foreignClass` is set only
+     *         when `state` is `foreign`.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function getState(): array
+    {
+        $configured     = (string) $this->config->getSystemValue(self::MAIL_TEMPLATE_CLASS_KEY, '');
+        $configReadOnly = $this->config->getSystemValueBool('config_is_read_only', false);
+
+        $state        = 'disabled';
+        $foreignClass = null;
+        if ($configured === NLDesignEMailTemplate::class) {
+            $state = 'enabled';
+        } else if ($configured !== '') {
+            $state        = 'foreign';
+            $foreignClass = $configured;
+        }
+
+        return [
+            'state'          => $state,
+            'configReadOnly' => $configReadOnly,
+            'foreignClass'   => $foreignClass,
+        ];
+    }//end getState()
+
+    /**
+     * Enable the nldesign branded template.
+     *
+     * @return void
+     *
+     * @throws ForeignMailTemplateClassException When a different class is already configured.
+     * @throws ConfigReadOnlyException When config.php cannot be written.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function enable(): void
+    {
+        $state = $this->getState();
+        if ($state['state'] === 'foreign') {
+            throw new ForeignMailTemplateClassException(foreignClass: (string) $state['foreignClass']);
+        }
+
+        if ($state['configReadOnly'] === true) {
+            throw new ConfigReadOnlyException(occEnableCommand: self::OCC_ENABLE_COMMAND, occDisableCommand: self::OCC_DISABLE_COMMAND);
+        }
+
+        try {
+            $this->config->setSystemValue(self::MAIL_TEMPLATE_CLASS_KEY, NLDesignEMailTemplate::class);
+        } catch (HintException $e) {
+            // The config_is_read_only flag can miss a filesystem-level
+            // read-only config.php (e.g. chmod 444) — the write itself
+            // throws HintException in that case.
+            throw new ConfigReadOnlyException(occEnableCommand: self::OCC_ENABLE_COMMAND, occDisableCommand: self::OCC_DISABLE_COMMAND, previous: $e);
+        }
+    }//end enable()
+
+    /**
+     * Disable the nldesign branded template.
+     *
+     * A foreign class is left untouched (nothing to disable on nldesign's
+     * behalf); config.php read-only still blocks the delete when nldesign's
+     * own value is configured.
+     *
+     * @return void
+     *
+     * @throws ConfigReadOnlyException When config.php cannot be written.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function disable(): void
+    {
+        $state = $this->getState();
+        if ($state['state'] === 'foreign' || $state['state'] === 'disabled') {
+            return;
+        }
+
+        if ($state['configReadOnly'] === true) {
+            throw new ConfigReadOnlyException(occEnableCommand: self::OCC_ENABLE_COMMAND, occDisableCommand: self::OCC_DISABLE_COMMAND);
+        }
+
+        try {
+            $this->config->deleteSystemValue(self::MAIL_TEMPLATE_CLASS_KEY);
+        } catch (HintException $e) {
+            throw new ConfigReadOnlyException(occEnableCommand: self::OCC_ENABLE_COMMAND, occDisableCommand: self::OCC_DISABLE_COMMAND, previous: $e);
+        }
+    }//end disable()
+}//end class

--- a/lib/Service/Exception/ConfigReadOnlyException.php
+++ b/lib/Service/Exception/ConfigReadOnlyException.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * NL Design Config Read-Only Exception.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Exception
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/nldesign
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Service\Exception;
+
+/**
+ * Thrown when the `mail_template_class` system config cannot be written
+ * because config.php is read-only — either the `config_is_read_only` flag
+ * is set, or the write failed at the filesystem level (surfaced by the
+ * server as an `\OCP\HintException`). Carries the exact `occ` commands so
+ * the caller (the settings controller) can hand them to the admin verbatim.
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+class ConfigReadOnlyException extends \RuntimeException
+{
+
+    /**
+     * The occ command to enable the branded template manually.
+     *
+     * @var string
+     */
+    private string $occEnableCommand;
+
+    /**
+     * The occ command to disable the branded template manually.
+     *
+     * @var string
+     */
+    private string $occDisableCommand;
+
+    /**
+     * Constructor.
+     *
+     * @param string          $occEnableCommand  The occ command to enable manually.
+     * @param string          $occDisableCommand The occ command to disable manually.
+     * @param \Throwable|null $previous          The previous exception, if any.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function __construct(string $occEnableCommand, string $occDisableCommand, ?\Throwable $previous=null)
+    {
+        parent::__construct(message: 'config.php is read-only; mail_template_class cannot be written.', code: 0, previous: $previous);
+        $this->occEnableCommand  = $occEnableCommand;
+        $this->occDisableCommand = $occDisableCommand;
+    }//end __construct()
+
+    /**
+     * Get the occ command to enable the branded template manually.
+     *
+     * @return string The occ command.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function getOccEnableCommand(): string
+    {
+        return $this->occEnableCommand;
+    }//end getOccEnableCommand()
+
+    /**
+     * Get the occ command to disable the branded template manually.
+     *
+     * @return string The occ command.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function getOccDisableCommand(): string
+    {
+        return $this->occDisableCommand;
+    }//end getOccDisableCommand()
+}//end class

--- a/lib/Service/Exception/FooterValidationException.php
+++ b/lib/Service/Exception/FooterValidationException.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * NL Design Footer Validation Exception.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Exception
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/nldesign
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Service\Exception;
+
+/**
+ * Thrown when a footer config value fails validation at write time — e.g. a
+ * URL that is not `http(s)://` (rejecting `javascript:` and other schemes)
+ * or exceeds the maximum stored length. The controller maps this to HTTP 422.
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+class FooterValidationException extends \InvalidArgumentException
+{
+
+    /**
+     * The footer field that failed validation.
+     *
+     * @var string
+     */
+    private string $field;
+
+    /**
+     * Constructor.
+     *
+     * @param string $field   The footer field that failed validation.
+     * @param string $message The validation error message.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function __construct(string $field, string $message)
+    {
+        parent::__construct(message: $message);
+        $this->field = $field;
+    }//end __construct()
+
+    /**
+     * Get the footer field that failed validation.
+     *
+     * @return string The field name.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function getField(): string
+    {
+        return $this->field;
+    }//end getField()
+}//end class

--- a/lib/Service/Exception/ForeignMailTemplateClassException.php
+++ b/lib/Service/Exception/ForeignMailTemplateClassException.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * NL Design Foreign Mail Template Class Exception.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Exception
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/nldesign
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Service\Exception;
+
+/**
+ * Thrown when enabling the branded template would clobber a `mail_template_class`
+ * system value that names some OTHER class (e.g. an enterprise template).
+ * nldesign must never overwrite it — the admin panel surfaces the configured
+ * class name instead and leaves the toggle disabled.
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+class ForeignMailTemplateClassException extends \RuntimeException
+{
+
+    /**
+     * The foreign class currently configured.
+     *
+     * @var string
+     */
+    private string $foreignClass;
+
+    /**
+     * Constructor.
+     *
+     * @param string $foreignClass The currently configured foreign class.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function __construct(string $foreignClass)
+    {
+        parent::__construct(message: 'mail_template_class is configured to a foreign class: '.$foreignClass);
+        $this->foreignClass = $foreignClass;
+    }//end __construct()
+
+    /**
+     * Get the foreign class currently configured.
+     *
+     * @return string The foreign class name.
+     *
+     * @spec openspec/specs/email-theming/spec.md
+     */
+    public function getForeignClass(): string
+    {
+        return $this->foreignClass;
+    }//end getForeignClass()
+}//end class

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace OCA\NLDesign\Settings;
 
 use OCA\NLDesign\AppInfo\Application;
+use OCA\NLDesign\Service\EmailThemingService;
 use OCA\NLDesign\Service\TokenSetService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
@@ -64,17 +65,30 @@ class Admin implements IDelegatedSettings
     private TokenSetService $tokenSetService;
 
     /**
+     * The email theming service.
+     *
+     * @var EmailThemingService
+     */
+    private EmailThemingService $emailThemingService;
+
+    /**
      * Constructor.
      *
-     * @param IConfig         $config          The config service.
-     * @param IL10N           $l               The localization service.
-     * @param TokenSetService $tokenSetService The token set service.
+     * @param IConfig             $config              The config service.
+     * @param IL10N               $l                   The localization service.
+     * @param TokenSetService     $tokenSetService     The token set service.
+     * @param EmailThemingService $emailThemingService The email theming service.
      */
-    public function __construct(IConfig $config, IL10N $l, TokenSetService $tokenSetService)
-    {
+    public function __construct(
+        IConfig $config,
+        IL10N $l,
+        TokenSetService $tokenSetService,
+        EmailThemingService $emailThemingService
+    ) {
         $this->config = $config;
         $this->l      = $l;
-        $this->tokenSetService = $tokenSetService;
+        $this->tokenSetService     = $tokenSetService;
+        $this->emailThemingService = $emailThemingService;
     }//end __construct()
 
     /**
@@ -106,14 +120,21 @@ class Admin implements IDelegatedSettings
             '0'
         ) === '1';
 
+        $emailThemingState = $this->emailThemingService->getState();
+        $emailFooterConfig = $this->emailThemingService->getFooterConfig();
+
         return new TemplateResponse(
             Application::APP_ID,
                 'settings/admin',
                 [
-                    'tokenSets'       => $tokenSets,
-                    'currentTokenSet' => $currentTokenSet,
-                    'hideSlogan'      => $hideSlogan,
-                    'showMenuLabels'  => $showMenuLabels,
+                    'tokenSets'         => $tokenSets,
+                    'currentTokenSet'   => $currentTokenSet,
+                    'hideSlogan'        => $hideSlogan,
+                    'showMenuLabels'    => $showMenuLabels,
+                    'emailThemingState' => $emailThemingState,
+                    'emailFooterConfig' => $emailFooterConfig,
+                    'occEnableCommand'  => EmailThemingService::OCC_ENABLE_COMMAND,
+                    'occDisableCommand' => EmailThemingService::OCC_DISABLE_COMMAND,
                 ]
         );
     }//end getForm()
@@ -175,6 +196,9 @@ class Admin implements IDelegatedSettings
                 '/show_menu_labels/',
                 '/disabled_apps/',
                 '/theming_syncs_total/',
+                '/email_footer_org_name/',
+                '/email_footer_accessibility_url/',
+                '/email_footer_privacy_url/',
             ],
         ];
     }//end getAuthorizedAppConfig()

--- a/openspec/changes/email-template-theming/tasks.md
+++ b/openspec/changes/email-template-theming/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Template class
 
-- [ ] 1.1 Create `lib/Mail/NLDesignEMailTemplate.php` (`OCA\NLDesign\Mail\NLDesignEMailTemplate`)
+- [x] 1.1 Create `lib/Mail/NLDesignEMailTemplate.php` (`OCA\NLDesign\Mail\NLDesignEMailTemplate`)
       extending `OC\Mail\EMailTemplate`. Keep the parent constructor untouched (the class is
       instantiated by `OC\Mail\Mailer::makeTemplate()` with a fixed argument list —
       `lib/private/Mail/Mailer.php:131-143` in the server checkout; adding constructor
       parameters would fatal). SPDX `@license`/`@copyright` docblock per hydra gate.
-- [ ] 1.2 Add a private lazy resolver `getEmailThemingService(): ?EmailThemingService` using
+- [x] 1.2 Add a private lazy resolver `getEmailThemingService(): ?EmailThemingService` using
       `\OCP\Server::get()` inside `try/catch (\Throwable)` returning `null` on any failure.
       NOTE for the semantic-auth/unsafe-resolver gates: this resolver gates *presentation
       fallback only* (branded vs stock mail), never an authorization decision — document that
       in the method docblock.
-- [ ] 1.3 Override `addHeader()`: when the service resolves and reports an active nldesign
+- [x] 1.3 Override `addHeader()`: when the service resolves and reports an active nldesign
       token set, render the header with the token-set primary color and the token-set logo
       (absolute URL via `IURLGenerator`); otherwise call `parent::addHeader()`. Reuse the
       parent's `$header` HEREDOC structure — only the substituted color/logo values change,
       so email-client-tested markup stays intact.
-- [ ] 1.4 Override `addBodyButton()` / `addBodyButtonGroup()` analogously: substitute the
+- [x] 1.4 Override `addBodyButton()` / `addBodyButtonGroup()` analogously: substitute the
       token-set primary color for `ThemingDefaults::getDefaultColorPrimary()` in the button
       background, and the token-set `--nldesign-color-primary-text` (default `#ffffff`) for
       the button text color; fall back to parent on any missing value.
-- [ ] 1.5 Override `addFooter()`: call the parent first, then append the configured footer
+- [x] 1.5 Override `addFooter()`: call the parent first, then append the configured footer
       block — org name, "Toegankelijkheidsverklaring" link, "Privacyverklaring" link (only
       non-empty values, order fixed) — to BOTH `$this->htmlBody` (small-print styled table
       row matching the parent's footer markup) and `$this->plainBody` (plain lines
@@ -28,7 +28,7 @@
 
 ## 2. Service + toggle plumbing
 
-- [ ] 2.1 Create `lib/Service/EmailThemingService.php` with:
+- [x] 2.1 Create `lib/Service/EmailThemingService.php` with:
       `getFooterConfig(): array` / `setFooterConfig(...)` over IConfig app values
       `email_footer_org_name`, `email_footer_accessibility_url`, `email_footer_privacy_url`
       (URL values validated: `https://` or `http://` scheme only, max 2048 chars, else 422);
@@ -44,7 +44,7 @@
       MUST throw a typed `ConfigReadOnlyException`-style exception when config.php is
       read-only (catch `\OCP\HintException` from the write path too, since read-only
       detection via the flag can miss filesystem-level read-only config.php).
-- [ ] 2.2 Add `SettingsController::getEmailTheming()` (GET) returning state + footer config,
+- [x] 2.2 Add `SettingsController::getEmailTheming()` (GET) returning state + footer config,
       and `SettingsController::setEmailTheming()` (POST, params `enabled`, `orgName`,
       `accessibilityUrl`, `privacyUrl`). Both `#[AuthorizedAdminSetting(Admin::class)]`, no
       `NoCSRFRequired` (same posture as the other settings routes). `setEmailTheming` maps
@@ -54,28 +54,30 @@
       `{"error": "foreign_mail_template_class", "class": "<fqcn>"}`. Footer config saves MUST
       still succeed (app config is always writable) even when the toggle part fails —
       apply footer first, toggle second, and report per-part status.
-- [ ] 2.3 Register routes in `appinfo/routes.php`:
+- [x] 2.3 Register routes in `appinfo/routes.php`:
       `['name' => 'settings#getEmailTheming', 'url' => '/settings/email-theming', 'verb' => 'GET']`,
       `['name' => 'settings#setEmailTheming', 'url' => '/settings/email-theming', 'verb' => 'POST']`.
 
 ## 3. Admin UI (vanilla JS — no Vue)
 
-- [ ] 3.1 `lib/Settings/Admin.php` `getForm()`: add email-theming state, footer values, and
+- [x] 3.1 `lib/Settings/Admin.php` `getForm()`: add email-theming state, footer values, and
       the occ command strings to the template parameters.
-- [ ] 3.2 `templates/settings/admin.php`: new "Email template" section — enable checkbox,
+- [x] 3.2 `templates/settings/admin.php`: new "Email template" section — enable checkbox,
       three labeled text inputs (organization name, toegankelijkheidsverklaring URL, privacy
       statement URL), Save button, and a hidden `.nldesign-email-occ-hint` block containing
       the two occ commands in `<code>` elements. When state is `foreign`, render the checkbox
       disabled with an explanatory note naming the configured class.
-- [ ] 3.3 `js/admin.js`: wire the section — load via GET on init, save via POST; on 409
+- [x] 3.3 `js/admin.js`: wire the section — load via GET on init, save via POST; on 409
       `config_read_only` un-flip the checkbox and reveal the occ-hint block; on 409
       `foreign_mail_template_class` show the naming note. All user-facing strings via
       `t('nldesign', ...)` with ENGLISH keys.
-- [ ] 3.4 Add the new translatable strings to `l10n/` (en source + nl).
+- [x] 3.4 Add the new translatable strings to `l10n/` (en source + nl). (No `l10n/*.js` files
+      exist in this app — only `l10n/*.json` — so translations were added there, mirroring the
+      app's actual existing format.)
 
 ## 4. Tests
 
-- [ ] 4.1 `tests/unit/Mail/NLDesignEMailTemplateTest.php` — rendering unit tests
+- [x] 4.1 `tests/Unit/Mail/NLDesignEMailTemplateTest.php` — rendering unit tests
       (instantiate the template directly with mocked `Defaults`/`IURLGenerator`/l10n
       factory, injecting a stubbed `EmailThemingService` via a test seam or overridable
       resolver):
@@ -88,30 +90,42 @@
       (d) the plain-text part of a full email (header/heading/body/button/footer) still
       contains the button URL and standard footer — plain part intact, no HTML leakage;
       (e) footer values containing `<script>` / `"` are escaped in the HTML part.
-- [ ] 4.2 `tests/unit/Service/EmailThemingServiceTest.php` — enable/disable write and delete
+- [x] 4.2 `tests/Unit/Service/EmailThemingServiceTest.php` — enable/disable write and delete
       the system value; enable with a foreign class configured throws; read-only config
       throws the typed exception; footer URL validation rejects `javascript:` and
       non-URL junk; `getActiveEmailTheme()` returns manifest theming for `amsterdam`,
       preview-resolved colors for a set without `theming`, and `null` for `nextcloud`.
-- [ ] 4.3 Controller test: `setEmailTheming` returns 409 + occ strings when the service
-      throws read-only; footer-only save succeeds in the same read-only situation.
+- [x] 4.3 Controller test (`tests/Unit/Controller/SettingsControllerTest.php`): `setEmailTheming`
+      returns 409 + occ strings when the service throws read-only; footer-only save succeeds
+      in the same read-only situation.
 
 ## 5. Verify
 
-- [ ] 5.1 Run PHPUnit in the nextcloud:34 container
-      (`docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit`) — all new
-      tests green; `composer check:strict` passes (SPDX headers, PHPCS, Psalm, PHPStan).
+- [x] 5.1 Run PHPUnit in the nextcloud:34 container — all new tests green (21 new tests: 5
+      template + 13 service + 3 controller); full suite 113 tests / 1391 assertions, all
+      green. `composer check:strict` passes: lint/phpcs/phpmd/psalm clean (psalm: "No errors
+      found!"); phpstan reports the same pre-existing, unfixable-by-design
+      "extends unknown class" finding already present for `HealthController`'s cross-app
+      extends (PHPStan disallows ignoring that error category; the composer `phpstan` script
+      degrades to a warning by design) — not a new defect, same shape as the established
+      precedent. NOTE: the worktree's `vendor/` is a symlink whose PSR-4 base resolves to the
+      MAIN CHECKOUT's `lib/` (not the worktree's), so the brief's literal
+      `docker run -v <worktree>:/app` invocation cannot autoload NEW worktree-only classes;
+      verified instead by staging the worktree's non-vendor files over a copy of the main
+      checkout's `vendor/`+`node_modules/` inside the (ephemeral, `--rm`) container — never
+      writes to the host's main checkout.
 - [ ] 5.2 Live on the 8080 dev instance: activate the `amsterdam` token set, enable the
       email toggle in the nldesign admin panel, then run
       `occ mail:send-test admin@example.com` (or trigger a password-reset mail) with a local
       mailhog/smtp catcher and confirm the received HTML shows the `#004699` header/button
       color, the Amsterdam logo, and the configured footer links; confirm the plain-text
-      alternative part still reads correctly.
+      alternative part still reads correctly. (deferred to post-merge live verification)
 - [ ] 5.3 Live negative path: set `config_is_read_only => true` in config.php (or
       `chmod 444` it inside the container), flip the toggle in the UI, and confirm the 409
       path shows the occ instructions and the checkbox reverts; then run the shown
       `occ config:system:set mail_template_class ...` command and confirm branded mail works.
-      Restore config.php writability afterwards.
+      Restore config.php writability afterwards. (deferred to post-merge live verification)
 - [ ] 5.4 Live fallback proof: with the toggle enabled, `occ app:disable nldesign`, send a
       test mail, and confirm stock-branded mail is delivered (Mailer's `class_exists` guard
-      falls back — no error in the log beyond that). Re-enable the app.
+      falls back — no error in the log beyond that). Re-enable the app. (deferred to
+      post-merge live verification)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,7 +19,18 @@ parameters:
         - vendor/nextcloud/ocp
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
-        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp.
+        # lib/Mail/NLDesignEMailTemplate.php extends the private OC\Mail\EMailTemplate
+        # (the server's own sanctioned mail_template_class hook) — PHPStan cannot
+        # resolve OC\ classes under the OCP/NCU-only bootstrap this app uses, and
+        # "extends unknown class" is a hard PHPStan error category that cannot be
+        # ignored via ignoreErrors (only excludePaths, which would hide real bugs
+        # in the file). This mirrors the pre-existing, same-shaped situation in
+        # lib/Controller/HealthController.php (extends the cross-app
+        # OCA\OpenRegister\AppHost\Controller\GenericHealthController) — accepted as
+        # a known static-analysis gap covered by composer check:strict's designed
+        # fallback (the `phpstan` composer script degrades to a warning when the
+        # analysis itself cannot complete), not a defect in either file.
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
         - '#Access to static property \$server on an unknown class OC#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -88,6 +88,13 @@
                 <!-- Nextcloud Theming app peer-app classes (theming app is always enabled in NC) -->
                 <referencedClass name="OCA\Theming\ImageManager"/>
                 <referencedClass name="OCA\Theming\ThemingDefaults"/>
+                <!-- Server-internal (private-namespace) mail classes. Extending
+                     OC\Mail\EMailTemplate is the platform's own sanctioned
+                     mail_template_class hook (OC\Mail\Mailer::makeTemplate()) —
+                     not stubbed in nextcloud/ocp because OC\ is intentionally
+                     private API, mirroring the OCA\Theming precedent above. -->
+                <referencedClass name="OC\Mail\EMailTemplate"/>
+                <referencedClass name="OC\Mail\Mailer"/>
                 <!-- NLDesign own Settings class (loaded at runtime, not in Psalm analysis path) -->
                 <referencedClass name="OCA\NLDesign\Settings\Admin"/>
                 <!-- GuzzleHttp (loaded via composer at runtime) -->

--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -2,6 +2,10 @@
 /**
  * @var array $tokenSets
  * @var string $currentTokenSet
+ * @var array{state: string, configReadOnly: bool, foreignClass: ?string} $emailThemingState
+ * @var array{orgName: string, accessibilityUrl: string, privacyUrl: string} $emailFooterConfig
+ * @var string $occEnableCommand
+ * @var string $occDisableCommand
  */
 
 // Load the pure token/colour transforms first so admin.js can consume them via
@@ -100,6 +104,63 @@ style('nldesign', 'admin');
 			<?php p($l->t('Save app theming')); ?>
 		</button>
 		<span id="nldesign-app-theming-feedback" class="nldesign-app-theming-feedback" role="status" aria-live="polite"></span>
+	</div>
+
+	<!-- Email template theming — mail_template_class toggle + compliance footer -->
+	<div class="nldesign-email-theming" id="nldesign-email-theming" style="margin-top:2em"
+		 data-state="<?php p($_['emailThemingState']['state']); ?>"
+		 data-config-read-only="<?php p($_['emailThemingState']['configReadOnly'] ? '1' : '0'); ?>"
+		 data-foreign-class="<?php p($_['emailThemingState']['foreignClass'] ?? ''); ?>">
+		<h3><?php p($l->t('Email template')); ?></h3>
+		<p class="settings-hint">
+			<?php p($l->t('Brand password-reset, share-notification, and other system emails with the active token set\'s color and logo. If nldesign is later disabled, Nextcloud automatically falls back to the stock email template — mail is never blocked by this setting.')); ?>
+		</p>
+
+		<?php if ($_['emailThemingState']['state'] === 'foreign'): ?>
+			<p class="nldesign-email-foreign-note" role="alert">
+				<?php p($l->t('A different mail template class is already configured ({class}); nldesign will not overwrite it.', ['class' => $_['emailThemingState']['foreignClass']])); ?>
+			</p>
+		<?php endif; ?>
+
+		<div class="nldesign-option">
+			<input type="checkbox"
+				   name="nldesign-email-theming-enabled"
+				   id="nldesign-email-theming-enabled"
+				   class="checkbox"
+				   <?php if ($_['emailThemingState']['state'] === 'enabled'): ?>checked<?php endif; ?>
+				   <?php if ($_['emailThemingState']['state'] === 'foreign'): ?>disabled<?php endif; ?>>
+			<label for="nldesign-email-theming-enabled">
+				<?php p($l->t('Use NL Design email template')); ?>
+			</label>
+		</div>
+
+		<div class="nldesign-email-footer-fields">
+			<label for="nldesign-email-footer-org-name"><?php p($l->t('Organization name')); ?></label>
+			<input type="text" id="nldesign-email-footer-org-name" class="nldesign-email-footer-input"
+				   value="<?php p($_['emailFooterConfig']['orgName']); ?>"
+				   placeholder="<?php p($l->t('e.g. Gemeente Voorbeeld')); ?>" maxlength="2048">
+
+			<label for="nldesign-email-footer-accessibility-url"><?php p($l->t('Accessibility statement URL')); ?></label>
+			<input type="url" id="nldesign-email-footer-accessibility-url" class="nldesign-email-footer-input"
+				   value="<?php p($_['emailFooterConfig']['accessibilityUrl']); ?>"
+				   placeholder="https://example.org/toegankelijkheidsverklaring" maxlength="2048">
+
+			<label for="nldesign-email-footer-privacy-url"><?php p($l->t('Privacy statement URL')); ?></label>
+			<input type="url" id="nldesign-email-footer-privacy-url" class="nldesign-email-footer-input"
+				   value="<?php p($_['emailFooterConfig']['privacyUrl']); ?>"
+				   placeholder="https://example.org/privacy" maxlength="2048">
+		</div>
+
+		<button type="button" id="nldesign-email-theming-save" class="button">
+			<?php p($l->t('Save email template settings')); ?>
+		</button>
+		<span id="nldesign-email-theming-feedback" class="nldesign-email-theming-feedback" role="status" aria-live="polite"></span>
+
+		<div class="nldesign-email-occ-hint" id="nldesign-email-occ-hint" role="alert" style="display:none">
+			<p><?php p($l->t('config.php is read-only. Run one of the following commands manually to enable or disable the email template:')); ?></p>
+			<p><code id="nldesign-email-occ-enable"><?php p($_['occEnableCommand']); ?></code></p>
+			<p><code id="nldesign-email-occ-disable"><?php p($_['occDisableCommand']); ?></code></p>
+		</div>
 	</div>
 
 	<div class="nldesign-preview" id="nldesign-preview">

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Unit tests for SettingsController's email theming endpoints.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit\Controller;
+
+use OCA\NLDesign\Controller\SettingsController;
+use OCA\NLDesign\Service\AppThemingService;
+use OCA\NLDesign\Service\EmailThemingService;
+use OCA\NLDesign\Service\Exception\ConfigReadOnlyException;
+use OCA\NLDesign\Service\ThemingService;
+use OCA\NLDesign\Service\TokenSetPreviewService;
+use OCA\NLDesign\Service\TokenSetService;
+use OCP\IConfig;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for SettingsController's email theming endpoints.
+ */
+class SettingsControllerTest extends TestCase
+{
+
+    /**
+     * Build a controller with a stubbed EmailThemingService and inert mocks
+     * for the other constructor dependencies (unused by these tests).
+     *
+     * @param EmailThemingService $emailThemingService The stubbed service.
+     *
+     * @return SettingsController The controller under test.
+     */
+    private function makeController(EmailThemingService $emailThemingService): SettingsController
+    {
+        return new SettingsController(
+            'nldesign',
+            $this->createMock(IRequest::class),
+            $this->createMock(IConfig::class),
+            $this->createMock(TokenSetService::class),
+            $this->createMock(ThemingService::class),
+            $this->createMock(TokenSetPreviewService::class),
+            $this->createMock(AppThemingService::class),
+            $emailThemingService
+        );
+    }//end makeController()
+
+    /**
+     * setEmailTheming returns HTTP 409 with the occ command strings when the
+     * service reports config.php is read-only.
+     *
+     * @return void
+     */
+    public function testSetEmailThemingReturns409WithOccCommandsOnReadOnly(): void
+    {
+        $emailThemingService = $this->createMock(EmailThemingService::class);
+        $emailThemingService->expects($this->once())->method('setFooterConfig')
+            ->with('Org', '', '')
+            ->willReturn(['orgName' => 'Org', 'accessibilityUrl' => '', 'privacyUrl' => '']);
+        $emailThemingService->method('enable')
+            ->willThrowException(new ConfigReadOnlyException('occ enable-cmd', 'occ disable-cmd'));
+        $emailThemingService->method('getFooterConfig')
+            ->willReturn(['orgName' => 'Org', 'accessibilityUrl' => '', 'privacyUrl' => '']);
+
+        $controller = $this->makeController($emailThemingService);
+        $response   = $controller->setEmailTheming(true, 'Org', '', '');
+
+        $this->assertSame(409, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('config_read_only', $data['error']);
+        $this->assertSame('occ enable-cmd', $data['occEnable']);
+        $this->assertSame('occ disable-cmd', $data['occDisable']);
+    }//end testSetEmailThemingReturns409WithOccCommandsOnReadOnly()
+
+    /**
+     * The footer config save still succeeds (and is reported back) even
+     * when the toggle write fails because config.php is read-only —
+     * footer is applied first, independently of the toggle outcome.
+     *
+     * @return void
+     */
+    public function testFooterSaveSucceedsWhenToggleFailsReadOnly(): void
+    {
+        $emailThemingService = $this->createMock(EmailThemingService::class);
+        $emailThemingService->expects($this->once())->method('setFooterConfig')
+            ->with('Gemeente Voorbeeld', 'https://voorbeeld.nl/a11y', 'https://voorbeeld.nl/privacy')
+            ->willReturn(
+                [
+                    'orgName'          => 'Gemeente Voorbeeld',
+                    'accessibilityUrl' => 'https://voorbeeld.nl/a11y',
+                    'privacyUrl'       => 'https://voorbeeld.nl/privacy',
+                ]
+            );
+        $emailThemingService->method('enable')
+            ->willThrowException(new ConfigReadOnlyException('occ enable-cmd', 'occ disable-cmd'));
+        $emailThemingService->method('getFooterConfig')->willReturn(
+            [
+                'orgName'          => 'Gemeente Voorbeeld',
+                'accessibilityUrl' => 'https://voorbeeld.nl/a11y',
+                'privacyUrl'       => 'https://voorbeeld.nl/privacy',
+            ]
+        );
+
+        $controller = $this->makeController($emailThemingService);
+        $response   = $controller->setEmailTheming(
+            true,
+            'Gemeente Voorbeeld',
+            'https://voorbeeld.nl/a11y',
+            'https://voorbeeld.nl/privacy'
+        );
+
+        $this->assertSame(409, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('Gemeente Voorbeeld', $data['footer']['orgName']);
+        $this->assertSame('https://voorbeeld.nl/a11y', $data['footer']['accessibilityUrl']);
+        $this->assertSame('https://voorbeeld.nl/privacy', $data['footer']['privacyUrl']);
+    }//end testFooterSaveSucceedsWhenToggleFailsReadOnly()
+
+    /**
+     * A successful enable (writable config.php, nothing foreign configured)
+     * returns status ok with the updated state.
+     *
+     * @return void
+     */
+    public function testSetEmailThemingSucceeds(): void
+    {
+        $emailThemingService = $this->createMock(EmailThemingService::class);
+        $emailThemingService->expects($this->once())->method('setFooterConfig')
+            ->willReturn(['orgName' => '', 'accessibilityUrl' => '', 'privacyUrl' => '']);
+        $emailThemingService->expects($this->once())->method('enable');
+        $emailThemingService->method('getState')
+            ->willReturn(['state' => 'enabled', 'configReadOnly' => false, 'foreignClass' => null]);
+        $emailThemingService->method('getFooterConfig')
+            ->willReturn(['orgName' => '', 'accessibilityUrl' => '', 'privacyUrl' => '']);
+
+        $controller = $this->makeController($emailThemingService);
+        $response   = $controller->setEmailTheming(true, '', '', '');
+
+        $this->assertSame(200, $response->getStatus());
+        $data = $response->getData();
+        $this->assertSame('ok', $data['status']);
+        $this->assertSame('enabled', $data['state']['state']);
+    }//end testSetEmailThemingSucceeds()
+}//end class

--- a/tests/Unit/Mail/NLDesignEMailTemplateTest.php
+++ b/tests/Unit/Mail/NLDesignEMailTemplateTest.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * Unit tests for NLDesignEMailTemplate.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit\Mail;
+
+use OC\Mail\EMailTemplate;
+use OCA\NLDesign\Mail\NLDesignEMailTemplate;
+use OCA\NLDesign\Service\EmailThemingService;
+use OCP\Defaults;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test seam: overrides the private-service resolver so a stubbed
+ * EmailThemingService (or null, for the fallback-proof scenario) can be
+ * injected without touching the live \OCP\Server container the real
+ * `Mailer::makeTemplate()` resolves through.
+ */
+class TestableNLDesignEMailTemplate extends NLDesignEMailTemplate
+{
+
+    /**
+     * The stubbed email theming service, or null.
+     *
+     * @var EmailThemingService|null
+     */
+    private ?EmailThemingService $stubService = null;
+
+    /**
+     * Inject a stubbed service (or null, to simulate total resolution failure).
+     *
+     * @param EmailThemingService|null $service The stubbed service.
+     *
+     * @return void
+     */
+    public function setStubService(?EmailThemingService $service): void
+    {
+        $this->stubService = $service;
+    }//end setStubService()
+
+    /**
+     * Test seam override — returns the injected stub instead of resolving
+     * \OCP\Server::get().
+     *
+     * @return EmailThemingService|null The stubbed service.
+     */
+    protected function getEmailThemingService(): ?EmailThemingService
+    {
+        return $this->stubService;
+    }//end getEmailThemingService()
+}//end class
+
+/**
+ * Unit tests for NLDesignEMailTemplate.
+ */
+class NLDesignEMailTemplateTest extends TestCase
+{
+
+    /**
+     * The theming defaults mock.
+     *
+     * @var Defaults
+     */
+    private Defaults $themingDefaults;
+
+    /**
+     * The URL generator mock.
+     *
+     * @var IURLGenerator
+     */
+    private IURLGenerator $urlGenerator;
+
+    /**
+     * The l10n factory mock.
+     *
+     * @var IFactory
+     */
+    private IFactory $l10nFactory;
+
+    /**
+     * Set up shared constructor-argument mocks before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->themingDefaults = $this->createMock(Defaults::class);
+        $this->themingDefaults->method('getDefaultColorPrimary')->willReturn('#0082c9');
+        $this->themingDefaults->method('getDefaultTextColorPrimary')->willReturn('#ffffff');
+        $this->themingDefaults->method('getLogo')->willReturn('/core/img/logo/logo.svg');
+        $this->themingDefaults->method('getName')->willReturn('Nextcloud');
+        $this->themingDefaults->method('getSlogan')->willReturn('');
+
+        $this->urlGenerator = $this->createMock(IURLGenerator::class);
+        $this->urlGenerator->method('getAbsoluteURL')->willReturnCallback(
+            fn (string $url) => 'https://cloud.example.com'.$url
+        );
+
+        $l10n = $this->createMock(IL10N::class);
+        $l10n->method('t')->willReturnCallback(fn (string $text, $params = []) => $text);
+
+        $this->l10nFactory = $this->createMock(IFactory::class);
+        $this->l10nFactory->method('get')->willReturn($l10n);
+    }//end setUp()
+
+    /**
+     * Build a testable branded template, stubbed with the given service.
+     *
+     * @param EmailThemingService|null $service The stubbed service, or null.
+     *
+     * @return TestableNLDesignEMailTemplate The template under test.
+     */
+    private function makeTemplate(?EmailThemingService $service): TestableNLDesignEMailTemplate
+    {
+        $template = new TestableNLDesignEMailTemplate(
+            $this->themingDefaults,
+            $this->urlGenerator,
+            $this->l10nFactory,
+            32,
+            32,
+            'test',
+            []
+        );
+        $template->setStubService($service);
+
+        return $template;
+    }//end makeTemplate()
+
+    /**
+     * Build a stock EMailTemplate with the same constructor arguments, for
+     * byte-identical fallback comparison.
+     *
+     * @return EMailTemplate The stock template.
+     */
+    private function makeStockTemplate(): EMailTemplate
+    {
+        return new EMailTemplate(
+            $this->themingDefaults,
+            $this->urlGenerator,
+            $this->l10nFactory,
+            32,
+            32,
+            'test',
+            []
+        );
+    }//end makeStockTemplate()
+
+    /**
+     * (a) Header and body button markup use the active token set's color
+     * and the absolute logo URL.
+     *
+     * @return void
+     */
+    public function testHeaderAndButtonUseActiveTokenSetTheme(): void
+    {
+        $service = $this->createMock(EmailThemingService::class);
+        $service->method('getActiveEmailTheme')->willReturn(
+            [
+                'primaryColor'     => '#154273',
+                'primaryTextColor' => '#ffffff',
+                'logoUrl'          => 'https://cloud.example.com/apps/nldesign/img/logos/test.svg',
+            ]
+        );
+        $service->method('getFooterConfig')->willReturn(['orgName' => '', 'accessibilityUrl' => '', 'privacyUrl' => '']);
+
+        $template = $this->makeTemplate($service);
+        $template->setSubject('Test');
+        $template->addHeader();
+        $template->addHeading('Heading');
+        $template->addBodyText('Body text');
+        $template->addBodyButton('Click', 'https://example.org/action');
+        $template->addFooter();
+
+        $html = $template->renderHtml();
+
+        $this->assertStringContainsString('#154273', $html);
+        $this->assertStringContainsString('https://cloud.example.com/apps/nldesign/img/logos/test.svg', $html);
+    }//end testHeaderAndButtonUseActiveTokenSetTheme()
+
+    /**
+     * (b) Configured footer org name and both URLs appear in the HTML part
+     * AND as plain lines in renderText().
+     *
+     * @return void
+     */
+    public function testFooterConfigRendersInBothParts(): void
+    {
+        $service = $this->createMock(EmailThemingService::class);
+        $service->method('getActiveEmailTheme')->willReturn(null);
+        $service->method('getFooterConfig')->willReturn(
+            [
+                'orgName'          => 'Gemeente Voorbeeld',
+                'accessibilityUrl' => 'https://voorbeeld.nl/toegankelijkheid',
+                'privacyUrl'       => 'https://voorbeeld.nl/privacy',
+            ]
+        );
+
+        $template = $this->makeTemplate($service);
+        $template->addHeader();
+        $template->addFooter();
+
+        $html = $template->renderHtml();
+        $text = $template->renderText();
+
+        $this->assertStringContainsString('Gemeente Voorbeeld', $html);
+        $this->assertStringContainsString('https://voorbeeld.nl/toegankelijkheid', $html);
+        $this->assertStringContainsString('https://voorbeeld.nl/privacy', $html);
+
+        $this->assertStringContainsString('Gemeente Voorbeeld', $text);
+        $this->assertStringContainsString('https://voorbeeld.nl/toegankelijkheid', $text);
+        $this->assertStringContainsString('https://voorbeeld.nl/privacy', $text);
+    }//end testFooterConfigRendersInBothParts()
+
+    /**
+     * (c) With the service resolver returning null, HTML and plain output
+     * are byte-identical to a stock EMailTemplate render — the fallback proof.
+     *
+     * @return void
+     */
+    public function testNullServiceFallsBackToStockRendering(): void
+    {
+        $branded = $this->makeTemplate(null);
+        $stock   = $this->makeStockTemplate();
+
+        foreach ([$branded, $stock] as $tpl) {
+            $tpl->setSubject('Test');
+            $tpl->addHeader();
+            $tpl->addHeading('Heading');
+            $tpl->addBodyText('Body text');
+            $tpl->addBodyButton('Click', 'https://example.org/action');
+            $tpl->addFooter();
+        }
+
+        $this->assertSame($stock->renderHtml(), $branded->renderHtml());
+        $this->assertSame($stock->renderText(), $branded->renderText());
+    }//end testNullServiceFallsBackToStockRendering()
+
+    /**
+     * (d) The plain-text part of a full email (header/heading/body/button/
+     * footer) still contains the button URL and the standard footer text —
+     * plain part stays intact, no HTML leakage.
+     *
+     * @return void
+     */
+    public function testPlainTextPartStaysIntact(): void
+    {
+        $service = $this->createMock(EmailThemingService::class);
+        $service->method('getActiveEmailTheme')->willReturn(
+            [
+                'primaryColor'     => '#154273',
+                'primaryTextColor' => '#ffffff',
+                'logoUrl'          => null,
+            ]
+        );
+        $service->method('getFooterConfig')->willReturn(['orgName' => '', 'accessibilityUrl' => '', 'privacyUrl' => '']);
+
+        $template = $this->makeTemplate($service);
+        $template->addHeader();
+        $template->addHeading('Heading');
+        $template->addBodyText('Body text');
+        $template->addBodyButton('Click here', 'https://example.org/action');
+        $template->addFooter();
+
+        $text = $template->renderText();
+
+        $this->assertStringContainsString('https://example.org/action', $text);
+        $this->assertStringContainsString('Nextcloud', $text);
+        $this->assertStringNotContainsString('<', $text);
+    }//end testPlainTextPartStaysIntact()
+
+    /**
+     * (e) Footer values containing markup/quotes are HTML-escaped in the
+     * HTML part, never rendered as live markup.
+     *
+     * @return void
+     */
+    public function testFooterValuesAreOutputEncoded(): void
+    {
+        $service = $this->createMock(EmailThemingService::class);
+        $service->method('getActiveEmailTheme')->willReturn(null);
+        $service->method('getFooterConfig')->willReturn(
+            [
+                'orgName'          => '<script>alert(1)</script>',
+                'accessibilityUrl' => 'https://voorbeeld.nl/a"onclick="x',
+                'privacyUrl'       => '',
+            ]
+        );
+
+        $template = $this->makeTemplate($service);
+        $template->addHeader();
+        $template->addFooter();
+
+        $html = $template->renderHtml();
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+        $this->assertStringNotContainsString('"onclick="x"', $html);
+    }//end testFooterValuesAreOutputEncoded()
+}//end class

--- a/tests/Unit/Service/EmailThemingServiceTest.php
+++ b/tests/Unit/Service/EmailThemingServiceTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * Unit tests for EmailThemingService.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @spec openspec/specs/email-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit\Service;
+
+use OCA\NLDesign\Mail\NLDesignEMailTemplate;
+use OCA\NLDesign\Service\EmailThemingService;
+use OCA\NLDesign\Service\Exception\ConfigReadOnlyException;
+use OCA\NLDesign\Service\Exception\FooterValidationException;
+use OCA\NLDesign\Service\Exception\ForeignMailTemplateClassException;
+use OCA\NLDesign\Service\TokenSetPreviewService;
+use OCA\NLDesign\Service\TokenSetService;
+use OCP\HintException;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for EmailThemingService.
+ */
+class EmailThemingServiceTest extends TestCase
+{
+
+    /**
+     * The config mock.
+     *
+     * @var IConfig
+     */
+    private $config;
+
+    /**
+     * The token set service mock.
+     *
+     * @var TokenSetService
+     */
+    private $tokenSetService;
+
+    /**
+     * The token set preview service mock.
+     *
+     * @var TokenSetPreviewService
+     */
+    private $previewService;
+
+    /**
+     * The URL generator mock.
+     *
+     * @var IURLGenerator
+     */
+    private $urlGenerator;
+
+    /**
+     * The service under test.
+     *
+     * @var EmailThemingService
+     */
+    private EmailThemingService $service;
+
+    /**
+     * Set up mocks before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->config          = $this->createMock(IConfig::class);
+        $this->tokenSetService = $this->createMock(TokenSetService::class);
+        $this->previewService  = $this->createMock(TokenSetPreviewService::class);
+        $this->urlGenerator    = $this->createMock(IURLGenerator::class);
+
+        $this->service = new EmailThemingService(
+            $this->config,
+            $this->tokenSetService,
+            $this->previewService,
+            $this->urlGenerator
+        );
+    }//end setUp()
+
+    /**
+     * Enabling with a writable config.php and nothing configured writes the
+     * system value.
+     *
+     * @return void
+     */
+    public function testEnableWritesSystemValue(): void
+    {
+        $this->config->method('getSystemValue')->willReturn('');
+        $this->config->method('getSystemValueBool')->willReturn(false);
+        $this->config->expects($this->once())
+            ->method('setSystemValue')
+            ->with('mail_template_class', NLDesignEMailTemplate::class);
+
+        $this->service->enable();
+    }//end testEnableWritesSystemValue()
+
+    /**
+     * Disabling deletes the system value.
+     *
+     * @return void
+     */
+    public function testDisableDeletesSystemValue(): void
+    {
+        $this->config->method('getSystemValue')->willReturn(NLDesignEMailTemplate::class);
+        $this->config->method('getSystemValueBool')->willReturn(false);
+        $this->config->expects($this->once())->method('deleteSystemValue')->with('mail_template_class');
+
+        $this->service->disable();
+    }//end testDisableDeletesSystemValue()
+
+    /**
+     * Enabling never clobbers a foreign mail_template_class — it throws instead.
+     *
+     * @return void
+     */
+    public function testEnableThrowsOnForeignClass(): void
+    {
+        $this->config->method('getSystemValue')->willReturn('OCA\\Enterprise\\Mail\\CustomTemplate');
+        $this->config->method('getSystemValueBool')->willReturn(false);
+        $this->config->expects($this->never())->method('setSystemValue');
+
+        $this->expectException(ForeignMailTemplateClassException::class);
+        $this->service->enable();
+    }//end testEnableThrowsOnForeignClass()
+
+    /**
+     * A read-only config.php (via the config_is_read_only flag) throws
+     * before attempting the write.
+     *
+     * @return void
+     */
+    public function testEnableThrowsOnReadOnlyFlag(): void
+    {
+        $this->config->method('getSystemValue')->willReturn('');
+        $this->config->method('getSystemValueBool')->willReturn(true);
+        $this->config->expects($this->never())->method('setSystemValue');
+
+        $this->expectException(ConfigReadOnlyException::class);
+        $this->service->enable();
+    }//end testEnableThrowsOnReadOnlyFlag()
+
+    /**
+     * A filesystem-level read-only config.php the flag missed still throws
+     * the typed exception, via the caught HintException from the write path.
+     *
+     * @return void
+     */
+    public function testEnableThrowsOnReadOnlyHintExceptionFromWrite(): void
+    {
+        $this->config->method('getSystemValue')->willReturn('');
+        $this->config->method('getSystemValueBool')->willReturn(false);
+        $this->config->method('setSystemValue')->willThrowException(new HintException('read-only', 'hint'));
+
+        $this->expectException(ConfigReadOnlyException::class);
+        $this->service->enable();
+    }//end testEnableThrowsOnReadOnlyHintExceptionFromWrite()
+
+    /**
+     * Disabling a foreign class is a no-op — nldesign never touches it.
+     *
+     * @return void
+     */
+    public function testDisableLeavesForeignClassUntouched(): void
+    {
+        $this->config->method('getSystemValue')->willReturn('OCA\\Enterprise\\Mail\\CustomTemplate');
+        $this->config->method('getSystemValueBool')->willReturn(false);
+        $this->config->expects($this->never())->method('deleteSystemValue');
+
+        $this->service->disable();
+    }//end testDisableLeavesForeignClassUntouched()
+
+    /**
+     * A javascript: scheme URL is rejected before anything is persisted.
+     *
+     * @return void
+     */
+    public function testFooterUrlValidationRejectsJavascriptScheme(): void
+    {
+        $this->config->expects($this->never())->method('setAppValue');
+
+        $this->expectException(FooterValidationException::class);
+        $this->service->setFooterConfig('Org', 'javascript:alert(1)', '');
+    }//end testFooterUrlValidationRejectsJavascriptScheme()
+
+    /**
+     * Non-URL junk is rejected.
+     *
+     * @return void
+     */
+    public function testFooterUrlValidationRejectsJunk(): void
+    {
+        $this->expectException(FooterValidationException::class);
+        $this->service->setFooterConfig('Org', 'not a url', '');
+    }//end testFooterUrlValidationRejectsJunk()
+
+    /**
+     * Valid http(s) URLs are accepted and persisted.
+     *
+     * @return void
+     */
+    public function testFooterUrlValidationAcceptsHttpsAndPersists(): void
+    {
+        $this->config->expects($this->exactly(3))->method('setAppValue');
+        $this->config->method('getAppValue')->willReturnCallback(
+            fn ($app, $key, $default) => match ($key) {
+                'email_footer_org_name' => 'Org',
+                'email_footer_accessibility_url' => 'https://example.org/a11y',
+                'email_footer_privacy_url' => 'https://example.org/privacy',
+                default => $default,
+            }
+        );
+
+        $result = $this->service->setFooterConfig('Org', 'https://example.org/a11y', 'https://example.org/privacy');
+
+        $this->assertSame('Org', $result['orgName']);
+        $this->assertSame('https://example.org/a11y', $result['accessibilityUrl']);
+        $this->assertSame('https://example.org/privacy', $result['privacyUrl']);
+    }//end testFooterUrlValidationAcceptsHttpsAndPersists()
+
+    /**
+     * Empty URL values are always valid (omitted, never validated as a scheme).
+     *
+     * @return void
+     */
+    public function testFooterUrlValidationAllowsEmptyValues(): void
+    {
+        $this->config->method('getAppValue')->willReturn('');
+        $result = $this->service->setFooterConfig('', '', '');
+        $this->assertSame('', $result['accessibilityUrl']);
+    }//end testFooterUrlValidationAllowsEmptyValues()
+
+    /**
+     * The active token set's manifest theming metadata is used verbatim
+     * when present, and the logo resolves to an absolute URL.
+     *
+     * @return void
+     */
+    public function testGetActiveEmailThemeReturnsManifestTheming(): void
+    {
+        $this->config->method('getAppValue')->willReturnCallback(
+            fn ($app, $key, $default) => ($key === 'token_set') ? 'amsterdam' : $default
+        );
+        $this->tokenSetService->method('getAvailableTokenSets')->willReturn(
+            [
+                [
+                    'id'      => 'amsterdam',
+                    'theming' => ['primary_color' => '#004699', 'logo' => 'img/logos/amsterdam.svg'],
+                ],
+            ]
+        );
+        $this->urlGenerator->method('imagePath')->with('nldesign', 'logos/amsterdam.svg')
+            ->willReturn('/apps/nldesign/img/logos/amsterdam.svg');
+        $this->urlGenerator->method('getAbsoluteURL')->willReturnCallback(
+            fn (string $url) => 'https://cloud.example.com'.$url
+        );
+
+        $theme = $this->service->getActiveEmailTheme();
+
+        $this->assertNotNull($theme);
+        $this->assertSame('#004699', $theme['primaryColor']);
+        $this->assertSame('#ffffff', $theme['primaryTextColor']);
+        $this->assertSame('https://cloud.example.com/apps/nldesign/img/logos/amsterdam.svg', $theme['logoUrl']);
+    }//end testGetActiveEmailThemeReturnsManifestTheming()
+
+    /**
+     * A token set without a `theming` block falls back to
+     * TokenSetPreviewService::getResolvedColors().
+     *
+     * @return void
+     */
+    public function testGetActiveEmailThemeFallsBackToResolvedColorsWithoutTheming(): void
+    {
+        $this->config->method('getAppValue')->willReturnCallback(
+            fn ($app, $key, $default) => ($key === 'token_set') ? 'utrecht-custom' : $default
+        );
+        $this->tokenSetService->method('getAvailableTokenSets')->willReturn([['id' => 'utrecht-custom']]);
+        $this->previewService->method('getResolvedColors')->willReturn(
+            [
+                '--color-primary'      => '#24578F',
+                '--color-primary-text' => '#ffffff',
+            ]
+        );
+
+        $theme = $this->service->getActiveEmailTheme();
+
+        $this->assertNotNull($theme);
+        $this->assertSame('#24578F', $theme['primaryColor']);
+        $this->assertSame('#ffffff', $theme['primaryTextColor']);
+        $this->assertNull($theme['logoUrl']);
+    }//end testGetActiveEmailThemeFallsBackToResolvedColorsWithoutTheming()
+
+    /**
+     * The stock `nextcloud` token set (unthemed) resolves to null.
+     *
+     * @return void
+     */
+    public function testGetActiveEmailThemeReturnsNullForNextcloud(): void
+    {
+        $this->config->method('getAppValue')->willReturnCallback(
+            fn ($app, $key, $default) => ($key === 'token_set') ? 'nextcloud' : $default
+        );
+
+        $this->assertNull($this->service->getActiveEmailTheme());
+    }//end testGetActiveEmailThemeReturnsNullForNextcloud()
+}//end class

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,27 @@ spl_autoload_register(static function (string $class): void {
     }
 });
 
+// Server-internal `OC\` classes (e.g. OC\Mail\EMailTemplate, extended by
+// lib/Mail/NLDesignEMailTemplate.php) are not part of the nextcloud/ocp dev
+// dependency — there is no public stub package for private-namespace code.
+// When the full Nextcloud server IS mounted (real environment, or a
+// standalone container with the server's lib/private/ bind-mounted at
+// /var/www/html/lib/private per the fleet-standard phpunit invocation), fall
+// back to loading the class directly from there. Absent that mount this is a
+// silent no-op — mirrors the OCP/NCU registration above, and any test that
+// actually needs the class simply fails with a clear "class not found"
+// rather than the bootstrap itself failing.
+spl_autoload_register(static function (string $class): void {
+    if (str_starts_with($class, 'OC\\') === false) {
+        return;
+    }
+
+    $path = '/var/www/html/lib/private/' . str_replace('\\', '/', substr($class, strlen('OC\\'))) . '.php';
+    if (is_file($path) === true) {
+        require_once $path;
+    }
+});
+
 if (!defined('OC_CONSOLE')) {
     if (file_exists(__DIR__ . '/../../../lib/base.php')) {
         require_once __DIR__ . '/../../../lib/base.php';


### PR DESCRIPTION
## What

Adds `OCA\NLDesign\Mail\NLDesignEMailTemplate`, extending the server's private
`OC\Mail\EMailTemplate` via the platform's own sanctioned `mail_template_class`
system-config hook (`OC\Mail\Mailer::makeTemplate()`). Header/button colors and
logo derive from the active NL Design token set (manifest `theming` metadata
first, `TokenSetPreviewService::getResolvedColors()` fallback), with total
fallback to stock rendering on any resolution failure — a theming bug can
never block mail. Adds a configurable compliance footer (organization name,
toegankelijkheidsverklaring URL, privacy URL), rendered in both the HTML and
plain-text parts, output-encoded.

## Why

"Emails with wrong/giant logo" is a named end-user pain point, and Nextcloud's
own enterprise docs answer deep mail branding with "write a custom app" — this
ships that app-level implementation using the server's documented extension
point, off by default.

## How

- `lib/Mail/NLDesignEMailTemplate.php` — the branded template; lazily resolves
  nldesign services via `\OCP\Server::get()` inside `try/catch`, never in the
  (fixed-signature) constructor.
- `lib/Service/EmailThemingService.php` — footer config (URL-scheme validated,
  max 2048 chars), and the `mail_template_class` toggle: never clobbers a
  foreign class (typed exception), structured 409 + exact `occ` commands when
  config.php is read-only (both the `config_is_read_only` flag and a caught
  `\OCP\HintException` from the write path).
- `SettingsController::getEmailTheming()`/`setEmailTheming()` +
  `appinfo/routes.php` — admin-only endpoints; footer is applied first and
  independently of the toggle, so it always saves even when the toggle fails.
- Admin panel section (`templates/settings/admin.php` + `js/admin.js`) —
  checkbox + three footer fields, occ-command hint block on read-only,
  foreign-class note. English-keyed i18n + Dutch translations in `l10n/`.
- `psalm.xml` — added `OC\Mail\EMailTemplate`/`OC\Mail\Mailer` to the existing
  server-internal `UndefinedClass` suppression list (same pattern already used
  for `OCA\Theming\*`).

Tests: **21 new PHPUnit tests** (5 template rendering incl. a byte-identical
stock-fallback proof, 13 service, 3 controller) — full suite **113 tests /
1391 assertions**, all green in the `nextcloud:34.0.0-apache` container.
`composer check:strict`: lint/phpcs/phpmd clean, **psalm: "No errors
found!"**, phpstan's one remaining finding is the same *pre-existing,
by-design-unfixable* "extends unknown class" shape already present for
`HealthController`'s cross-app extends (PHPStan disallows ignoring that error
category; the composer `phpstan` script degrades to a warning by design) —
not a new defect.

Deferred to post-merge live verification on the 8080 instance (documented in
`tasks.md` 5.2-5.4, unchecked with a reason):
- Branded mail rendering end-to-end with the `amsterdam` token set + a local
  SMTP catcher.
- The read-only `config.php` negative path (409 + manual `occ` recovery).
- The app-disabled fallback proof (`occ app:disable nldesign` → stock mail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)