### PR TITLE
fix(quality): analyzer reconciliation for email-template-theming under strict gates

### DIFF
--- a/lib/Mail/NLDesignEMailTemplate.php
+++ b/lib/Mail/NLDesignEMailTemplate.php
@@ -63,6 +63,10 @@ class NLDesignEMailTemplate extends EMailTemplate
      * @return EmailThemingService|null The service, or null on any failure.
      *
      * @spec openspec/specs/email-theming/spec.md
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) - Mailer::makeTemplate() constructs this class with a
+     * fixed argument list, so constructor injection is impossible; \OCP\Server::get() is the
+     * sanctioned lazy-resolution seam here.
      */
     protected function getEmailThemingService(): ?EmailThemingService
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,10 @@ parameters:
         # which is absent during static analysis. phpstan refuses to ignore
         # "extends unknown class" via ignoreErrors and mandates excludePaths.
         - lib/Controller/HealthController.php
+        # Extends the server-private OC\Mail\EMailTemplate (the sanctioned
+        # mail_template_class hook) — same "extends unknown class" shape as
+        # HealthController; behavior is covered by tests/Unit/Mail/.
+        - lib/Mail/NLDesignEMailTemplate.php
         # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuild).
         - lib/Resources/template
     scanDirectories:


### PR DESCRIPTION
PR #151 was built before #150 made analyzer exit codes honest. Adds the phpstan excludePaths entry for lib/Mail/NLDesignEMailTemplate.php (extends server-private OC\Mail\EMailTemplate — same shape as HealthController; behavior covered by 21 unit tests) and a reasoned PHPMD StaticAccess suppression for the sanctioned Server::get seam. check:strict fully green again; 130 tests pass in-container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)