### PR TITLE
refactor(theming): move CSS injection from boot() to render events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+- Style injection moved from `Application::boot()` (every request) to a `ThemeInjectionListener` on `BeforeTemplateRenderedEvent`/`BeforeLoginTemplateRenderedEvent` (only actual template renders) — same stylesheets, same cascade order, same excluded-app behavior by default. Adds an occ-only `themed_contexts` appconfig key to selectively unthemed a render context (`user`/`login`/`guest`/`public`/`error`); absent (the default) themes every context exactly as before. See `openspec/changes/render-event-injection/`.
+
 ### Security
 - Hardened `CustomTokenSetValidator::isForbiddenValue()` to reject declaration values containing a semicolon (`;`) or a CSS comment marker (`/*`, `*/`), closing a CSS-injection gap where a single accepted `--nldesign-*`/`--{slug}-*` declaration's value could smuggle an arbitrary extra declaration (e.g. `background: url(...)`) past the name whitelist into the `:root {}` block served to every anonymous visitor (login page, share links). Applies to both the CSS upload path and the W3C Design Tokens JSON path (`CustomTokenSetController::mapFromJson()`), which shares the same gate. Only new uploads are affected — a custom token set uploaded before this fix is not retroactively re-validated; the served `custom-*.css` file for an existing set is unchanged until it is re-uploaded. See `openspec/changes/harden-custom-token-set-value-validation/`.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ on air-gapped government instances.
 Free and open source under the EUPL-1.2 license.
 Gratis en open source onder de EUPL-1.2 licentie.
 	]]></description>
-	<version>0.1.3-unstable.14</version>
+	<version>0.1.3-unstable.15</version>
 	<licence>EUPL-1.2</licence>
 	<author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
 	<namespace>NLDesign</namespace>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -15,6 +15,7 @@
  *
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-1
  * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-2
+ * @spec openspec/changes/render-event-injection/tasks.md#task-3.1
  */
 
 declare(strict_types=1);
@@ -22,16 +23,13 @@ declare(strict_types=1);
 namespace OCA\NLDesign\AppInfo;
 
 use OCA\NLDesign\Capabilities;
-use OCA\NLDesign\Service\AppThemingService;
-use OCA\NLDesign\Service\CustomOverridesService;
-use OCA\NLDesign\Service\DesignSystemService;
-use OCA\NLDesign\Service\FontService;
-use OCA\NLDesign\Themes\NLDesignTheme;
+use OCA\NLDesign\Listener\ThemeInjectionListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\IURLGenerator;
+use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 
 /**
  * Main application class for NL Design.
@@ -70,11 +68,21 @@ class Application extends App implements IBootstrap
      * first real `register()`-time registration — so the huisstijl is exposed
      * on every capabilities document without any request-time cost.
      *
+     * `ThemeInjectionListener` is registered for both `BeforeTemplateRenderedEvent`
+     * and `BeforeLoginTemplateRenderedEvent` — style injection is event-driven,
+     * not boot-driven (see `openspec/changes/render-event-injection`).
+     * `registerEventListener()` registers a lazy service: the listener (and its
+     * whole service graph — config, design system, custom overrides, fonts) is
+     * only instantiated when one of these two events actually fires, so
+     * requests that render no template (WebDAV, OCS/API, cron) never pay for
+     * it.
+     *
      * @param IRegistrationContext $context The registration context.
      *
      * @return void
      *
      * @spec openspec/changes/adopt-apphost-2026-06-16/tasks.md#task-2
+     * @spec openspec/changes/render-event-injection/tasks.md#task-3.1
      * @spec openspec/specs/theming-capability/spec.md
      */
     public function register(IRegistrationContext $context): void
@@ -83,139 +91,30 @@ class Application extends App implements IBootstrap
         // subclass of the AppHost engine — no explicit registration needed.
         // Public huisstijl capability — see lib/Capabilities.php.
         $context->registerCapability(Capabilities::class);
+
+        // Event-driven CSS injection — see lib/Listener/ThemeInjectionListener.php.
+        $context->registerEventListener(BeforeTemplateRenderedEvent::class, ThemeInjectionListener::class);
+        $context->registerEventListener(BeforeLoginTemplateRenderedEvent::class, ThemeInjectionListener::class);
     }//end register()
 
     /**
      * Boot the application.
      *
-     * @param IBootContext $context The boot context.
+     * Intentionally a no-op: `IBootstrap` requires the method, but style
+     * injection is entirely event-driven since
+     * `openspec/changes/render-event-injection` — see
+     * `lib/Listener/ThemeInjectionListener.php` and
+     * `lib/Service/CssInjectionService.php`.
+     *
+     * @param IBootContext $context The boot context (unused — kept only to satisfy the IBootstrap signature).
      *
      * @return void
      *
-     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-1
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) - IBootstrap::boot() mandates this exact signature
+     *
+     * @spec openspec/changes/render-event-injection/tasks.md#task-3.2
      */
     public function boot(IBootContext $context): void
     {
-        $serverContainer = $context->getServerContainer();
-
-        // Inject our CSS variables.
-        $this->injectThemeCSS(serverContainer: $serverContainer);
     }//end boot()
-
-    /**
-     * Inject theme CSS files based on configuration.
-     *
-     * @param mixed $serverContainer The server container.
-     *
-     * @return void
-     *
-     * @SuppressWarnings(PHPMD.StaticAccess) - \OCP\Util::addStyle() is the Nextcloud API for CSS injection
-     *
-     * @spec openspec/changes/retrofit-2026-05-24-annotate-nldesign/tasks.md#task-2
-     * @spec openspec/specs/custom-fonts/spec.md
-     */
-    private function injectThemeCSS($serverContainer): void
-    {
-        // Per-app theming guard: if the app currently being rendered is in the
-        // admin's exclusion list, skip ALL nldesign style injection so its pages
-        // render as stock Nextcloud. Resolution failures (occ/cron, no path info)
-        // fail open to themed — theming is presentation, never security.
-        if ($this->isThemingDisabled(serverContainer: $serverContainer) === true) {
-            return;
-        }
-
-        $config         = $serverContainer->get(\OCP\IConfig::class);
-        $tokenSet       = $config->getAppValue(self::APP_ID, 'token_set', 'nextcloud');
-        $hideSlogan     = $config->getAppValue(self::APP_ID, 'hide_slogan', '0') === '1';
-        $showMenuLabels = $config->getAppValue(self::APP_ID, 'show_menu_labels', '0') === '1';
-
-        // 1. Resolve which design system this token set uses.
-        $dsService      = $serverContainer->get(DesignSystemService::class);
-        $tokenSetMeta   = $dsService->getTokenSetMeta($tokenSet);
-        $designSystemId = $tokenSetMeta['design_system'] ?? 'nldesign';
-        $designSystem   = $dsService->getDesignSystem($designSystemId);
-
-        // 2. Load design system stylesheets in declared order.
-        // For "none" (stock Nextcloud) this array is empty — no CSS loads.
-        foreach ($designSystem['stylesheets'] as $stylesheet) {
-            \OCP\Util::addStyle(application: self::APP_ID, file: $stylesheet);
-        }
-
-        // 3. Load token values (only when a design system reads --nldesign-* vars).
-        if ($designSystemId !== 'none') {
-            \OCP\Util::addStyle(application: self::APP_ID, file: 'tokens/'.$tokenSet);
-            // Functional contrast fix shared by all design systems: app icons
-            // that carry their white fill on <path> vanish on light surfaces
-            // in the NC 34 app-management list (see css/icon-contrast.css).
-            \OCP\Util::addStyle(application: self::APP_ID, file: 'icon-contrast');
-            // Functional contrast fix shared by all design systems: our error
-            // fill is a saturated brand red where Nextcloud's is pale, so the
-            // components painting --color-error-text on it lose all contrast
-            // (see css/error-contrast.css).
-            \OCP\Util::addStyle(application: self::APP_ID, file: 'error-contrast');
-        }
-
-        // 4. Custom overrides — admin-defined token overrides, always loaded last.
-        $customOverridesSvc = $serverContainer->get(CustomOverridesService::class);
-        $customOverridesSvc->ensureExists();
-        \OCP\Util::addStyle(application: self::APP_ID, file: 'custom-overrides');
-
-        // 4.5 Custom fonts — admin-uploaded, self-hosted webfonts. Injected as
-        // a <link rel="stylesheet"> (not \OCP\Util::addStyle(), because the
-        // CSS is generated dynamically by FontController::css(), not a static
-        // file under css/) AFTER the token-set styles so the font tokens win
-        // the cascade, and only when at least one font is configured, so a
-        // themed instance with zero uploaded fonts issues no extra request.
-        if ($designSystemId !== 'none') {
-            $fontService = $serverContainer->get(FontService::class);
-            if ($fontService->hasFonts() === true) {
-                $urlGenerator = $serverContainer->get(IURLGenerator::class);
-                $cssUrl       = $urlGenerator->linkToRoute('nldesign.font.css').'?v='.$fontService->getRevision();
-                \OCP\Util::addHeader(
-                    tag: 'link',
-                    attributes: [
-                        'rel'  => 'stylesheet',
-                        'href' => $cssUrl,
-                    ]
-                );
-            }
-        }
-
-        // 5. Conditional stylesheets.
-        if ($hideSlogan === true) {
-            \OCP\Util::addStyle(application: self::APP_ID, file: 'hide-slogan');
-        }
-
-        if ($showMenuLabels === true) {
-            \OCP\Util::addStyle(application: self::APP_ID, file: 'show-menu-labels');
-        }
-    }//end injectThemeCSS()
-
-    /**
-     * Resolve whether theming must be skipped for the request being rendered.
-     *
-     * Reads the request path, resolves the app id, and consults the exclusion
-     * list. Wrapped in a try/catch so any resolution failure (CLI/occ, cron, an
-     * unavailable request) fails open to themed.
-     *
-     * @param mixed $serverContainer The server container.
-     *
-     * @return bool True when nldesign style injection must be skipped.
-     *
-     * @spec openspec/changes/per-app-theming-toggle/tasks.md#task-2.1
-     */
-    private function isThemingDisabled($serverContainer): bool
-    {
-        try {
-            $appTheming = $serverContainer->get(AppThemingService::class);
-            $request    = $serverContainer->get(\OCP\IRequest::class);
-            $appId      = $appTheming->resolveAppIdFromPath(pathInfo: $request->getPathInfo());
-
-            return $appTheming->isThemingDisabledFor(appId: $appId);
-        } catch (\Throwable $e) {
-            // Fail open: presentation, not security — a broken resolve must not
-            // strip theming everywhere, nor crash the boot path.
-            return false;
-        }
-    }//end isThemingDisabled()
 }//end class

--- a/lib/Listener/ThemeInjectionListener.php
+++ b/lib/Listener/ThemeInjectionListener.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * NL Design Theme Injection Listener.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Listener
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/nldesign
+ *
+ * @spec openspec/specs/css-architecture/spec.md
+ * @spec openspec/specs/per-app-theming/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Listener;
+
+use OCA\NLDesign\Service\AppThemingService;
+use OCA\NLDesign\Service\CssInjectionService;
+use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IRequest;
+use Throwable;
+
+/**
+ * Injects nldesign CSS on render events instead of at `Application::boot()`.
+ *
+ * Registered in `Application::register()` for both
+ * `BeforeTemplateRenderedEvent` and `BeforeLoginTemplateRenderedEvent` — the
+ * same two events Nextcloud core's own `ThemeInjectionService` uses. For a
+ * `BeforeTemplateRenderedEvent` the response's `renderAs` is mapped to a
+ * render context, the per-app exclusion guard runs (resolved from
+ * `TemplateResponse::getApp()`, falling back to the request path), and
+ * `CssInjectionService::inject()` is called for that context. For
+ * `BeforeLoginTemplateRenderedEvent` the context is always `login` and the
+ * per-app guard never runs — login is never an app page. Any failure inside
+ * `handle()` is caught so a broken listener can never break page rendering
+ * (theming is presentation, never a hard dependency).
+ *
+ * @template-implements IEventListener<Event>
+ *
+ * @spec openspec/specs/css-architecture/spec.md
+ * @spec openspec/specs/per-app-theming/spec.md
+ */
+class ThemeInjectionListener implements IEventListener
+{
+
+    /**
+     * The CSS injection service.
+     *
+     * @var CssInjectionService
+     */
+    private CssInjectionService $cssInjectionService;
+
+    /**
+     * Resolves the per-app theming exclusion guard.
+     *
+     * @var AppThemingService
+     */
+    private AppThemingService $appThemingService;
+
+    /**
+     * The current request, used only as the per-app guard's path fallback.
+     *
+     * @var IRequest
+     */
+    private IRequest $request;
+
+    /**
+     * Constructor.
+     *
+     * @param CssInjectionService $cssInjectionService The CSS injection service.
+     * @param AppThemingService   $appThemingService   The per-app theming guard resolver.
+     * @param IRequest            $request             The current request.
+     */
+    public function __construct(
+        CssInjectionService $cssInjectionService,
+        AppThemingService $appThemingService,
+        IRequest $request
+    ) {
+        $this->cssInjectionService = $cssInjectionService;
+        $this->appThemingService   = $appThemingService;
+        $this->request = $request;
+    }//end __construct()
+
+    /**
+     * Handle a render event by injecting nldesign CSS for its context.
+     *
+     * @param Event $event The dispatched event.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/css-architecture/spec.md
+     * @spec openspec/specs/per-app-theming/spec.md
+     */
+    public function handle(Event $event): void
+    {
+        try {
+            if ($event instanceof BeforeLoginTemplateRenderedEvent) {
+                // Login is never an app page — the per-app guard never runs.
+                $this->cssInjectionService->inject(context: 'login');
+                return;
+            }
+
+            if ($event instanceof BeforeTemplateRenderedEvent) {
+                $response = $event->getResponse();
+
+                if ($this->isThemingDisabledForResponse(response: $response) === true) {
+                    return;
+                }
+
+                $this->cssInjectionService->inject(context: $this->resolveContext(response: $response));
+            }
+        } catch (Throwable $e) {
+            // Fail open: a listener failure must never break page rendering
+            // (theming is presentation, never a hard dependency).
+        }
+    }//end handle()
+
+    /**
+     * Map a `TemplateResponse`'s `renderAs` to a render context.
+     *
+     * Any value outside the four mapped `renderAs` constants (e.g. `blank`,
+     * `base`, or a future value) is passed through unchanged — it is not one
+     * of `CssInjectionService::VALID_CONTEXTS`, so injection always proceeds
+     * as themed for it regardless of the `themed_contexts` configuration
+     * (forward-compatibility fail-open, see design.md §2).
+     *
+     * @param TemplateResponse $response The response being rendered.
+     *
+     * @return string The resolved render context.
+     *
+     * @spec openspec/specs/css-architecture/spec.md
+     */
+    private function resolveContext(TemplateResponse $response): string
+    {
+        $renderAs = $response->getRenderAs();
+
+        return match ($renderAs) {
+            TemplateResponse::RENDER_AS_USER   => 'user',
+            TemplateResponse::RENDER_AS_GUEST  => 'guest',
+            TemplateResponse::RENDER_AS_PUBLIC => 'public',
+            TemplateResponse::RENDER_AS_ERROR  => 'error',
+            default                            => (string) $renderAs,
+        };
+    }//end resolveContext()
+
+    /**
+     * Resolve whether nldesign styling must be skipped for the app being rendered.
+     *
+     * The app id is resolved primarily from the response's own `getApp()`;
+     * when that is empty or `core` the request path is consulted as a
+     * fallback. Any resolution failure fails open to themed — theming is
+     * presentation, not security.
+     *
+     * @param TemplateResponse $response The response being rendered.
+     *
+     * @return bool True when nldesign style injection must be skipped.
+     *
+     * @spec openspec/specs/per-app-theming/spec.md
+     */
+    private function isThemingDisabledForResponse(TemplateResponse $response): bool
+    {
+        try {
+            $appId = $response->getApp();
+            if ($appId === '' || $appId === 'core') {
+                $appId = $this->appThemingService->resolveAppIdFromPath(pathInfo: $this->request->getPathInfo());
+            }
+
+            return $this->appThemingService->isThemingDisabledFor(appId: $appId);
+        } catch (Throwable $e) {
+            // Fail open: presentation, not security — a broken resolve must
+            // not strip theming everywhere, nor crash the render path.
+            return false;
+        }
+    }//end isThemingDisabledForResponse()
+}//end class

--- a/lib/Service/CssInjectionService.php
+++ b/lib/Service/CssInjectionService.php
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * NL Design CSS Injection Service.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category  Service
+ * @package   OCA\NLDesign
+ * @author    Conduction <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/nldesign
+ *
+ * @spec openspec/specs/css-architecture/spec.md
+ * @spec openspec/specs/custom-fonts/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Service;
+
+use OCA\NLDesign\AppInfo\Application;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+
+/**
+ * Injects the nldesign stylesheet cascade for a themed render context.
+ *
+ * The body of {@see inject()} is the former `Application::injectThemeCSS()`
+ * moved verbatim (css-architecture layers 1-8 + conditionals, including the
+ * custom-font stylesheet link added by the custom-font-upload change), now
+ * driven by render events instead of `Application::boot()` — see
+ * `openspec/changes/render-event-injection`. The only behavior addition is
+ * context gating via the `themed_contexts` appconfig key; every stylesheet,
+ * its cascade position, and its loading condition are otherwise unchanged.
+ *
+ * The two `\OCP\Util::addStyle()` / `\OCP\Util::addHeader()` calls are
+ * wrapped in the protected `emitStyle()` / `emitFontLink()` seams purely so
+ * unit tests can assert the exact stylesheet sequence via a partial mock —
+ * the real static calls delegate to the server-private `\OC_Util`, which is
+ * not resolvable outside a full Nextcloud bootstrap. Production code always
+ * runs through these two one-line wrappers, so no behavior changes.
+ *
+ * @spec openspec/specs/css-architecture/spec.md
+ */
+class CssInjectionService
+{
+
+    /**
+     * The appconfig key holding the JSON render-context allow-list.
+     *
+     * @var string
+     */
+    private const THEMED_CONTEXTS_KEY = 'themed_contexts';
+
+    /**
+     * The render-context names the `themed_contexts` allow-list recognizes.
+     *
+     * Any other context value (e.g. an unmapped/future `renderAs`) always
+     * fails open to themed — see {@see isContextThemed()}.
+     *
+     * @var string[]
+     */
+    private const VALID_CONTEXTS = ['user', 'login', 'guest', 'public', 'error'];
+
+    /**
+     * The application configuration service.
+     *
+     * @var IConfig
+     */
+    private IConfig $config;
+
+    /**
+     * Resolves which design system a token set uses and its stylesheet order.
+     *
+     * @var DesignSystemService
+     */
+    private DesignSystemService $designSystemService;
+
+    /**
+     * Ensures the custom-overrides.css file exists before it is loaded.
+     *
+     * @var CustomOverridesService
+     */
+    private CustomOverridesService $overridesService;
+
+    /**
+     * Resolves admin-uploaded custom fonts.
+     *
+     * @var FontService
+     */
+    private FontService $fontService;
+
+    /**
+     * Builds the URL to the generated custom-fonts stylesheet route.
+     *
+     * @var IURLGenerator
+     */
+    private IURLGenerator $urlGenerator;
+
+    /**
+     * Constructor.
+     *
+     * @param IConfig                $config              The config service.
+     * @param DesignSystemService    $designSystemService The design system resolver.
+     * @param CustomOverridesService $overridesService    The custom overrides file service.
+     * @param FontService            $fontService         The custom font resolver.
+     * @param IURLGenerator          $urlGenerator        The URL generator.
+     */
+    public function __construct(
+        IConfig $config,
+        DesignSystemService $designSystemService,
+        CustomOverridesService $overridesService,
+        FontService $fontService,
+        IURLGenerator $urlGenerator
+    ) {
+        $this->config = $config;
+        $this->designSystemService = $designSystemService;
+        $this->overridesService    = $overridesService;
+        $this->fontService         = $fontService;
+        $this->urlGenerator        = $urlGenerator;
+    }//end __construct()
+
+    /**
+     * Inject the full nldesign stylesheet cascade for a render context.
+     *
+     * A no-op when the context is gated out by the `themed_contexts`
+     * appconfig (see {@see isContextThemed()}). Otherwise this is the
+     * verbatim former `Application::injectThemeCSS()` body: design-system
+     * stylesheets in declared order, token set CSS, icon/error contrast
+     * fixes, custom overrides, custom fonts, then conditional
+     * hide-slogan/show-menu-labels stylesheets.
+     *
+     * @param string $context One of `user`/`login`/`guest`/`public`/`error`,
+     *                        or any other value (always themed — fail open).
+     *
+     * @return void
+     *
+     * @spec openspec/specs/css-architecture/spec.md
+     * @spec openspec/specs/custom-fonts/spec.md
+     */
+    public function inject(string $context): void
+    {
+        if ($this->isContextThemed(context: $context) === false) {
+            return;
+        }
+
+        $tokenSet       = $this->config->getAppValue(Application::APP_ID, 'token_set', 'nextcloud');
+        $hideSlogan     = $this->config->getAppValue(Application::APP_ID, 'hide_slogan', '0') === '1';
+        $showMenuLabels = $this->config->getAppValue(Application::APP_ID, 'show_menu_labels', '0') === '1';
+
+        // 1. Resolve which design system this token set uses.
+        $tokenSetMeta   = $this->designSystemService->getTokenSetMeta(tokenSetId: $tokenSet);
+        $designSystemId = $tokenSetMeta['design_system'] ?? 'nldesign';
+        $designSystem   = $this->designSystemService->getDesignSystem(id: $designSystemId);
+
+        // 2. Load design system stylesheets in declared order.
+        // For "none" (stock Nextcloud) this array is empty — no CSS loads.
+        foreach ($designSystem['stylesheets'] as $stylesheet) {
+            $this->emitStyle(file: $stylesheet);
+        }
+
+        // 3. Load token values (only when a design system reads --nldesign-* vars).
+        if ($designSystemId !== 'none') {
+            $this->emitStyle(file: 'tokens/'.$tokenSet);
+            // Functional contrast fix shared by all design systems: app icons
+            // that carry their white fill on <path> vanish on light surfaces
+            // in the NC 34 app-management list (see css/icon-contrast.css).
+            $this->emitStyle(file: 'icon-contrast');
+            // Functional contrast fix shared by all design systems: our error
+            // fill is a saturated brand red where Nextcloud's is pale, so the
+            // components painting --color-error-text on it lose all contrast
+            // (see css/error-contrast.css).
+            $this->emitStyle(file: 'error-contrast');
+        }
+
+        // 4. Custom overrides — admin-defined token overrides, always loaded last.
+        $this->overridesService->ensureExists();
+        $this->emitStyle(file: 'custom-overrides');
+
+        // 4.5 Custom fonts — admin-uploaded, self-hosted webfonts. Injected as
+        // a <link rel="stylesheet"> (not \OCP\Util::addStyle(), because the
+        // CSS is generated dynamically by FontController::css(), not a static
+        // file under css/) AFTER the token-set styles so the font tokens win
+        // the cascade, and only when at least one font is configured, so a
+        // themed instance with zero uploaded fonts issues no extra request.
+        if ($designSystemId !== 'none' && $this->fontService->hasFonts() === true) {
+            $cssUrl = $this->urlGenerator->linkToRoute('nldesign.font.css').'?v='.$this->fontService->getRevision();
+            $this->emitFontLink(url: $cssUrl);
+        }
+
+        // 5. Conditional stylesheets.
+        if ($hideSlogan === true) {
+            $this->emitStyle(file: 'hide-slogan');
+        }
+
+        if ($showMenuLabels === true) {
+            $this->emitStyle(file: 'show-menu-labels');
+        }
+    }//end inject()
+
+    /**
+     * Whether a render context must receive nldesign CSS.
+     *
+     * A context outside {@see VALID_CONTEXTS} (an unmapped or future
+     * `renderAs` value) is never gated by configuration — it always resolves
+     * to themed, so a forward-compatibility gap can never silently strip
+     * theming. For a recognized context, an absent, empty, or unparseable
+     * `themed_contexts` value themes ALL contexts (byte-identical to the
+     * previous boot-time injection); a non-empty valid list themes only the
+     * contexts it names.
+     *
+     * @param string $context The render context to check.
+     *
+     * @return bool True when the context must receive nldesign CSS.
+     *
+     * @spec openspec/specs/css-architecture/spec.md
+     */
+    private function isContextThemed(string $context): bool
+    {
+        if (in_array($context, self::VALID_CONTEXTS, true) === false) {
+            return true;
+        }
+
+        $raw     = $this->config->getAppValue(Application::APP_ID, self::THEMED_CONTEXTS_KEY, '[]');
+        $decoded = json_decode($raw, true);
+        if (is_array($decoded) === false || empty($decoded) === true) {
+            return true;
+        }
+
+        return in_array($context, $decoded, true);
+    }//end isContextThemed()
+
+    /**
+     * Emit a static nldesign stylesheet via the Nextcloud style registry.
+     *
+     * @param string $file The stylesheet path relative to `css/` (no extension).
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) - \OCP\Util::addStyle() is the Nextcloud API for CSS injection
+     *
+     * @spec openspec/specs/css-architecture/spec.md
+     */
+    protected function emitStyle(string $file): void
+    {
+        \OCP\Util::addStyle(application: Application::APP_ID, file: $file);
+    }//end emitStyle()
+
+    /**
+     * Emit the dynamically-generated custom-fonts stylesheet as a `<link>`
+     * header (not a static `css/` file, so `Util::addStyle()` cannot serve it).
+     *
+     * @param string $url The absolute URL to the generated fonts CSS route.
+     *
+     * @return void
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) - \OCP\Util::addHeader() is the Nextcloud API for header injection
+     *
+     * @spec openspec/specs/custom-fonts/spec.md
+     */
+    protected function emitFontLink(string $url): void
+    {
+        \OCP\Util::addHeader(
+            tag: 'link',
+            attributes: [
+                'rel'  => 'stylesheet',
+                'href' => $url,
+            ]
+        );
+    }//end emitFontLink()
+}//end class

--- a/openspec/changes/render-event-injection/tasks.md
+++ b/openspec/changes/render-event-injection/tasks.md
@@ -1,20 +1,26 @@
 ## 1. Extract the injection service
 
-- [ ] 1.1 Create `lib/Service/CssInjectionService.php` (SPDX docblock, `@spec` tags): move the
+- [x] 1.1 Create `lib/Service/CssInjectionService.php` (SPDX docblock, `@spec` tags): move the
       body of `Application::injectThemeCSS()` into `inject(string $context): void` with
       constructor-injected `IConfig`, `DesignSystemService`, `CustomOverridesService`. Preserve
       the exact stylesheet order: design-system stylesheets (declared order) → `tokens/{set}` →
       `icon-contrast` → `error-contrast` → `custom-overrides` (after
       `CustomOverridesService::ensureExists()`) → conditional `hide-slogan` /
       `show-menu-labels`. No logic changes beyond parameterization.
-- [ ] 1.2 Implement context gating in the service: read appconfig `themed_contexts` (JSON array;
+      Note: also constructor-injects `FontService` + `IURLGenerator` (omitted from this task's
+      own wording but required by the proposal's explicit instruction to preserve the
+      custom-font stylesheet link — layer 4.5 in the cascade). The two `\OCP\Util::` static
+      calls are wrapped in protected `emitStyle()`/`emitFontLink()` seams purely so unit tests
+      can assert the call sequence via a partial mock (the real static call delegates to
+      `\OC_Util`, unavailable outside a full Nextcloud bootstrap) — no behavior change.
+- [x] 1.2 Implement context gating in the service: read appconfig `themed_contexts` (JSON array;
       recognized values `user`, `login`, `guest`, `public`, `error`). Absent / empty / invalid
       JSON ⇒ all contexts themed. When the given context is not in a valid configured list,
       `inject()` returns without adding any style.
 
 ## 2. Listener
 
-- [ ] 2.1 Create `lib/Listener/ThemeInjectionListener.php` implementing
+- [x] 2.1 Create `lib/Listener/ThemeInjectionListener.php` implementing
       `OCP\EventDispatcher\IEventListener` (SPDX docblock, `@spec` tags), handling:
       - `OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent`: map
         `getResponse()->getRenderAs()` to context (`user`/`guest`/`public`/`error`; any other
@@ -24,29 +30,39 @@
         `inject('login')`.
       Wrap handling in try/catch failing open to no-op (an event listener throwing must never
       break page rendering).
-- [ ] 2.2 Move the per-app guard into the listener: resolve app id primarily from
+      Note: "any other value" is passed through to `inject()` unchanged rather than normalized
+      to `'user'` — `CssInjectionService::VALID_CONTEXTS` only recognizes the five named
+      contexts, so any unmapped/future `renderAs` value automatically fails open to themed
+      regardless of the configured `themed_contexts` list (this is what the ADDED spec
+      requirement "Unknown renderAs values stay themed" actually demands: the list must never
+      be able to strip theming for an unknown value, which mapping to literal `'user'` would
+      have violated whenever `'user'` is excluded).
+- [x] 2.2 Move the per-app guard into the listener: resolve app id primarily from
       `TemplateResponse::getApp()` (ignore empty/`core`), fall back to
       `AppThemingService::resolveAppIdFromPath($request->getPathInfo())`, then consult
       `AppThemingService::isThemingDisabledFor()`; any throwable or unresolved id fails open to
       themed. Update `AppThemingService::resolveAppIdFromPath()` docblock to describe its
       fallback role (no API change).
+      Note: `resolveAppIdFromPath()`'s docblock was already accurate/generic (describes the
+      path-matching contract, not caller identity) — left unchanged; no behavior or API change.
 
 ## 3. Application cleanup
 
-- [ ] 3.1 In `lib/AppInfo/Application.php` `register()`: add
+- [x] 3.1 In `lib/AppInfo/Application.php` `register()`: add
       `$context->registerEventListener(BeforeTemplateRenderedEvent::class, ThemeInjectionListener::class);`
       and `$context->registerEventListener(BeforeLoginTemplateRenderedEvent::class, ThemeInjectionListener::class);`
       with imports; update the docblock.
-- [ ] 3.2 Remove `injectThemeCSS()` and `isThemingDisabled()`; reduce `boot()` to an empty
+- [x] 3.2 Remove `injectThemeCSS()` and `isThemingDisabled()`; reduce `boot()` to an empty
       method with a comment stating injection is event-driven (IBootstrap requires the method).
-- [ ] 3.3 Remove the dead import `use OCA\NLDesign\Themes\NLDesignTheme;` (line 27 — class
+- [x] 3.3 Remove the dead import `use OCA\NLDesign\Themes\NLDesignTheme;` (line 27 — class
       exists nowhere; no `lib/Themes/` directory).
-- [ ] 3.4 Bump `appinfo/info.xml` `<version>` (CSS delivery path changed — bust the `?v=`
-      cache-buster).
+- [x] 3.4 Bump `appinfo/info.xml` `<version>` (CSS delivery path changed — bust the `?v=`
+      cache-buster). Bumped `0.1.3-unstable.14` → `0.1.3-unstable.15`; CHANGELOG.md "Unreleased"
+      section updated.
 
 ## 4. Tests
 
-- [ ] 4.1 New `tests/Unit/Listener/ThemeInjectionListenerTest.php`:
+- [x] 4.1 New `tests/Unit/Listener/ThemeInjectionListenerTest.php`:
       - renderAs `user`/`guest`/`public`/`error` each reach `inject()` with the right context;
       - unknown renderAs (`blank`) still injects (fail-open);
       - login event injects with context `login` and never consults the per-app guard;
@@ -55,40 +71,62 @@
       - non-TemplateResponse events / throwing service ⇒ no exception escapes `handle()`;
       - double dispatch of the same event yields no duplicated `addStyle` effects (idempotency,
         design.md §4).
-- [ ] 4.2 New `tests/Unit/Service/CssInjectionServiceTest.php`: stylesheet order preserved
+      13 tests, incl. the `core`-attributed-response fallback case (task 2.2's second URL form)
+      as an extra beyond the brief's list.
+- [x] 4.2 New `tests/Unit/Service/CssInjectionServiceTest.php`: stylesheet order preserved
       (assert the exact `addStyle` sequence for a `nldesign`-system set, the empty sequence for
       `design_system: none` except token/contrast handling per current behavior, conditional
       hide-slogan/menu-labels); `themed_contexts` gating (absent ⇒ all themed; `["user"]` ⇒
       `login` context injects nothing; invalid JSON ⇒ all themed).
-- [ ] 4.3 Migrate/retire the existing boot-guard unit tests that target
+      14 tests, incl. custom-font-link injection/omission (layer 4.5) and the non-array-JSON
+      fail-open case as extras beyond the brief's list.
+- [x] 4.3 Migrate/retire the existing boot-guard unit tests that target
       `Application::isThemingDisabled()`; keep `AppThemingService` tests unchanged (service API
       untouched).
-- [ ] 4.4 Run `composer check:strict` and the PHP suite in the nextcloud:34 container
+      No pre-existing tests targeted `Application::isThemingDisabled()`/`injectThemeCSS()` to
+      retire — both were private methods with no reflection-based test coverage in the
+      pre-change suite (verified via `grep -rl 'isThemingDisabled\|injectThemeCSS' tests/`).
+      `AppThemingServiceTest.php` is untouched, confirming the service API is unaffected.
+- [x] 4.4 Run `composer check:strict` and the PHP suite in the nextcloud:34 container
       (`docker run --rm -v $PWD:/app -w /app <nc-image> php vendor/bin/phpunit -c phpunit-unit.xml`);
       green.
+      `check:strict`: lint/phpcs/phpmd/psalm/phpstan all green; `test:all` inside `check:strict`
+      dies at suite-load time on the pre-existing, unrelated `OC\Mail\EMailTemplate` gap
+      (`tests/Unit/Mail/NLDesignEMailTemplateTest.php`) — documented harness limitation, not a
+      regression from this change (reproduced identically on `development` before this change).
+      Running only the new + an existing unaffected suite in the nextcloud:34.0.0-apache
+      container (excluding the blocked Mail test file) is fully green: 43 tests, 65 assertions.
 
 ## 5. Verify (regression — all surfaces still receive the stylesheets)
 
 - [ ] 5.1 Deploy to the 8080 dev instance with an active token set (e.g. `rijkshuisstijl`);
       restart apache in the container (`apachectl -k restart`) so opcache picks up the change.
+      (deferred to post-merge live verification)
 - [ ] 5.2 Login page: `curl -sL http://localhost:8080/login | grep -c "apps/nldesign/css"` ≥ 1,
       and the matched links include the design-system and token stylesheets (compare the link
       set against a pre-change capture — must be identical).
+      (deferred to post-merge live verification)
 - [ ] 5.3 User page: authenticated curl (admin session cookie or basic auth)
       `curl -su admin:admin -L http://localhost:8080/index.php/apps/files/ | grep -c "apps/nldesign/css"`
       ≥ 1 with the same link set as pre-change.
+      (deferred to post-merge live verification)
 - [ ] 5.4 Public share page: create a public share link for a file (occ or UI), then
       unauthenticated `curl -sL http://localhost:8080/s/<token> | grep -c "apps/nldesign/css"`
       ≥ 1.
+      (deferred to post-merge live verification)
 - [ ] 5.5 Per-app exclusion regression: exclude `calendar` in the admin panel, confirm
       authenticated curl of `/index.php/apps/calendar/` contains NO `apps/nldesign/css` link
       while `/index.php/apps/files/` still does; re-enable afterwards.
+      (deferred to post-merge live verification)
 - [ ] 5.6 API-surface negative check: `curl -su admin:admin http://localhost:8080/ocs/v2.php/cloud/capabilities -H "OCS-APIRequest: true"`
       succeeds and server logs show no nldesign listener errors (`docker logs`/nextcloud.log
       grep `nldesign`).
+      (deferred to post-merge live verification)
 - [ ] 5.7 Browser check on 8080 (browser-1): visually confirm login page, Files, and the public
       share page render themed (header color, fonts, logo/lint) identically to before the
       change; screenshot each.
+      (deferred to post-merge live verification)
 - [ ] 5.8 Context gating smoke test: `occ config:app:set nldesign themed_contexts --value='["user","login","guest","error"]'`,
       reload the public share page → unthemed; delete the key
       (`occ config:app:delete nldesign themed_contexts`) → themed again.
+      (deferred to post-merge live verification)

--- a/tests/Unit/Listener/ThemeInjectionListenerTest.php
+++ b/tests/Unit/Listener/ThemeInjectionListenerTest.php
@@ -1,0 +1,260 @@
+<?php
+
+/**
+ * Unit tests for ThemeInjectionListener.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @spec openspec/changes/render-event-injection/tasks.md#task-4.1
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit\Listener;
+
+use OCA\NLDesign\Listener\ThemeInjectionListener;
+use OCA\NLDesign\Service\AppThemingService;
+use OCA\NLDesign\Service\CssInjectionService;
+use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
+use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\EventDispatcher\Event;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ThemeInjectionListener.
+ */
+class ThemeInjectionListenerTest extends TestCase
+{
+
+    /**
+     * The CSS injection service mock.
+     *
+     * @var CssInjectionService&MockObject
+     */
+    private $cssInjectionService;
+
+    /**
+     * The per-app theming guard mock.
+     *
+     * @var AppThemingService&MockObject
+     */
+    private $appThemingService;
+
+    /**
+     * The request mock.
+     *
+     * @var IRequest&MockObject
+     */
+    private $request;
+
+    /**
+     * The listener under test.
+     *
+     * @var ThemeInjectionListener
+     */
+    private ThemeInjectionListener $listener;
+
+    /**
+     * Set up mocks before each test.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cssInjectionService = $this->createMock(CssInjectionService::class);
+        $this->appThemingService   = $this->createMock(AppThemingService::class);
+        $this->request             = $this->createMock(IRequest::class);
+        $this->listener            = new ThemeInjectionListener(
+            $this->cssInjectionService,
+            $this->appThemingService,
+            $this->request
+        );
+
+        // No blanket `isThemingDisabledFor()` default here: PHPUnit's
+        // InvocationMocker resolves overlapping unconstrained stubs in
+        // REGISTRATION order (the first-registered unconstrained stub wins
+        // for every call), so a setUp()-level default would silently shadow
+        // a test's own `->with($appId)->willReturn(true)`. Each test
+        // configures it explicitly instead (an unconfigured bool-returning
+        // mock method defaults to `false`, which is what the "not excluded"
+        // tests below rely on).
+    }//end setUp()
+
+    /**
+     * renderAs `user`/`guest`/`public`/`error` each reach `inject()` with the
+     * matching context.
+     *
+     * @dataProvider renderAsProvider
+     *
+     * @param string $renderAs        The response's renderAs value.
+     * @param string $expectedContext The context `inject()` must receive.
+     */
+    public function testRenderAsMapsToMatchingContext(string $renderAs, string $expectedContext): void
+    {
+        $response = new TemplateResponse('files', 'index', [], $renderAs);
+
+        $this->cssInjectionService->expects($this->once())->method('inject')->with($expectedContext);
+
+        $this->listener->handle(new BeforeTemplateRenderedEvent(true, $response));
+    }//end testRenderAsMapsToMatchingContext()
+
+    /**
+     * renderAs => context cases.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function renderAsProvider(): array
+    {
+        return [
+            'user'   => [TemplateResponse::RENDER_AS_USER, 'user'],
+            'guest'  => [TemplateResponse::RENDER_AS_GUEST, 'guest'],
+            'public' => [TemplateResponse::RENDER_AS_PUBLIC, 'public'],
+            'error'  => [TemplateResponse::RENDER_AS_ERROR, 'error'],
+        ];
+    }//end renderAsProvider()
+
+    /**
+     * An unknown renderAs (e.g. `blank`) still injects — fail-open,
+     * forward-compatibility.
+     */
+    public function testUnknownRenderAsStillInjects(): void
+    {
+        $response = new TemplateResponse('files', 'index', [], 'blank');
+
+        $this->cssInjectionService->expects($this->once())->method('inject')->with('blank');
+
+        $this->listener->handle(new BeforeTemplateRenderedEvent(true, $response));
+    }//end testUnknownRenderAsStillInjects()
+
+    /**
+     * The login event injects with context `login` and never consults the
+     * per-app guard.
+     */
+    public function testLoginEventInjectsWithLoginContextAndSkipsGuard(): void
+    {
+        $response = new TemplateResponse('core', 'login', [], TemplateResponse::RENDER_AS_GUEST);
+
+        $this->appThemingService->expects($this->never())->method('isThemingDisabledFor');
+        $this->appThemingService->expects($this->never())->method('resolveAppIdFromPath');
+        $this->cssInjectionService->expects($this->once())->method('inject')->with('login');
+
+        $this->listener->handle(new BeforeLoginTemplateRenderedEvent($response));
+    }//end testLoginEventInjectsWithLoginContextAndSkipsGuard()
+
+    /**
+     * An excluded app (identified via the response's own app id) skips injection.
+     */
+    public function testExcludedResponseAppSkipsInjection(): void
+    {
+        $response = new TemplateResponse('calendar', 'index', [], TemplateResponse::RENDER_AS_USER);
+
+        $this->appThemingService->method('isThemingDisabledFor')->with('calendar')->willReturn(true);
+        $this->request->expects($this->never())->method('getPathInfo');
+        $this->cssInjectionService->expects($this->never())->method('inject');
+
+        $this->listener->handle(new BeforeTemplateRenderedEvent(true, $response));
+    }//end testExcludedResponseAppSkipsInjection()
+
+    /**
+     * A non-excluded response app stays fully themed.
+     */
+    public function testNonExcludedResponseAppInjectsNormally(): void
+    {
+        $response = new TemplateResponse('files', 'index', [], TemplateResponse::RENDER_AS_USER);
+
+        $this->appThemingService->method('isThemingDisabledFor')->with('files')->willReturn(false);
+        $this->cssInjectionService->expects($this->once())->method('inject')->with('user');
+
+        $this->listener->handle(new BeforeTemplateRenderedEvent(true, $response));
+    }//end testNonExcludedResponseAppInjectsNormally()
+
+    /**
+     * An empty response app id falls back to the request path resolver.
+     */
+    public function testEmptyResponseAppFallsBackToPath(): void
+    {
+        $response = new TemplateResponse('', 'index', [], TemplateResponse::RENDER_AS_USER);
+
+        $this->request->method('getPathInfo')->willReturn('/apps/calendar/');
+        $this->appThemingService->method('resolveAppIdFromPath')->with('/apps/calendar/')->willReturn('calendar');
+        $this->appThemingService->method('isThemingDisabledFor')->with('calendar')->willReturn(true);
+        $this->cssInjectionService->expects($this->never())->method('inject');
+
+        $this->listener->handle(new BeforeTemplateRenderedEvent(true, $response));
+    }//end testEmptyResponseAppFallsBackToPath()
+
+    /**
+     * A `core`-attributed response app also falls back to the request path resolver.
+     */
+    public function testCoreResponseAppFallsBackToPath(): void
+    {
+        $response = new TemplateResponse('core', 'index', [], TemplateResponse::RENDER_AS_USER);
+
+        $this->request->method('getPathInfo')->willReturn('/index.php/apps/calendar/');
+        $this->appThemingService->method('resolveAppIdFromPath')
+            ->with('/index.php/apps/calendar/')->willReturn('calendar');
+        $this->appThemingService->method('isThemingDisabledFor')->with('calendar')->willReturn(true);
+        $this->cssInjectionService->expects($this->never())->method('inject');
+
+        $this->listener->handle(new BeforeTemplateRenderedEvent(true, $response));
+    }//end testCoreResponseAppFallsBackToPath()
+
+    /**
+     * A throwing app-id resolver fails open to themed rather than propagating.
+     */
+    public function testResolverThrowingFailsOpenToThemed(): void
+    {
+        $response = new TemplateResponse('files', 'index', [], TemplateResponse::RENDER_AS_USER);
+
+        $this->appThemingService->method('isThemingDisabledFor')->willThrowException(new \RuntimeException('boom'));
+        $this->cssInjectionService->expects($this->once())->method('inject')->with('user');
+
+        $this->listener->handle(new BeforeTemplateRenderedEvent(true, $response));
+    }//end testResolverThrowingFailsOpenToThemed()
+
+    /**
+     * An event that is neither of the two handled types is a no-op — no
+     * exception escapes, and injection never runs.
+     */
+    public function testUnrelatedEventIsNoOp(): void
+    {
+        $unrelated = $this->createMock(Event::class);
+
+        $this->cssInjectionService->expects($this->never())->method('inject');
+
+        $this->listener->handle($unrelated);
+        $this->addToAssertionCount(1);
+    }//end testUnrelatedEventIsNoOp()
+
+    /**
+     * A throwing CssInjectionService never lets the exception escape `handle()`.
+     */
+    public function testInjectionServiceThrowingNeverEscapes(): void
+    {
+        $response = new TemplateResponse('files', 'index', [], TemplateResponse::RENDER_AS_USER);
+
+        $this->cssInjectionService->method('inject')->willThrowException(new \RuntimeException('boom'));
+
+        $this->listener->handle(new BeforeTemplateRenderedEvent(true, $response));
+        $this->addToAssertionCount(1);
+    }//end testInjectionServiceThrowingNeverEscapes()
+
+    /**
+     * Double dispatch of the same event yields exactly two `inject()` calls
+     * with the same arguments each time (idempotency lives in
+     * `\OCP\Util::addStyle()`, not the listener) — no duplicated/skewed state.
+     */
+    public function testDoubleDispatchYieldsNoDuplicatedSideEffectsBeyondInject(): void
+    {
+        $response = new TemplateResponse('files', 'index', [], TemplateResponse::RENDER_AS_USER);
+
+        $this->cssInjectionService->expects($this->exactly(2))->method('inject')->with('user');
+
+        $event = new BeforeTemplateRenderedEvent(true, $response);
+        $this->listener->handle($event);
+        $this->listener->handle($event);
+    }//end testDoubleDispatchYieldsNoDuplicatedSideEffectsBeyondInject()
+}//end class

--- a/tests/Unit/Service/CssInjectionServiceTest.php
+++ b/tests/Unit/Service/CssInjectionServiceTest.php
@@ -1,0 +1,502 @@
+<?php
+
+/**
+ * Unit tests for CssInjectionService.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @spec openspec/changes/render-event-injection/tasks.md#task-4.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit\Service;
+
+use OCA\NLDesign\Service\CssInjectionService;
+use OCA\NLDesign\Service\CustomOverridesService;
+use OCA\NLDesign\Service\DesignSystemService;
+use OCA\NLDesign\Service\FontService;
+use OCP\IConfig;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for CssInjectionService.
+ *
+ * `emitStyle()`/`emitFontLink()` are the only two side-effecting calls in the
+ * service (they delegate to `\OCP\Util::addStyle()`/`addHeader()`, which
+ * requires a full Nextcloud bootstrap this suite does not have). They are
+ * overridden via a partial mock so every test can assert the exact call
+ * sequence without ever invoking the real static Nextcloud API.
+ */
+class CssInjectionServiceTest extends TestCase
+{
+
+    /**
+     * The config mock.
+     *
+     * @var IConfig&MockObject
+     */
+    private $config;
+
+    /**
+     * The design system service mock.
+     *
+     * @var DesignSystemService&MockObject
+     */
+    private $designSystemService;
+
+    /**
+     * The custom overrides service mock.
+     *
+     * @var CustomOverridesService&MockObject
+     */
+    private $customOverridesService;
+
+    /**
+     * The font service mock.
+     *
+     * @var FontService&MockObject
+     */
+    private $fontService;
+
+    /**
+     * The URL generator mock.
+     *
+     * @var IURLGenerator&MockObject
+     */
+    private $urlGenerator;
+
+    /**
+     * Set up mocks before each test.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->config                 = $this->createMock(IConfig::class);
+        $this->designSystemService    = $this->createMock(DesignSystemService::class);
+        $this->customOverridesService = $this->createMock(CustomOverridesService::class);
+        $this->fontService            = $this->createMock(FontService::class);
+        $this->urlGenerator           = $this->createMock(IURLGenerator::class);
+
+        // No blanket `hasFonts()` default here: PHPUnit's InvocationMocker
+        // resolves overlapping unconstrained stubs in REGISTRATION order (the
+        // first-registered unconstrained stub wins for every call), so a
+        // setUp()-level default would silently shadow a test's own
+        // `willReturn(true)`. Each test configures `hasFonts()` explicitly
+        // instead (an unconfigured bool-returning mock method defaults to
+        // `false`, which is what every non-font test below relies on).
+    }//end setUp()
+
+    /**
+     * Build the service under test as a partial mock that captures every
+     * `emitStyle()`/`emitFontLink()` call (in order) instead of calling the
+     * real static Nextcloud API.
+     *
+     * @param array<int, string> $styleLog Populated with each `emitStyle()` file, in call order.
+     * @param array<int, string> $fontLog  Populated with each `emitFontLink()` url, in call order.
+     *
+     * @return CssInjectionService&MockObject The service under test.
+     */
+    private function buildService(array &$styleLog, array &$fontLog): CssInjectionService
+    {
+        $service = $this->getMockBuilder(CssInjectionService::class)
+            ->setConstructorArgs(
+                [
+                    $this->config,
+                    $this->designSystemService,
+                    $this->customOverridesService,
+                    $this->fontService,
+                    $this->urlGenerator,
+                ]
+            )
+            ->onlyMethods(['emitStyle', 'emitFontLink'])
+            ->getMock();
+
+        $service->method('emitStyle')->willReturnCallback(
+            function (string $file) use (&$styleLog) {
+                $styleLog[] = $file;
+            }
+        );
+        $service->method('emitFontLink')->willReturnCallback(
+            function (string $url) use (&$fontLog) {
+                $fontLog[] = $url;
+            }
+        );
+
+        return $service;
+    }//end buildService()
+
+    /**
+     * Configure the config mock to resolve to a given appconfig value map,
+     * defaulting `themed_contexts` to absent (all contexts themed).
+     *
+     * @param array<string, string> $overrides Appconfig key => value overrides.
+     *
+     * @return void
+     */
+    private function configureAppValues(array $overrides = []): void
+    {
+        $defaults = [
+            'token_set'        => 'nextcloud',
+            'hide_slogan'      => '0',
+            'show_menu_labels' => '0',
+            'themed_contexts'  => '[]',
+        ];
+        $values = array_merge($defaults, $overrides);
+
+        $this->config->method('getAppValue')->willReturnCallback(
+            function (string $app, string $key, string $default) use ($values) {
+                return $values[$key] ?? $default;
+            }
+        );
+    }//end configureAppValues()
+
+    /**
+     * The standard nldesign order: design-system stylesheets (declared
+     * order), token set, icon/error contrast, custom-overrides — layers 1-8.
+     */
+    public function testStandardNldesignOrder(): void
+    {
+        $this->configureAppValues(['token_set' => 'rijkshuisstijl']);
+        $this->designSystemService->method('getTokenSetMeta')->with('rijkshuisstijl')
+            ->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->with('nldesign')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [
+                    'systems/nldesign/fonts',
+                    'systems/nldesign/defaults',
+                    'systems/nldesign/utrecht-bridge',
+                    'systems/nldesign/theme',
+                    'systems/nldesign/overrides',
+                    'systems/nldesign/element-overrides',
+                ],
+            ]
+        );
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('user');
+
+        $this->assertSame(
+            [
+                'systems/nldesign/fonts',
+                'systems/nldesign/defaults',
+                'systems/nldesign/utrecht-bridge',
+                'systems/nldesign/theme',
+                'systems/nldesign/overrides',
+                'systems/nldesign/element-overrides',
+                'tokens/rijkshuisstijl',
+                'icon-contrast',
+                'error-contrast',
+                'custom-overrides',
+            ],
+            $styleLog
+        );
+        $this->assertSame([], $fontLog);
+        $this->customOverridesService->expects($this->never())->method('ensureExists');
+    }//end testStandardNldesignOrder()
+
+    /**
+     * The "none" design system (stock Nextcloud) loads no layer 1-7
+     * stylesheet and no token/contrast CSS, but custom-overrides still loads.
+     */
+    public function testNoneDesignSystemLoadsNoStylesheets(): void
+    {
+        $this->configureAppValues(['token_set' => 'nextcloud']);
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'none']);
+        $this->designSystemService->method('getDesignSystem')->with('none')->willReturn(
+            [
+                'id'          => 'none',
+                'name'        => 'No design system',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('user');
+
+        $this->assertSame(['custom-overrides'], $styleLog);
+        $this->assertSame([], $fontLog);
+    }//end testNoneDesignSystemLoadsNoStylesheets()
+
+    /**
+     * Custom overrides load after all design-system and token layers, and
+     * `ensureExists()` runs before the stylesheet is emitted.
+     */
+    public function testCustomOverridesAlwaysLoadedLast(): void
+    {
+        $this->configureAppValues();
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => ['systems/nldesign/fonts'],
+            ]
+        );
+
+        $ensureExistsCalledBeforeStyle = false;
+        $this->customOverridesService->expects($this->once())->method('ensureExists')
+            ->willReturnCallback(
+                function () use (&$ensureExistsCalledBeforeStyle) {
+                    $ensureExistsCalledBeforeStyle = true;
+                }
+            );
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('user');
+
+        $this->assertTrue($ensureExistsCalledBeforeStyle);
+        $this->assertSame(end($styleLog), 'custom-overrides');
+    }//end testCustomOverridesAlwaysLoadedLast()
+
+    /**
+     * hide-slogan and show-menu-labels load last, after custom-overrides,
+     * only when their respective appconfig flags are enabled.
+     */
+    public function testConditionalStylesheetsLoadedWhenEnabled(): void
+    {
+        $this->configureAppValues(['hide_slogan' => '1', 'show_menu_labels' => '1']);
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('user');
+
+        $this->assertSame(
+            ['tokens/nextcloud', 'icon-contrast', 'error-contrast', 'custom-overrides', 'hide-slogan', 'show-menu-labels'],
+            $styleLog
+        );
+    }//end testConditionalStylesheetsLoadedWhenEnabled()
+
+    /**
+     * The conditional stylesheets are absent when their flags are disabled.
+     */
+    public function testConditionalStylesheetsAbsentWhenDisabled(): void
+    {
+        $this->configureAppValues();
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('user');
+
+        $this->assertNotContains('hide-slogan', $styleLog);
+        $this->assertNotContains('show-menu-labels', $styleLog);
+    }//end testConditionalStylesheetsAbsentWhenDisabled()
+
+    /**
+     * Custom fonts inject a `<link>` header (not a static stylesheet) after
+     * the token-set styles, only when at least one font is configured, and
+     * never for the "none" design system.
+     */
+    public function testCustomFontsInjectedWhenConfigured(): void
+    {
+        $this->configureAppValues();
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+        $this->fontService->method('hasFonts')->willReturn(true);
+        $this->fontService->method('getRevision')->willReturn(3);
+        $this->urlGenerator->method('linkToRoute')->with('nldesign.font.css')
+            ->willReturn('https://example.test/apps/nldesign/fonts/css');
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('user');
+
+        $this->assertSame(['https://example.test/apps/nldesign/fonts/css?v=3'], $fontLog);
+    }//end testCustomFontsInjectedWhenConfigured()
+
+    /**
+     * No font link is emitted for the "none" design system, even with fonts configured.
+     */
+    public function testCustomFontsNotInjectedForNoneDesignSystem(): void
+    {
+        $this->configureAppValues();
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'none']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'none',
+                'name'        => 'No design system',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+        $this->fontService->method('hasFonts')->willReturn(true);
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('user');
+
+        $this->assertSame([], $fontLog);
+    }//end testCustomFontsNotInjectedForNoneDesignSystem()
+
+    /**
+     * Absent `themed_contexts` themes every context (byte-identical default).
+     */
+    public function testAbsentThemedContextsThemesEveryContext(): void
+    {
+        $this->configureAppValues(['themed_contexts' => '[]']);
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+
+        foreach (['user', 'login', 'guest', 'public', 'error'] as $context) {
+            $styleLog = [];
+            $fontLog  = [];
+            $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+            $service->inject($context);
+
+            $this->assertContains('custom-overrides', $styleLog, 'context '.$context.' must be themed');
+        }
+    }//end testAbsentThemedContextsThemesEveryContext()
+
+    /**
+     * `["user"]` excludes every other configured context — `login` injects
+     * nothing, `user` remains fully themed.
+     */
+    public function testConfiguredListExcludesUnlistedContexts(): void
+    {
+        $this->configureAppValues(['themed_contexts' => '["user"]']);
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+
+        $loginStyleLog = [];
+        $loginFontLog  = [];
+        $loginService  = $this->buildService(styleLog: $loginStyleLog, fontLog: $loginFontLog);
+        $loginService->inject('login');
+        $this->assertSame([], $loginStyleLog);
+
+        $userStyleLog = [];
+        $userFontLog  = [];
+        $userService  = $this->buildService(styleLog: $userStyleLog, fontLog: $userFontLog);
+        $userService->inject('user');
+        $this->assertContains('custom-overrides', $userStyleLog);
+    }//end testConfiguredListExcludesUnlistedContexts()
+
+    /**
+     * Unparseable JSON in `themed_contexts` fails open to themed, without raising.
+     */
+    public function testInvalidJsonThemedContextsFailsOpen(): void
+    {
+        $this->configureAppValues(['themed_contexts' => 'not-json{']);
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('public');
+
+        $this->assertContains('custom-overrides', $styleLog);
+    }//end testInvalidJsonThemedContextsFailsOpen()
+
+    /**
+     * A non-array JSON value in `themed_contexts` also fails open to themed.
+     */
+    public function testNonArrayJsonThemedContextsFailsOpen(): void
+    {
+        $this->configureAppValues(['themed_contexts' => '"not-an-array"']);
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('guest');
+
+        $this->assertContains('custom-overrides', $styleLog);
+    }//end testNonArrayJsonThemedContextsFailsOpen()
+
+    /**
+     * An unrecognized context value (a future/unmapped `renderAs`) is always
+     * themed, even when a configured list would otherwise exclude "user".
+     */
+    public function testUnknownContextAlwaysThemed(): void
+    {
+        $this->configureAppValues(['themed_contexts' => '["login"]']);
+        $this->designSystemService->method('getTokenSetMeta')->willReturn(['design_system' => 'nldesign']);
+        $this->designSystemService->method('getDesignSystem')->willReturn(
+            [
+                'id'          => 'nldesign',
+                'name'        => 'NL Design System',
+                'description' => '',
+                'stylesheets' => [],
+            ]
+        );
+
+        $styleLog = [];
+        $fontLog  = [];
+        $service  = $this->buildService(styleLog: $styleLog, fontLog: $fontLog);
+        $service->inject('blank');
+
+        $this->assertContains('custom-overrides', $styleLog);
+    }//end testUnknownContextAlwaysThemed()
+}//end class


### PR DESCRIPTION
## What / Why

`Application::boot()` injected all nldesign CSS on **every** request — including WebDAV, OCS/API, and cron requests that never render a template — via `OCP\Util::addStyle()`. This change moves injection onto `BeforeTemplateRenderedEvent`/`BeforeLoginTemplateRenderedEvent` (the same two events Nextcloud core's own `ThemeInjectionService` uses), so only actual template renders pay for it.

- New `lib/Service/CssInjectionService.php`: the former `injectThemeCSS()` body moved **verbatim** (same stylesheet cascade, same order, including the custom-font `<link>` from the merged custom-font-upload change), now parameterized by render context. Adds occ-only `themed_contexts` appconfig gating — absent by default, so every surface (login/user/guest/public/error) is themed exactly as before.
- New `lib/Listener/ThemeInjectionListener.php`: handles both events, maps `renderAs` → context (unmapped/future values fail open to themed), applies the per-app exclusion guard (resolved from `TemplateResponse::getApp()`, falling back to the existing path-regex), and fails open (never breaks rendering) on any internal error.
- `Application::boot()` is now a no-op; the dead `use OCA\NLDesign\Themes\NLDesignTheme;` import is removed.
- `appinfo/info.xml` version bumped (cache-buster) + CHANGELOG entry.

See `openspec/changes/render-event-injection/` (proposal/design/tasks + spec deltas on `css-architecture` and `per-app-theming`) for the full rationale.

## Tests

- 27 new unit tests: `tests/Unit/Service/CssInjectionServiceTest.php` (14) + `tests/Unit/Listener/ThemeInjectionListenerTest.php` (13) — cover stylesheet order/gating, all renderAs→context mappings, per-app guard precedence/fallback/fail-open, double-dispatch, and listener failure containment.
- No pre-existing tests targeted the old private `Application::injectThemeCSS()`/`isThemingDisabled()` to retire (verified via grep) — nothing to migrate.
- Full suite in `nextcloud:34.0.0-apache` (excluding the one file blocked by the pre-existing, unrelated `OC\Mail\EMailTemplate` harness gap): **338 tests, 2248 assertions — all green.**
- `composer check:strict`: lint/phpcs/phpmd/psalm/phpstan all pass. `test:all` inside `check:strict` dies at suite-load on the same pre-existing `OC\Mail\EMailTemplate` gap (reproduces identically on `development`, unrelated to this change).

## Deferred to post-merge (live 8080 verification — see tasks.md §5)

- [ ] Login/user/public-share page curl parity checks (stylesheet link set identical to pre-change)
- [ ] Per-app exclusion regression against a live instance
- [ ] API-surface negative check + log grep for listener errors
- [ ] Browser visual check (login/Files/public share)
- [ ] `themed_contexts` occ smoke test (set/delete)