### PR TITLE
fix(admin-js): restore DTCG diagnostics rendering lost in merge reconciliation

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1395,6 +1395,84 @@ function nldesignAdminMain() {
 		loadCustomTokenSets();
 	}
 
+	// Localised label for a DTCG import diagnostic `reason` code. Falls back to
+	// the raw code for any future reason this script does not yet know about,
+	// so a new mapper diagnostic never renders as blank.
+	function reasonLabel(reason) {
+		var labels = {
+			'unmapped-path': t('nldesign', 'Not part of the --nldesign-* vocabulary'),
+			'missing-type': t('nldesign', 'No $type could be resolved (never guessed)'),
+			'unsupported-color-space': t('nldesign', 'Unsupported color space'),
+			'unsupported-value-shape': t('nldesign', 'Unsupported value shape'),
+			'alias-cycle': t('nldesign', 'Alias cycle detected'),
+			'alias-target-missing': t('nldesign', 'Alias target does not exist'),
+			'alias-depth-exceeded': t('nldesign', 'Alias chain too deep (more than 10 hops)'),
+			'duplicate-target': t('nldesign', 'Another token already maps to this target')
+		};
+		return labels[reason] || reason;
+	}
+
+	// Inline copy of tokenTransforms' groupDiagnosticsByReason, used when the
+	// transforms module is not present on `window` (the app template loads it
+	// first, but admin.js must degrade rather than silently render nothing).
+	// Keep in sync with js/lib/tokenTransforms.js.
+	function groupDiagnosticsByReasonFallback(entries) {
+		if (!Array.isArray(entries) || entries.length === 0) {
+			return [];
+		}
+
+		var byReason = {};
+		entries.forEach(function(entry) {
+			var reason = (entry && entry.reason) || 'unknown';
+			if (byReason[reason] === undefined) {
+				byReason[reason] = [];
+			}
+			byReason[reason].push(entry);
+		});
+
+		return Object.keys(byReason).sort().map(function(reason) {
+			return { reason: reason, items: byReason[reason] };
+		});
+	}
+
+	// Build the DTCG import-diagnostics fragment for an upload response:
+	// skipped/error paths grouped by reason, plus $deprecated import warnings.
+	// Returns an empty (childless) fragment when both arrays are absent/empty,
+	// so a CSS upload's plain-text summary is never followed by empty markup.
+	function buildDiagnosticsFragment(data) {
+		var fragment = document.createDocumentFragment();
+
+		var diagnostics = [].concat(data.skipped || [], data.errors || []);
+		var groups = (typeof TT.groupDiagnosticsByReason === 'function')
+			? TT.groupDiagnosticsByReason(diagnostics)
+			: groupDiagnosticsByReasonFallback(diagnostics);
+
+		if (groups.length > 0) {
+			var list = document.createElement('ul');
+			list.className = 'nldesign-diagnostics-list';
+			groups.forEach(function(group) {
+				var item = document.createElement('li');
+				var paths = group.items.map(function(entry) { return entry.path; }).join(', ');
+				item.textContent = reasonLabel(group.reason) + ' (' + group.items.length + '): ' + paths;
+				list.appendChild(item);
+			});
+			fragment.appendChild(list);
+		}
+
+		if (data.importWarnings && data.importWarnings.length > 0) {
+			var warnList = document.createElement('ul');
+			warnList.className = 'nldesign-deprecation-list';
+			data.importWarnings.forEach(function(w) {
+				var item = document.createElement('li');
+				item.textContent = w.path + (w.message ? ': ' + w.message : '');
+				warnList.appendChild(item);
+			});
+			fragment.appendChild(warnList);
+		}
+
+		return fragment;
+	}
+
 	function uploadCustomTokenSet(name, file) {
 		var resultEl = document.getElementById('nldesign-upload-result');
 		var formData = new FormData();
@@ -1410,10 +1488,12 @@ function nldesignAdminMain() {
 		.then(function(res) {
 			if (resultEl !== null) {
 				resultEl.style.display = 'block';
+				resultEl.innerHTML = '';
 			}
 			if (res.status >= 400) {
 				if (resultEl !== null) {
-					resultEl.textContent = t('nldesign', 'Upload failed:') + ' ' + (res.data.error || '');
+					resultEl.appendChild(document.createTextNode(t('nldesign', 'Upload failed:') + ' ' + (res.data.error || '')));
+					resultEl.appendChild(buildDiagnosticsFragment(res.data));
 				}
 				OC.Notification.showTemporary(t('nldesign', 'Upload failed:') + ' ' + (res.data.error || ''));
 				return;
@@ -1425,8 +1505,12 @@ function nldesignAdminMain() {
 				msg += ' ' + t('nldesign', '{count} WCAG AA contrast warning(s) — see the apply dialog.')
 					.replace('{count}', res.data.warnings.length);
 			}
+			if (res.data.version) {
+				msg += ' ' + t('nldesign', 'Package version: {version}').replace('{version}', res.data.version);
+			}
 			if (resultEl !== null) {
-				resultEl.textContent = msg;
+				resultEl.appendChild(document.createTextNode(msg));
+				resultEl.appendChild(buildDiagnosticsFragment(res.data));
 			}
 			OC.Notification.showTemporary(t('nldesign', 'Token set uploaded. Reload the page to apply it.'));
 			loadCustomTokenSets();
@@ -1473,6 +1557,13 @@ function nldesignAdminMain() {
 			nameSpan.className = 'nldesign-custom-set-name';
 			nameSpan.textContent = set.name || set.id;
 			row.appendChild(nameSpan);
+
+			if (set.version) {
+				var versionSpan = document.createElement('span');
+				versionSpan.className = 'nldesign-custom-set-version';
+				versionSpan.textContent = t('nldesign', 'v{version}', { version: set.version });
+				row.appendChild(versionSpan);
+			}
 
 			var badge = document.createElement('span');
 			badge.className = 'nldesign-badge';


### PR DESCRIPTION
Self-inflicted regression repair: my admin.js reconstruction during the fonts/freshness merges dropped DTCG's upload-result rendering. Restored, plus an inline groupDiagnosticsByReason fallback so the rendering degrades correctly when the transforms module isn't on window.

24/24 vitest (was 22/24), 343 PHP tests, check:strict ALL CHECKS PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)