### PR TITLE
fix(a11y): keep keyboard focus on the moved row when reordering group mappings

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1484,8 +1484,16 @@ function nldesignAdminMain() {
 			var focusRows = listEl.querySelectorAll('.nldesign-group-theming-row');
 			var target = focusRows[focusMoveButtonIndex];
 			if (target) {
+				// A row moved to a boundary has its corresponding move button
+				// disabled, and a disabled control cannot hold focus — focus
+				// would fall back to <body>, losing the user's place. Focus the
+				// nearest still-operable control on the moved row instead, so
+				// keyboard users always land on the row they just moved.
 				var btn = target.querySelector('.nldesign-group-theming-move-up');
-				if (btn) { btn.focus(); }
+				if (btn === null || btn.disabled === true) {
+					btn = target.querySelector('.nldesign-group-theming-move-down');
+				}
+				if (btn !== null && btn.disabled === false) { btn.focus(); }
 			}
 		}
 	}

--- a/tests/vitest/admin-group-theming.spec.js
+++ b/tests/vitest/admin-group-theming.spec.js
@@ -199,9 +199,12 @@ describe('admin.js group theming section', () => {
 		const rows = document.querySelectorAll('.nldesign-group-theming-row')
 		expect(rows[0].querySelector('[data-field="group"]').value).toBe('gemeente-b')
 		expect(rows[1].querySelector('[data-field="group"]').value).toBe('gemeente-a')
-		// Focus MUST remain on the moved row's move-up button (WCAG 2.1.1,
-		// no keyboard trap) — the row is now first (index 0).
-		expect(document.activeElement).toBe(rows[0].querySelector('.nldesign-group-theming-move-up'))
+		// Focus MUST stay on the row the user just moved (WCAG 2.1.1 Keyboard /
+		// 2.4.3 Focus Order — focus must never fall back to <body>). The row is
+		// now first, so its move-up button is disabled and cannot hold focus;
+		// the nearest operable control on the same row takes it instead.
+		expect(rows[0].contains(document.activeElement)).toBe(true)
+		expect(document.activeElement).toBe(rows[0].querySelector('.nldesign-group-theming-move-down'))
 	})
 
 	it('disables move-up on the first row and move-down on the last row', async () => {


### PR DESCRIPTION
The per-group builder could not run vitest (broken node_modules symlink, since repaired), so this surfaced only after merge: reordering to a boundary disabled the corresponding move button, and focus fell back to <body> — a WCAG 2.1.1/2.4.3 regression for keyboard users.

The two authored specs contradicted each other (focus on a button required to be simultaneously disabled). Resolved by keeping the conventional disabled-at-boundary semantics and focusing the nearest operable control on the moved row; reasoning recorded in both the implementation and the test.

32/32 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)