### PR TITLE
test(e2e): revive the dead Playwright harness, cover the wave, and fix the NC34 toast bug it found

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -15,6 +15,35 @@ function nldesignAdminMain() {
 	// `|| {}` fallback keeps admin.js working even if the helper script is absent.
 	var TT = (typeof window !== 'undefined' && window.NldesignTokenTransforms) || {};
 
+	/**
+	 * Show a transient toast, never breaking the flow that raised it.
+	 *
+	 * `OC.Notification` was REMOVED in Nextcloud 34 (toasts live in
+	 * `OCP.Toast` / @nextcloud/dialogs now), so the old
+	 * `notify()` call throws a TypeError. Because those
+	 * calls sit inside `.then()` handlers, the throw aborted the rest of the
+	 * handler — e.g. an upload succeeded server-side but `loadCustomTokenSets()`
+	 * never ran, so the list silently never refreshed.
+	 *
+	 * A purely cosmetic notification must never be able to break a functional
+	 * flow, so every failure path here is swallowed and downgraded to a log.
+	 */
+	function notify(message) {
+		try {
+			if (window.OCP && OCP.Toast && typeof OCP.Toast.message === 'function') {
+				OCP.Toast.message(message);
+				return;
+			}
+			if (window.OC && OC.Notification && typeof OC.Notification.showTemporary === 'function') {
+				notify(message);
+				return;
+			}
+		} catch (e) {
+			// Fall through to the console fallback below.
+		}
+		console.info('[nldesign] ' + message);
+	}
+
 	var settingsEl = document.getElementById('nldesign-settings');
 	var tokenSetSelect = document.getElementById('nldesign-token-set-select');
 	var hideSloganCheckbox = document.getElementById('nldesign-hide-slogan');
@@ -193,13 +222,13 @@ function nldesignAdminMain() {
 					window.location.reload();
 				} else {
 					previewBtn.disabled = false;
-					OC.Notification.showTemporary(t('nldesign', 'Failed to start theme preview.'));
+					notify(t('nldesign', 'Failed to start theme preview.'));
 				}
 			})
 			.catch(function(error) {
 				previewBtn.disabled = false;
 				console.error('Error starting theme preview:', error);
-				OC.Notification.showTemporary(t('nldesign', 'Failed to start theme preview.'));
+				notify(t('nldesign', 'Failed to start theme preview.'));
 			});
 		});
 	}
@@ -219,7 +248,7 @@ function nldesignAdminMain() {
 			.catch(function(error) {
 				previewDiscardBtn.disabled = false;
 				console.error('Error discarding theme preview:', error);
-				OC.Notification.showTemporary(t('nldesign', 'Failed to discard theme preview.'));
+				notify(t('nldesign', 'Failed to discard theme preview.'));
 			});
 		});
 	}
@@ -261,7 +290,7 @@ function nldesignAdminMain() {
 		commitTokenSetChange(tokenSet, publishMode === true)
 		.then(function(data) {
 			if (data.status === 'ok') {
-				OC.Notification.showTemporary(publishMode === true
+				notify(publishMode === true
 					? t('nldesign', 'Theme published instance-wide. Reload the page to see changes.')
 					: t('nldesign', 'Theme updated successfully. reload the page to see changes.'));
 
@@ -271,12 +300,12 @@ function nldesignAdminMain() {
 					checkAndShowThemingDialog(tsData);
 				}
 			} else {
-				OC.Notification.showTemporary(t('nldesign', 'Failed to update theme.'));
+				notify(t('nldesign', 'Failed to update theme.'));
 			}
 		})
 		.catch(function(error) {
 			console.error('Error saving token set:', error);
-			OC.Notification.showTemporary(t('nldesign', 'Failed to update theme.'));
+			notify(t('nldesign', 'Failed to update theme.'));
 		});
 	}
 
@@ -469,18 +498,18 @@ function nldesignAdminMain() {
 			.then(function(data) {
 				closeDialogOverlay(overlay);
 				if (data.status === 'ok') {
-					OC.Notification.showTemporary(t('nldesign', 'Nextcloud theming updated successfully. reloading page...'));
+					notify(t('nldesign', 'Nextcloud theming updated successfully. reloading page...'));
 					setTimeout(function() {
 						window.location.reload();
 					}, 1500);
 				} else {
-					OC.Notification.showTemporary(t('nldesign', 'Failed to update Nextcloud theming:') + (data.error || ''));
+					notify(t('nldesign', 'Failed to update Nextcloud theming:') + (data.error || ''));
 				}
 			})
 			.catch(function(error) {
 				closeDialogOverlay(overlay);
 				console.error('Error updating theming:', error);
-				OC.Notification.showTemporary(t('nldesign', 'Failed to update Nextcloud theming.'));
+				notify(t('nldesign', 'Failed to update Nextcloud theming.'));
 			});
 		});
 	}
@@ -652,14 +681,14 @@ function nldesignAdminMain() {
 		.then(function(response) { return response.json(); })
 		.then(function(data) {
 			if (data.status === 'ok') {
-				OC.Notification.showTemporary(t('nldesign', 'Setting saved successfully. reload the page to see changes.'));
+				notify(t('nldesign', 'Setting saved successfully. reload the page to see changes.'));
 			} else {
-				OC.Notification.showTemporary(t('nldesign', 'Failed to save setting.'));
+				notify(t('nldesign', 'Failed to save setting.'));
 			}
 		})
 		.catch(function(error) {
 			console.error('Error saving dark variants setting:', error);
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save setting.'));
+			notify(t('nldesign', 'Failed to save setting.'));
 		});
 	}
 
@@ -678,14 +707,14 @@ function nldesignAdminMain() {
 		.then(function(response) { return response.json(); })
 		.then(function(data) {
 			if (data.status === 'ok') {
-				OC.Notification.showTemporary(t('nldesign', 'Setting saved successfully. reload the login page to see changes.'));
+				notify(t('nldesign', 'Setting saved successfully. reload the login page to see changes.'));
 			} else {
-				OC.Notification.showTemporary(t('nldesign', 'Failed to save setting.'));
+				notify(t('nldesign', 'Failed to save setting.'));
 			}
 		})
 		.catch(function(error) {
 			console.error('Error saving slogan setting:', error);
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save setting.'));
+			notify(t('nldesign', 'Failed to save setting.'));
 		});
 	}
 
@@ -704,14 +733,14 @@ function nldesignAdminMain() {
 		.then(function(response) { return response.json(); })
 		.then(function(data) {
 			if (data.status === 'ok') {
-				OC.Notification.showTemporary(t('nldesign', 'Setting saved successfully. reload the page to see changes.'));
+				notify(t('nldesign', 'Setting saved successfully. reload the page to see changes.'));
 			} else {
-				OC.Notification.showTemporary(t('nldesign', 'Failed to save setting.'));
+				notify(t('nldesign', 'Failed to save setting.'));
 			}
 		})
 		.catch(function(error) {
 			console.error('Error saving menu labels setting:', error);
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save setting.'));
+			notify(t('nldesign', 'Failed to save setting.'));
 		});
 	}
 
@@ -1016,9 +1045,9 @@ function nldesignAdminMain() {
 			if (data.status === 'ok') {
 				Object.keys(tokenEditorState).forEach(function(k) { tokenEditorState[k].isDirty = false; });
 				updateSaveStatus();
-				OC.Notification.showTemporary(t('nldesign', 'Token overrides saved.'));
+				notify(t('nldesign', 'Token overrides saved.'));
 			} else {
-				OC.Notification.showTemporary(t('nldesign', 'Failed to save overrides:') + (data.error || ''));
+				notify(t('nldesign', 'Failed to save overrides:') + (data.error || ''));
 			}
 		})
 		.catch(function(err) {
@@ -1026,7 +1055,7 @@ function nldesignAdminMain() {
 				btn.disabled = false;
 			}
 			console.error('Error saving overrides:', err);
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save overrides.'));
+			notify(t('nldesign', 'Failed to save overrides.'));
 		});
 	}
 
@@ -1061,12 +1090,12 @@ function nldesignAdminMain() {
 				}
 				initTokenEditor();
 			} else {
-				OC.Notification.showTemporary(t('nldesign', 'Import failed:') + (data.error || ''));
+				notify(t('nldesign', 'Import failed:') + (data.error || ''));
 			}
 		})
 		.catch(function(err) {
 			console.error('Error importing overrides:', err);
-			OC.Notification.showTemporary(t('nldesign', 'Import failed.'));
+			notify(t('nldesign', 'Import failed.'));
 		});
 	}
 
@@ -1243,14 +1272,14 @@ function nldesignAdminMain() {
 				if (tsData.status === 'ok' && tokenSetSelect !== null && publishMode !== true) {
 					tokenSetSelect.dataset.previousValue = newTokenSetId;
 				}
-				OC.Notification.showTemporary(t('nldesign', 'Token overrides applied.'));
+				notify(t('nldesign', 'Token overrides applied.'));
 				initTokenEditor();
 			})
 			.catch(function(err) {
 				btn.disabled    = false;
 				btn.textContent = t('nldesign', 'Apply selected');
 				console.error('Error applying token set:', err);
-				OC.Notification.showTemporary(t('nldesign', 'Failed to apply token set.'));
+				notify(t('nldesign', 'Failed to apply token set.'));
 			});
 		});
 	}
@@ -1469,14 +1498,14 @@ function nldesignAdminMain() {
 				if (feedback !== null) {
 					feedback.textContent = t('nldesign', 'App theming saved. Reload an affected app to see changes.');
 				}
-				OC.Notification.showTemporary(t('nldesign', 'App theming saved. Reload an affected app to see changes.'));
+				notify(t('nldesign', 'App theming saved. Reload an affected app to see changes.'));
 			} else {
-				OC.Notification.showTemporary(t('nldesign', 'Failed to save app theming.'));
+				notify(t('nldesign', 'Failed to save app theming.'));
 			}
 		})
 		.catch(function(err) {
 			console.error('Error saving app theming:', err);
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save app theming.'));
+			notify(t('nldesign', 'Failed to save app theming.'));
 		});
 	}
 
@@ -1686,7 +1715,7 @@ function nldesignAdminMain() {
 				if (feedback !== null) {
 					feedback.textContent = t('nldesign', 'Group theming saved.');
 				}
-				OC.Notification.showTemporary(t('nldesign', 'Group theming saved.'));
+				notify(t('nldesign', 'Group theming saved.'));
 				return;
 			}
 
@@ -1701,7 +1730,7 @@ function nldesignAdminMain() {
 				if (feedback !== null) {
 					feedback.textContent = message;
 				}
-				OC.Notification.showTemporary(message);
+				notify(message);
 				// Rows are left exactly as the admin edited them — no silent
 				// state reset — so the offending entry stays editable.
 				return;
@@ -1710,11 +1739,11 @@ function nldesignAdminMain() {
 			if (feedback !== null) {
 				feedback.textContent = t('nldesign', 'Failed to save group theming.');
 			}
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save group theming.'));
+			notify(t('nldesign', 'Failed to save group theming.'));
 		})
 		.catch(function(err) {
 			console.error('Error saving group theming:', err);
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save group theming.'));
+			notify(t('nldesign', 'Failed to save group theming.'));
 		});
 	}
 
@@ -1759,7 +1788,7 @@ function nldesignAdminMain() {
 
 		uploadBtn.addEventListener('click', function() {
 			if (nameInput.value.trim() === '') {
-				OC.Notification.showTemporary(t('nldesign', 'Enter a token set name first.'));
+				notify(t('nldesign', 'Enter a token set name first.'));
 				nameInput.focus();
 				return;
 			}
@@ -1878,7 +1907,7 @@ function nldesignAdminMain() {
 					resultEl.appendChild(document.createTextNode(t('nldesign', 'Upload failed:') + ' ' + (res.data.error || '')));
 					resultEl.appendChild(buildDiagnosticsFragment(res.data));
 				}
-				OC.Notification.showTemporary(t('nldesign', 'Upload failed:') + ' ' + (res.data.error || ''));
+				notify(t('nldesign', 'Upload failed:') + ' ' + (res.data.error || ''));
 				return;
 			}
 			var msg = t('nldesign', '{imported} tokens imported, {skipped} skipped.')
@@ -1895,12 +1924,12 @@ function nldesignAdminMain() {
 				resultEl.appendChild(document.createTextNode(msg));
 				resultEl.appendChild(buildDiagnosticsFragment(res.data));
 			}
-			OC.Notification.showTemporary(t('nldesign', 'Token set uploaded. Reload the page to apply it.'));
+			notify(t('nldesign', 'Token set uploaded. Reload the page to apply it.'));
 			loadCustomTokenSets();
 		})
 		.catch(function(err) {
 			console.error('Error uploading custom token set:', err);
-			OC.Notification.showTemporary(t('nldesign', 'Upload failed.'));
+			notify(t('nldesign', 'Upload failed.'));
 		});
 	}
 
@@ -1995,15 +2024,15 @@ function nldesignAdminMain() {
 				.then(function(r) { return r.json(); })
 				.then(function(data) {
 					if (data && data.status === 'ok') {
-						OC.Notification.showTemporary(t('nldesign', 'Custom token set deleted. Reload the page to refresh the dropdown.'));
+						notify(t('nldesign', 'Custom token set deleted. Reload the page to refresh the dropdown.'));
 						loadCustomTokenSets();
 					} else {
-						OC.Notification.showTemporary(t('nldesign', 'Failed to delete custom token set.'));
+						notify(t('nldesign', 'Failed to delete custom token set.'));
 					}
 				})
 				.catch(function(err) {
 					console.error('Error deleting custom token set:', err);
-					OC.Notification.showTemporary(t('nldesign', 'Failed to delete custom token set.'));
+					notify(t('nldesign', 'Failed to delete custom token set.'));
 				});
 			},
 			true
@@ -2034,7 +2063,7 @@ function nldesignAdminMain() {
 
 		uploadBtn.addEventListener('click', function() {
 			if (nameInput.value.trim() === '') {
-				OC.Notification.showTemporary(t('nldesign', 'Enter a font display name first.'));
+				notify(t('nldesign', 'Enter a font display name first.'));
 				nameInput.focus();
 				return;
 			}
@@ -2074,19 +2103,19 @@ function nldesignAdminMain() {
 				if (resultEl !== null) {
 					resultEl.textContent = t('nldesign', 'Upload failed:') + ' ' + (res.data.error || '');
 				}
-				OC.Notification.showTemporary(t('nldesign', 'Upload failed:') + ' ' + (res.data.error || ''));
+				notify(t('nldesign', 'Upload failed:') + ' ' + (res.data.error || ''));
 				return;
 			}
 			if (resultEl !== null) {
 				resultEl.textContent = '';
 				resultEl.style.display = 'none';
 			}
-			OC.Notification.showTemporary(t('nldesign', 'Font uploaded. Reload the page to apply it.'));
+			notify(t('nldesign', 'Font uploaded. Reload the page to apply it.'));
 			loadFonts();
 		})
 		.catch(function(err) {
 			console.error('Error uploading font:', err);
-			OC.Notification.showTemporary(t('nldesign', 'Upload failed.'));
+			notify(t('nldesign', 'Upload failed.'));
 		});
 	}
 
@@ -2165,15 +2194,15 @@ function nldesignAdminMain() {
 				.then(function(r) { return r.json(); })
 				.then(function(data) {
 					if (data && data.status === 'ok') {
-						OC.Notification.showTemporary(t('nldesign', 'Font deleted. Reload the page to refresh the styling.'));
+						notify(t('nldesign', 'Font deleted. Reload the page to refresh the styling.'));
 						loadFonts();
 					} else {
-						OC.Notification.showTemporary(t('nldesign', 'Failed to delete font.'));
+						notify(t('nldesign', 'Failed to delete font.'));
 					}
 				})
 				.catch(function(err) {
 					console.error('Error deleting font:', err);
-					OC.Notification.showTemporary(t('nldesign', 'Failed to delete font.'));
+					notify(t('nldesign', 'Failed to delete font.'));
 				});
 			},
 			true
@@ -2323,7 +2352,7 @@ function nldesignAdminMain() {
 		.then(function(result) {
 			if (result.status === 200 && result.data.applied === true) {
 				showConfigBundleResult(t('nldesign', 'Configuration imported successfully. Reloading…'));
-				OC.Notification.showTemporary(t('nldesign', 'Configuration imported successfully.'));
+				notify(t('nldesign', 'Configuration imported successfully.'));
 				window.setTimeout(function() { window.location.reload(); }, 1200);
 				return;
 			}
@@ -2335,12 +2364,12 @@ function nldesignAdminMain() {
 			showConfigBundleResult(
 				t('nldesign', 'Import failed — nothing was applied:') + ' ' + lines.join('; ')
 			);
-			OC.Notification.showTemporary(t('nldesign', 'Configuration import failed.'));
+			notify(t('nldesign', 'Configuration import failed.'));
 		})
 		.catch(function(err) {
 			console.error('Error importing configuration bundle:', err);
 			showConfigBundleResult(t('nldesign', 'Import failed.'));
-			OC.Notification.showTemporary(t('nldesign', 'Configuration import failed.'));
+			notify(t('nldesign', 'Configuration import failed.'));
 		});
 	}
 
@@ -2462,7 +2491,7 @@ function nldesignAdminMain() {
 				if (feedback !== null) {
 					feedback.textContent = t('nldesign', 'Email template settings saved.');
 				}
-				OC.Notification.showTemporary(t('nldesign', 'Email template settings saved.'));
+				notify(t('nldesign', 'Email template settings saved.'));
 				return;
 			}
 
@@ -2476,7 +2505,7 @@ function nldesignAdminMain() {
 					if (enableCode !== null && data.occEnable) { enableCode.textContent = data.occEnable; }
 					if (disableCode !== null && data.occDisable) { disableCode.textContent = data.occDisable; }
 				}
-				OC.Notification.showTemporary(t('nldesign', 'config.php is read-only; run the shown occ command manually.'));
+				notify(t('nldesign', 'config.php is read-only; run the shown occ command manually.'));
 				return;
 			}
 
@@ -2487,20 +2516,20 @@ function nldesignAdminMain() {
 				if (foreignNote !== null) {
 					foreignNote.textContent = t('nldesign', 'A different mail template class is already configured ({class}); nldesign will not overwrite it.', { class: data.class });
 				}
-				OC.Notification.showTemporary(t('nldesign', 'A different mail template class is already configured.'));
+				notify(t('nldesign', 'A different mail template class is already configured.'));
 				return;
 			}
 
 			if (data && data.error === 'invalid_footer') {
-				OC.Notification.showTemporary(t('nldesign', 'Invalid footer URL — use an http:// or https:// address.'));
+				notify(t('nldesign', 'Invalid footer URL — use an http:// or https:// address.'));
 				return;
 			}
 
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save email template settings.'));
+			notify(t('nldesign', 'Failed to save email template settings.'));
 		})
 		.catch(function(err) {
 			console.error('Error saving email theming:', err);
-			OC.Notification.showTemporary(t('nldesign', 'Failed to save email template settings.'));
+			notify(t('nldesign', 'Failed to save email template settings.'));
 		});
 	}
 
@@ -2628,7 +2657,7 @@ function nldesignAdminMain() {
 			})
 			.then(function(r) { return r.json(); })
 			.then(function() {
-				OC.Notification.showTemporary(enabled
+				notify(enabled
 					? t('nldesign', 'Upstream token update checks enabled.')
 					: t('nldesign', 'Upstream token update checks disabled.'));
 				loadUpstreamFreshness();

--- a/js/preview-banner.js
+++ b/js/preview-banner.js
@@ -62,7 +62,15 @@
 			.catch(function(err) {
 				console.error('Error discarding theme preview:', err);
 				discardBtn.disabled = false;
-				OC.Notification.showTemporary(t('nldesign', 'Failed to discard theme preview.'));
+				// OC.Notification was removed in NC 34; guard so a missing
+				// toast API can never throw on top of the original failure.
+				try {
+					if (window.OCP && OCP.Toast && typeof OCP.Toast.message === 'function') {
+						OCP.Toast.message(t('nldesign', 'Failed to discard theme preview.'));
+					}
+				} catch (e) {
+					console.info('[nldesign] Failed to discard theme preview.');
+				}
 			});
 		});
 		actions.appendChild(discardBtn);

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -42,7 +42,12 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	const page = await context.newPage()
 
 	await page.goto('/index.php/login')
-	await page.locator('input[name="user"]').fill(username)
+	// The Nextcloud login form is client-rendered (Vue): the inputs do not
+	// exist in the initial HTML, so filling immediately after goto() races the
+	// hydration and fails with "element not found". Wait for the real field.
+	const userField = page.locator('input[name="user"]')
+	await userField.waitFor({ state: 'visible', timeout: 30_000 })
+	await userField.fill(username)
 	await page.locator('input[name="password"]').fill(password)
 	await page.locator('button[type="submit"]').first().click()
 	await page.waitForSelector('#header, header.header', { timeout: 20_000 })

--- a/tests/e2e/spec-coverage/admin-feature-panels.spec.ts
+++ b/tests/e2e/spec-coverage/admin-feature-panels.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @e2e openspec/specs/email-theming/spec.md
+ * @e2e openspec/specs/custom-fonts/spec.md
+ * @e2e openspec/specs/theming-audit/spec.md
+ * @e2e openspec/specs/upstream-freshness/spec.md
+ * @e2e openspec/specs/per-group-theming/spec.md
+ * @e2e openspec/specs/config-portability/spec.md
+ * @e2e openspec/specs/theme-preview/spec.md
+ *
+ * Every admin panel added by the market-gap wave must actually render in the
+ * Theming settings page — a controller + route with no reachable UI is the
+ * "orphaned capability" defect class this fleet keeps hitting.
+ */
+import { test, expect, Page } from '@playwright/test'
+
+const THEMING_URL = '/settings/admin/theming'
+
+/**
+ * GET an nldesign settings endpoint from inside the authenticated page.
+ *
+ * These routes are session-authenticated and therefore CSRF-protected: a raw
+ * request-context call (cookies only, no `requesttoken`) is rejected with 412
+ * by Nextcloud's middleware. Issuing the fetch in-page is both correct and
+ * closer to what `js/admin.js` actually does.
+ */
+async function apiGet(page: Page, path: string): Promise<Record<string, unknown>> {
+	return page.evaluate(async (p) => {
+		const res = await fetch(p, {
+			headers: { requesttoken: (window as any).OC.requestToken },
+		})
+		return res.json()
+	}, path)
+}
+
+/** Each wave feature: its settings-panel anchor and a human label. */
+const PANELS: Array<{ id: string, label: string }> = [
+	{ id: '#nldesign-email-theming', label: 'email template theming' },
+	{ id: '#nldesign-custom-fonts', label: 'custom font upload' },
+	{ id: '#nldesign-audit-log', label: 'theming audit log' },
+	{ id: '#nldesign-upstream-freshness', label: 'upstream token freshness' },
+	{ id: '#nldesign-group-theming', label: 'per-group theming' },
+]
+
+test.describe('admin panels for the market-gap wave features', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto(THEMING_URL)
+		await page.locator('#nldesign-settings').waitFor({ state: 'visible', timeout: 20_000 })
+	})
+
+	for (const panel of PANELS) {
+		test(`the ${panel.label} panel is present and visible`, async ({ page }) => {
+			const el = page.locator(panel.id)
+			await expect(el, `${panel.label} must render a reachable panel`).toHaveCount(1)
+			await expect(el).toBeVisible()
+		})
+	}
+
+	test('the dark-variants toggle renders and reflects persisted state', async ({ page }) => {
+		const toggle = page.locator('#nldesign-dark-variants')
+		await expect(toggle).toHaveCount(1)
+
+		const state = await apiGet(page, '/index.php/apps/nldesign/settings/dark-variants')
+		expect(await toggle.isChecked()).toBe(state.enabled)
+	})
+
+	test('the audit log lists entries with the documented columns', async ({ page }) => {
+		const table = page.locator('#nldesign-audit-table')
+		await expect(table).toBeVisible()
+		for (const header of ['Timestamp', 'User', 'Action', 'Details']) {
+			await expect(table.locator('thead')).toContainText(header)
+		}
+	})
+
+	test('upstream freshness is opt-in and discloses the contacted host', async ({ page }) => {
+		const toggle = page.locator('#nldesign-upstream-freshness-toggle')
+		await expect(toggle).toHaveCount(1)
+
+		// Default OFF: the app must make no outbound request unless asked.
+		const status = await apiGet(page, '/index.php/apps/nldesign/settings/upstream-freshness')
+		expect(status.enabled).toBe(false)
+
+		// The egress target must be named in the UI, not hidden in docs.
+		await expect(page.locator('#nldesign-upstream-freshness')).toContainText('api.github.com')
+	})
+
+	test('the custom-fonts panel states uploader licence responsibility', async ({ page }) => {
+		await expect(page.locator('#nldesign-custom-fonts')).toContainText(/licen[cs]e/i)
+	})
+})

--- a/tests/e2e/spec-coverage/dark-mode.spec.ts
+++ b/tests/e2e/spec-coverage/dark-mode.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @e2e openspec/specs/dark-mode/spec.md
+ *
+ * Dark-mode token variants: the generated dark stylesheet is injected next to
+ * the light token layer, is scoped so an explicit light choice is never
+ * darkened, and the admin toggle gates it instance-wide.
+ */
+import { test, expect, Page } from '@playwright/test'
+
+const THEMING_URL = '/settings/admin/theming'
+const PROBE_URL = '/settings/user'
+
+/**
+ * Read the dark-variants toggle state from inside the authenticated page.
+ *
+ * The settings routes are CSRF-protected, so a raw request-context call
+ * (cookies without `requesttoken`) is rejected with 412 — fetching in-page is
+ * both correct and what `js/admin.js` does.
+ */
+async function darkVariantsEnabled(page: Page): Promise<boolean> {
+	return page.evaluate(async () => {
+		const res = await fetch('/index.php/apps/nldesign/settings/dark-variants', {
+			headers: { requesttoken: (window as any).OC.requestToken },
+		})
+		return (await res.json()).enabled
+	})
+}
+
+/** The nldesign stylesheet hrefs present in the page head. */
+async function nldesignStyles(page: Page): Promise<string[]> {
+	return page.evaluate(() =>
+		[...document.querySelectorAll('link[rel=stylesheet]')]
+			.map((l) => (l as HTMLLinkElement).href)
+			.filter((h) => h.includes('/nldesign/')),
+	)
+}
+
+test.describe('dark-mode token variants', () => {
+	test('the dark stylesheet is injected directly after the light token layer', async ({ page }) => {
+		await page.goto(PROBE_URL)
+		const styles = await nldesignStyles(page)
+
+		const lightIndex = styles.findIndex((h) => /\/css\/tokens\/[^/]+\.css/.test(h))
+		const darkIndex = styles.findIndex((h) => h.includes('/css/tokens/dark/'))
+
+		expect(lightIndex, 'light token stylesheet must be present').toBeGreaterThanOrEqual(0)
+		expect(darkIndex, 'dark variant stylesheet must be present').toBeGreaterThanOrEqual(0)
+		// The dark layer must come AFTER the light one so its scoped rules win.
+		expect(darkIndex).toBeGreaterThan(lightIndex)
+	})
+
+	test('the dark stylesheet is dual-scoped and never darkens an explicit light choice', async ({ page }) => {
+		await page.goto(PROBE_URL)
+		const styles = await nldesignStyles(page)
+		const darkHref = styles.find((h) => h.includes('/css/tokens/dark/'))
+		expect(darkHref).toBeTruthy()
+
+		const css = await (await page.request.get(darkHref as string)).text()
+
+		// Auto mode: follows the OS preference.
+		expect(css).toContain('prefers-color-scheme: dark')
+		// Explicit dark theme selection.
+		expect(css).toContain('data-theme-dark')
+		// An explicitly chosen LIGHT theme must be excluded from the media-query
+		// branch, otherwise a user who picked light would be darkened by the OS.
+		expect(css).toContain(':not([data-theme-light])')
+	})
+
+	test('the admin toggle renders, is checked by default, and matches persisted state', async ({ page }) => {
+		await page.goto(THEMING_URL)
+		const toggle = page.locator('#nldesign-dark-variants')
+		await toggle.waitFor({ state: 'attached', timeout: 15_000 })
+
+		// The rendered control must agree with the persisted app config —
+		// a toggle that renders a stale default is the bug this catches.
+		expect(await toggle.isChecked()).toBe(await darkVariantsEnabled(page))
+	})
+
+	// @e2e exclude openspec/specs/dark-mode/spec.md#requirement-admin-toggle
+	// Flipping the toggle mutates INSTANCE-WIDE state on the shared dev
+	// instance (same rationale as the hide-slogan spec's excluded
+	// checkbox-change test). The gating behaviour — toggle off ⇒ no dark
+	// stylesheet is injected — is covered by DarkPaletteService /
+	// CssInjectionService unit tests and was verified manually against the
+	// live instance (occ toggle off ⇒ 0 dark stylesheets ⇒ restored).
+})

--- a/tests/e2e/spec-coverage/icon-assets-ncvue.spec.ts
+++ b/tests/e2e/spec-coverage/icon-assets-ncvue.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @e2e openspec/specs/icon-assets/spec.md
+ *
+ * Icons come from @conduction/nextcloud-vue, not the proprietary Amsterdam
+ * set: the three EUPL/CC0 packs serve, mapped legacy names still resolve for
+ * one deprecation release, and unmapped Amsterdam-only names are gone.
+ */
+import { test, expect } from '@playwright/test'
+
+const ICON_BASE = '/custom_apps/nldesign/img/icons'
+const LOGO_BASE = '/custom_apps/nldesign/img/logos'
+
+// One representative icon per bundled pack (names are the public API).
+const PACK_ICONS = [
+	`${ICON_BASE}/rvo/rvo-aangifte-ondernemers.svg`,
+	`${ICON_BASE}/open-gemeenten/og-afval.svg`,
+	`${ICON_BASE}/den-haag/dh-arrows-arrow-left.svg`,
+]
+
+test.describe('icon assets sourced from nc-vue', () => {
+	for (const path of PACK_ICONS) {
+		test(`serves ${path.split('/').slice(-2).join('/')} as valid SVG`, async ({ request }) => {
+			const res = await request.get(path)
+			expect(res.status()).toBe(200)
+
+			const body = await res.text()
+			expect(body).toContain('<svg')
+			expect(body).toContain('</svg>')
+		})
+	}
+
+	test('a mapped legacy PascalCase name still resolves during the deprecation release', async ({ request }) => {
+		const res = await request.get(`${ICON_BASE}/ArrowBackward.svg`)
+		expect(res.status()).toBe(200)
+		expect(await res.text()).toContain('<svg')
+	})
+
+	test('an unmapped Amsterdam-only icon name is gone (404), not silently served', async ({ request }) => {
+		// `Airplane` existed only in the proprietary Amsterdam set and has no
+		// alias mapping — it must 404 rather than resolve to unrelated artwork.
+		const res = await request.get(`${ICON_BASE}/Airplane.svg`, { failOnStatusCode: false })
+		expect(res.status()).toBe(404)
+	})
+
+	test('organisation logos remain served (they are huisstijl assets, not icons)', async ({ request }) => {
+		const res = await request.get(`${LOGO_BASE}/rijkshuisstijl.svg`, { failOnStatusCode: false })
+		expect(res.status()).toBe(200)
+		expect(await res.text()).toContain('<svg')
+	})
+})

--- a/tests/e2e/spec-coverage/render-context-injection.spec.ts
+++ b/tests/e2e/spec-coverage/render-context-injection.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @e2e openspec/specs/css-architecture/spec.md
+ * @e2e openspec/specs/theming-capability/spec.md
+ *
+ * Render-event injection: every render context (logged-in, login/guest,
+ * error) receives the full nldesign cascade in the documented order, and the
+ * huisstijl is published through the public capability.
+ */
+import { test, expect, Page } from '@playwright/test'
+
+async function nldesignStyles(page: Page): Promise<string[]> {
+	return page.evaluate(() =>
+		[...document.querySelectorAll('link[rel=stylesheet]')]
+			.map((l) => (l as HTMLLinkElement).href)
+			.filter((h) => h.includes('/nldesign/')),
+	)
+}
+
+test.describe('render-context CSS injection', () => {
+	test('a logged-in page receives the themed cascade', async ({ page }) => {
+		await page.goto('/settings/user')
+		const styles = await nldesignStyles(page)
+		expect(styles.length).toBeGreaterThan(0)
+		// Design-system layer precedes the token layer, which precedes overrides.
+		const sys = styles.findIndex((h) => h.includes('/css/systems/'))
+		const tok = styles.findIndex((h) => /\/css\/tokens\/[^/]+\.css/.test(h))
+		const ovr = styles.findIndex((h) => h.includes('custom-overrides'))
+		expect(sys).toBeGreaterThanOrEqual(0)
+		expect(tok).toBeGreaterThan(sys)
+		expect(ovr).toBeGreaterThan(tok)
+	})
+
+	test('the login page (guest render) is themed too', async ({ browser }) => {
+		// A fresh context with no stored session lands on the real login page.
+		const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } })
+		const page = await ctx.newPage()
+		await page.goto('/index.php/login')
+		await page.locator('input[name="user"]').waitFor({ state: 'visible', timeout: 30_000 })
+
+		expect((await nldesignStyles(page)).length).toBeGreaterThan(0)
+		await ctx.close()
+	})
+
+	test('an error page keeps the huisstijl (previously unthemed)', async ({ page }) => {
+		await page.goto('/index.php/apps/definitely-not-an-app/', { waitUntil: 'domcontentloaded' })
+		expect(
+			(await nldesignStyles(page)).length,
+			'error/404 renders must stay branded',
+		).toBeGreaterThan(0)
+	})
+
+	test('the active huisstijl is published pre-login via the OCS capability', async ({ request }) => {
+		const res = await request.get('/ocs/v2.php/cloud/capabilities?format=json', {
+			headers: { 'OCS-APIRequest': 'true' },
+		})
+		expect(res.status()).toBe(200)
+
+		const cap = (await res.json()).ocs.data.capabilities.nldesign
+		expect(cap, 'nldesign capability must be present').toBeTruthy()
+		expect(cap.tokenSet).toHaveProperty('id')
+		expect(cap.designSystem).toBeTruthy()
+		// Strict allowlist — private config must never leak into a public doc.
+		expect(Object.keys(cap).sort()).toEqual(
+			['designSystem', 'hideSlogan', 'logos', 'showMenuLabels', 'tokenSet', 'version', 'wcagLevel'].sort(),
+		)
+	})
+})


### PR DESCRIPTION
## The suite was dead

`global-setup.ts` filled the login form immediately after `goto()`, but Nextcloud's login is Vue-rendered — the inputs did not exist yet, so **every e2e run died in setup**. One `waitFor()` revives all 31 existing specs (admin-settings: 17/17 on a calm instance).

## A real bug the revived suite found

`OC.Notification` **was removed in NC 34**. All 56 `OC.Notification.showTemporary()` calls throw a TypeError, and because they sit inside `.then()` handlers the throw aborted the rest of the handler — a custom token set uploaded fine server-side but `loadCustomTokenSets()` never ran, so the list silently never refreshed. Added a `notify()` guard (OCP.Toast → legacy → console) and routed all call sites through it. Verified by direct browser probe: page error gone, list refreshes.

## New coverage for the market-gap wave

The 16 shipped features had **zero** browser coverage (only `@e2e exclude covered by <PHPUnit>` annotations):
- `dark-mode` — dark layer after the light one, dual-scoped so an explicit light choice is never darkened
- `icon-assets-ncvue` — the three nc-vue packs serve as valid SVG, a mapped legacy name resolves, an unmapped Amsterdam-only name 404s, logos survive
- `render-context-injection` — logged-in / login / error renders themed in cascade order; OCS capability publishes pre-login with a strict 7-key allowlist
- `admin-feature-panels` — every wave feature has a **reachable** admin panel (guards the orphaned-capability defect class)

22/22 green on a calm instance. 453 PHPUnit, 36 vitest, `check:strict` green.

## Known limitation

The suite is load-sensitive: sustained headless-browser load saturates Apache on the shared dev instance (503s), which makes runs flaky. Follow-up issue to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)