### PR TITLE
feat(lasuite): generate full Cunningham token base, sourced violet override, complete bridge coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,8 @@ tests/e2e/test-results/
 tests/e2e/.auth/
 /coverage-vitest/
 /coverage/
+
+# Scratch research inputs for the lasuite-token-completeness change — captured
+# facts about the LIVE docs.numerique.gouv.fr bundle, not app source. The
+# authoritative, committed output is css/systems/lasuite/brand-override.css.
+/.lasuite-src/

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Apply Dutch government design tokens (NL Design System) to your Nextcloud instan
 
 ## Features
 
-- **43 token sets**: Choose from Dutch government design systems, including:
+- **44 token sets**: Choose from Dutch government design systems, including:
   - Rijkshuisstijl (Dutch national government)
   - Gemeente Utrecht
   - Gemeente Amsterdam
   - Gemeente Den Haag
   - Gemeente Rotterdam
-  - La Suite numérique (Cunningham design system, European sovereign-workplace / MinBZK-mijn-bureau EDIC bundles)
+  - La Suite numérique (Cunningham design system, European sovereign-workplace / MinBZK-mijn-bureau EDIC bundles) — plus the published Cunningham blue base as an optional sibling set
   - …and a broad set of community-maintained municipality and organization brands
 
 - **Open Source Fonts**: Uses **Fira Sans** from `@fontsource/fira-sans` and **Inter** (self-hosted from `@fontsource/inter`) as professional alternatives to proprietary government fonts

--- a/css/systems/lasuite/brand-override.css
+++ b/css/systems/lasuite/brand-override.css
@@ -1,0 +1,96 @@
+/**
+ * La Suite numérique — Sourced Brand Override Layer (VIOLET, deployed theme)
+ *
+ * PROVENANCE: observed in the live docs.numerique.gouv.fr La Suite Docs
+ * bundle, `:root` block 5 (the VIOLET override block that wins the cascade
+ * over block 0's blue Cunningham base), observed 2026-07-24. These values
+ * are NOT present in any published Cunningham npm package — neither
+ * `@openfun/cunningham-tokens@3.0.0` nor `@gouvfr-lasuite/ui-kit@0.27.0`
+ * ship anything but the blue base (brand-600 #0659c5 / #1a509f respectively).
+ * The violet La Suite users actually see exists only as this app-level
+ * deployment override, so it is hand-authored and sourced here rather than
+ * generated — see css/systems/lasuite/defaults.css for the generated blue
+ * base this file redeclares over.
+ *
+ * SCOPE: only the brand colour scale and the logo tokens the live block-5
+ * override actually changes. The live bundle's block 5 also touches a
+ * `--c--components--*` namespace (badge/alert component tokens) that does
+ * not exist at all in the published npm packages (a newer/live-only
+ * Cunningham build) — those are out of scope here; this file only overrides
+ * tokens the generated defaults.css already defines.
+ *
+ * Load order: fonts → defaults → [brand-override] → bridge →
+ * element-overrides, then tokens/lasuite. Both this file and defaults.css
+ * write plain `:root`, so — loaded after defaults — this file's
+ * declarations win the cascade for every token it redeclares; the
+ * compatibility-alias short names in defaults.css (`--lasuite-color-brand-*`)
+ * reference the canonical `--lasuite--globals--colors--brand-*` tokens via
+ * var(), so overriding the canonical tokens here is sufficient for the alias
+ * names to resolve violet too — the four aliases the bridge/element-overrides
+ * layers actually read are ALSO redeclared explicitly below for robustness
+ * (belt-and-braces, not reliance on var() indirection alone).
+ *
+ * NOT generator output: scripts/generate-lasuite-tokens.mjs must never write
+ * to this file, and the drift guard (`npm run test:lasuite-tokens`) does not
+ * touch it.
+ */
+
+:root {
+	/* ===================================================================
+	 * BRAND SCALE (violet) — full 19-step scale, block-5 observed values.
+	 * =================================================================== */
+
+	--lasuite--globals--colors--brand-050: #eef1fa;
+	--lasuite--globals--colors--brand-100: #dde2f5;
+	--lasuite--globals--colors--brand-150: #ced3f1;
+	--lasuite--globals--colors--brand-200: #bec5f0;
+	--lasuite--globals--colors--brand-250: #afb5f1;
+	--lasuite--globals--colors--brand-300: #a0a5f6;
+	--lasuite--globals--colors--brand-350: #8f94fd;
+	--lasuite--globals--colors--brand-400: #8184fc;
+	--lasuite--globals--colors--brand-450: #7576ee;
+	--lasuite--globals--colors--brand-500: #6969df;
+	--lasuite--globals--colors--brand-550: #5e5cd0;
+	--lasuite--globals--colors--brand-600: #534fc2;
+	--lasuite--globals--colors--brand-650: #4844ad; /* La Suite brand — also the logo colour */
+	--lasuite--globals--colors--brand-700: #3e3b98;
+	--lasuite--globals--colors--brand-750: #36347d;
+	--lasuite--globals--colors--brand-800: #2d2f5f;
+	--lasuite--globals--colors--brand-850: #262848;
+	--lasuite--globals--colors--brand-900: #1c1e32;
+	--lasuite--globals--colors--brand-950: #11131f;
+
+	/* ===================================================================
+	 * LOGO TOKENS
+	 * The base Cunningham package defines --c--globals--colors--logo-1/-2
+	 * (no "-light" suffix) and --logo-1-dark/--logo-2-dark. The live violet
+	 * override INTRODUCES a "-light" variant (not present in the base
+	 * package at all) and redirects --c--contextuals--content--logo1/logo2
+	 * to point at it — both reproduced below. It also changes the existing
+	 * dark variants from the base's blue #95abff to a violet-scale #bec5f0
+	 * (brand-200); reproduced for upstream fidelity even though nldesign
+	 * does not currently activate the .cunningham-theme--dark block.
+	 * =================================================================== */
+
+	--lasuite--globals--colors--logo-1-light: #4844ad;
+	--lasuite--globals--colors--logo-2-light: #4844ad;
+	--lasuite--globals--colors--logo-1-dark: #bec5f0;
+	--lasuite--globals--colors--logo-2-dark: #bec5f0;
+
+	--lasuite--contextuals--content--logo1: var(--lasuite--globals--colors--logo-1-light);
+	--lasuite--contextuals--content--logo2: var(--lasuite--globals--colors--logo-2-light);
+
+	/* ===================================================================
+	 * SHORT-ALIAS COUNTERPARTS
+	 * The four --lasuite-color-brand-* short names bridge.css and
+	 * element-overrides.css actually read. Already implied by the canonical
+	 * overrides above via var() indirection (defaults.css's compatibility
+	 * aliases reference these canonical names) — redeclared explicitly here
+	 * so this file is self-contained and does not rely on that indirection.
+	 * =================================================================== */
+
+	--lasuite-color-brand-050: var(--lasuite--globals--colors--brand-050);
+	--lasuite-color-brand-100: var(--lasuite--globals--colors--brand-100);
+	--lasuite-color-brand-650: var(--lasuite--globals--colors--brand-650);
+	--lasuite-color-brand-750: var(--lasuite--globals--colors--brand-750);
+}

--- a/css/systems/lasuite/bridge.css
+++ b/css/systems/lasuite/bridge.css
@@ -9,15 +9,24 @@
  *   2. Nextcloud's own `--color-*` custom properties (so core chrome and the
  *      Cn* component library pick up the theme without touching source).
  *
- * Load order: fonts → defaults → [bridge] → element-overrides, then
- * tokens/lasuite.
+ * Load order: fonts → defaults → brand-override → [bridge] →
+ * element-overrides, then tokens/lasuite.
+ *
+ * COVERAGE: every one of the 68 audited Nextcloud `--color-*` variables (the
+ * `nextcloud-variable-mapping` canonical surface — the same set
+ * css/systems/nldesign/overrides.css covers) appears below, either as an
+ * active mapping or as a commented line stating why it is not overridden.
+ * `npm run test:lasuite-bridge-coverage` (tests/css/check-lasuite-bridge-
+ * coverage.js) asserts this by diffing the variable name sets and fails on
+ * any audited variable that is neither mapped nor commented here.
  *
  * css-architecture invariants honoured here (REQ-CSS-005/007, ADR-CSS-002):
  *   - !important is used ONLY where Nextcloud's own `body[data-themes]` CSS
  *     sets the same variable at equal specificity and must be beaten.
  *   - --color-main-background, --color-main-background-rgb,
- *     --color-main-background-translucent and --color-background-plain are
- *     NEVER set here (dark-mode auto-derivation depends on them).
+ *     --color-main-background-translucent, --color-main-background-blur,
+ *     --color-background-plain and --color-background-plain-text are NEVER
+ *     set here (dark-mode auto-derivation depends on them).
  *   - --background-invert-if-dark / --background-invert-if-bright are NEVER
  *     set here (Nextcloud's dark-theme header-icon logic depends on them).
  *   - Every fallback resolves to a concrete value or a --lasuite-* token
@@ -38,15 +47,20 @@
 	--nldesign-color-primary-light: var(--lasuite-color-brand-050);
 	--nldesign-color-primary-light-hover: var(--lasuite-color-brand-100);
 
+	/* -*-rgb literal triples below MUST stay in sync with the hex value of
+	 * the corresponding --lasuite-color-*-550 token (plain CSS custom
+	 * properties cannot derive an rgba() triple from a hex var() at
+	 * declaration time). Recomputed against the generated defaults.css —
+	 * see css/systems/lasuite/defaults.css for the current hex values. */
 	--nldesign-color-error: var(--lasuite-color-error-550);
-	--nldesign-color-error-rgb: 215, 1, 14;
+	--nldesign-color-error-rgb: 216, 0, 0; /* #d80000 */
 	--nldesign-color-error-hover: var(--lasuite-color-error-650);
 	--nldesign-color-warning: var(--lasuite-color-warning-550);
-	--nldesign-color-warning-rgb: 188, 66, 0;
+	--nldesign-color-warning-rgb: 131, 103, 3; /* #836703 */
 	--nldesign-color-success: var(--lasuite-color-success-550);
-	--nldesign-color-success-rgb: 2, 123, 62;
+	--nldesign-color-success-rgb: 66, 120, 22; /* #427816 */
 	--nldesign-color-info: var(--lasuite-color-info-550);
-	--nldesign-color-info-rgb: 0, 105, 207;
+	--nldesign-color-info-rgb: 17, 103, 212; /* #1167d4 */
 
 	--nldesign-color-text: var(--lasuite-color-gray-900);
 	--nldesign-color-text-muted: var(--lasuite-color-gray-500);
@@ -58,8 +72,8 @@
 	/* Focus ring — semi-transparent info blue, same DELIBERATE-EXCEPTION
 	 * rationale as ADR-CSS-003: translucency keeps the ring visible on any
 	 * background without needing separate light/dark variants. */
-	--nldesign-color-focus: rgba(0, 105, 207, 0.5);
-	--nldesign-color-focus-rgb: 0, 105, 207;
+	--nldesign-color-focus: rgba(17, 103, 212, 0.5); /* #1167d4 */
+	--nldesign-color-focus-rgb: 17, 103, 212; /* #1167d4 */
 
 	--nldesign-color-header-background: var(--lasuite-color-gray-000);
 	--nldesign-color-header-text: var(--lasuite-color-gray-900);
@@ -97,53 +111,168 @@
 }
 
 /* ===================================================================
- * NEXTCLOUD --color-* MAPPING
+ * NEXTCLOUD --color-* MAPPING (68/68 audited variables — see COVERAGE
+ * note in the file header)
  * Applied at body[data-themes] to beat NC's own equal-specificity
  * assignment of the same variables (ADR-CSS-002 category 1).
  * =================================================================== */
 
 body[data-themes],
 body {
+
+	/* ===================================================================
+	 * PRIMARY COLORS
+	 * =================================================================== */
+
 	--color-primary: var(--lasuite-color-brand-650) !important;
 	--color-primary-text: var(--lasuite-color-gray-000) !important;
 	--color-primary-hover: var(--lasuite-color-brand-750) !important;
 	--color-primary-light: var(--lasuite-color-brand-050) !important;
+	--color-primary-light-hover: var(--lasuite-color-brand-100) !important;
+	--color-primary-light-text: var(--lasuite-color-brand-650) !important;
 	--color-primary-element: var(--lasuite-color-brand-650) !important;
 	--color-primary-element-text: var(--lasuite-color-gray-000) !important;
 	--color-primary-element-hover: var(--lasuite-color-brand-750) !important;
 	--color-primary-element-light: var(--lasuite-color-brand-050) !important;
 	--color-primary-element-light-text: var(--lasuite-color-brand-650) !important;
 	--color-primary-element-light-hover: var(--lasuite-color-brand-100) !important;
+	/* --color-primary-element-text-dark: intentionally not overridden — dark variant auto-calculated by Nextcloud */
 
-	/* Surfaces — background-hover/dark/darker only. --color-main-background
-	 * and --color-background-plain are intentionally NOT set here: Nextcloud
-	 * derives its dark-mode calculations from them (REQ-CSS-007). */
+	/* ===================================================================
+	 * MAIN BACKGROUND — REQ-CSS-007
+	 * Intentionally not overridden — core to Nextcloud's dark/light mode
+	 * auto-derivation and admin/user configuration.
+	 * =================================================================== */
+
+	/* --color-main-background: intentionally not overridden — overriding breaks dark mode (REQ-CSS-007) */
+	/* --color-main-background-rgb: intentionally not overridden — depends on main-background (REQ-CSS-007) */
+	/* --color-main-background-translucent: intentionally not overridden — depends on main-background-rgb (REQ-CSS-007) */
+	/* --color-main-background-blur: intentionally not overridden — depends on main-background-rgb (REQ-CSS-007) */
+	/* --color-background-plain: intentionally not overridden — admin/user configured, entangled with dark-mode background derivation (REQ-CSS-007) */
+	/* --color-background-plain-text: intentionally not overridden — auto-calculated by Nextcloud */
+
+	/* ===================================================================
+	 * BACKGROUND STATES
+	 * =================================================================== */
+
 	--color-background-hover: var(--lasuite-color-gray-050) !important;
 	--color-background-dark: var(--lasuite-color-gray-100) !important;
 	--color-background-darker: var(--lasuite-color-gray-200) !important;
 
+	/* ===================================================================
+	 * PLACEHOLDER COLORS
+	 * Skeleton-loader shimmer gradient — two adjacent tones from the
+	 * Cunningham greyscale, same theme regardless of light/dark.
+	 * =================================================================== */
+
+	--color-placeholder-light: var(--lasuite-color-gray-025) !important;
+	--color-placeholder-dark: var(--lasuite-color-gray-100) !important;
+
+	/* ===================================================================
+	 * TEXT COLORS
+	 * =================================================================== */
+
 	--color-main-text: var(--lasuite-color-gray-900) !important;
 	--color-text-maxcontrast: var(--lasuite-color-gray-500) !important;
+	/* --color-text-maxcontrast-default: unmapped — auto-calculated per theme by Nextcloud */
+	/* --color-text-maxcontrast-background-blur: unmapped — blur-adjusted maxcontrast, auto-calculated */
 	--color-text-light: var(--lasuite-color-gray-000) !important;
+	--color-text-lighter: var(--lasuite-color-gray-500) !important;
+	--color-text-error: var(--lasuite-color-error-550) !important;
+	--color-text-success: var(--lasuite-color-success-550) !important;
+	--color-text-warning: var(--lasuite-color-warning-550) !important;
+
+	/* ===================================================================
+	 * STATUS: ERROR
+	 * =================================================================== */
 
 	--color-error: var(--lasuite-color-error-550) !important;
+	--color-error-hover: var(--lasuite-color-error-650) !important;
+	/* --color-error-text: unmapped — auto-calculated for contrast by Nextcloud */
+	--color-error-rgb: var(--nldesign-color-error-rgb) !important;
+	--color-element-error: var(--lasuite-color-error-550) !important;
+	--color-border-error: var(--lasuite-color-error-550) !important;
+
+	/* ===================================================================
+	 * STATUS: WARNING
+	 * =================================================================== */
+
 	--color-warning: var(--lasuite-color-warning-550) !important;
+	--color-warning-hover: var(--lasuite-color-warning-650) !important;
+	/* --color-warning-text: unmapped — auto-calculated for contrast by Nextcloud */
+	--color-warning-rgb: var(--nldesign-color-warning-rgb) !important;
+	--color-element-warning: var(--lasuite-color-warning-550) !important;
+
+	/* ===================================================================
+	 * STATUS: SUCCESS
+	 * =================================================================== */
+
 	--color-success: var(--lasuite-color-success-550) !important;
+	--color-success-hover: var(--lasuite-color-success-650) !important;
+	/* --color-success-text: unmapped — auto-calculated for contrast by Nextcloud */
+	--color-success-rgb: var(--nldesign-color-success-rgb) !important;
+	--color-element-success: var(--lasuite-color-success-550) !important;
+	--color-border-success: var(--lasuite-color-success-550) !important;
+
+	/* ===================================================================
+	 * STATUS: INFO
+	 * =================================================================== */
+
 	--color-info: var(--lasuite-color-info-550) !important;
+	--color-info-hover: var(--lasuite-color-info-650) !important;
+	/* --color-info-text: unmapped — auto-calculated for contrast by Nextcloud */
+	/* --color-info-rgb: unmapped — deprecated, RGB for rgba() (mirrors the nldesign bridge's own audit in overrides.css) */
+	--color-element-info: var(--lasuite-color-info-550) !important;
+
+	/* ===================================================================
+	 * BORDERS
+	 * =================================================================== */
 
 	--color-border: var(--lasuite-color-gray-200) !important;
 	--color-border-dark: var(--lasuite-color-gray-500) !important;
 	--color-border-maxcontrast: var(--lasuite-color-gray-500) !important;
+
+	/* ===================================================================
+	 * BORDER RADIUS
+	 * =================================================================== */
 
 	--border-radius: var(--lasuite-border-radius) !important;
 	--border-radius-small: var(--lasuite-border-radius) !important;
 	--border-radius-large: var(--lasuite-border-radius) !important;
 	--border-radius-element: var(--lasuite-border-radius) !important;
 
+	/* ===================================================================
+	 * SPECIAL COLORS
+	 * =================================================================== */
+
+	/* --color-favorite: unmapped — no Cunningham equivalent; Nextcloud's default gold favorite-star colour is used */
+	/* --color-loading-light: unmapped — NC loading animation internal */
+	/* --color-loading-dark: unmapped — NC loading animation internal */
+	/* --color-scrollbar: intentionally not overridden — depends on --color-border-maxcontrast, already mapped above */
+
+	/* ===================================================================
+	 * SHADOWS
+	 * =================================================================== */
+
+	/* --color-box-shadow-rgb: unmapped — auto-calculated from background */
+	/* --color-box-shadow: unmapped — depends on --color-box-shadow-rgb */
+
+	/* ===================================================================
+	 * ASSISTANT (AI)
+	 * Intentionally not overridden — NC-specific feature, no Cunningham
+	 * equivalent.
+	 * =================================================================== */
+
+	/* --color-background-assistant: intentionally not overridden — NC-specific */
+	/* --color-border-assistant: intentionally not overridden — NC-specific */
+	/* --color-element-assistant: intentionally not overridden — NC-specific */
+	/* --color-element-assistant-icon: intentionally not overridden — NC-specific */
+
 	/* --color-main-background, --color-main-background-rgb,
-	 * --color-main-background-translucent, --color-background-plain,
-	 * --background-invert-if-dark and --background-invert-if-bright are
-	 * deliberately absent from this rule — see file header (REQ-CSS-007). */
+	 * --color-main-background-translucent, --color-main-background-blur,
+	 * --color-background-plain and --color-background-plain-text are
+	 * deliberately absent from active mapping above — see file header
+	 * (REQ-CSS-007). */
 }
 
 /* Font — applied via inheritance from body (ADR-CSS-001), no !important and

--- a/css/systems/lasuite/defaults.css
+++ b/css/systems/lasuite/defaults.css
@@ -1,110 +1,1243 @@
 /**
- * La Suite numérique — Cunningham Token Defaults Layer
+ * La Suite numérique — Cunningham Token Defaults Layer (GENERATED)
  *
- * Curated `--lasuite-*` subset transcribed from Cunningham
- * (`@gouvfr-lasuite/cunningham-react`, MIT license —
- * https://github.com/suitenumerique/cunningham), the design system behind
- * La Suite Docs/Meet/Chat and the MinBZK/mijn-bureau EDIC sovereign-workplace
- * bundle. Values verified live against the shipped
- * `src/frontend/apps/impress/src/cunningham/cunningham-tokens.css` in
- * suitenumerique/docs (fetched 2026-07-23; `--c--globals--colors--*` /
- * `--c--globals--spacings--*` / `--c--components--button--border-radius`
- * token names below are the upstream source).
+ * Do not hand-edit — regenerate with:
+ *   node scripts/generate-lasuite-tokens.mjs
+ * A committed-file drift check runs as `npm run test:lasuite-tokens`.
  *
- * This is a CURATED subset (the upstream file generates ~14k lines across
- * light/dark/high-contrast variants and every component) — only the values
- * the lasuite bridge and element-overrides layers consume. It is NOT a copy
- * of the full generated token file.
+ * Source package: @openfun/cunningham-tokens@3.0.0 (MIT licence)
+ *   https://www.npmjs.com/package/@openfun/cunningham-tokens
+ *   Cunningham is the design system behind La Suite numérique
+ *   (Docs/Meet/Chat) — https://github.com/suitenumerique/cunningham
+ * Read from: dist/cunningham-tokens.css
+ * Generated: 2026-07-25
+ * Token count: 1167 (584 light + 583 dark —
+ *   see the module header comment in generate-lasuite-tokens.mjs for
+ *   why the source splits into these two blocks instead of one).
+ * Mapping rule: --c--<rest> ⇄ --lasuite--<rest> — a prefix swap only,
+ *   every "--" hierarchy separator preserved, no segment collapsing
+ *   (e.g. --c--globals--colors--brand-600 →
+ *   --lasuite--globals--colors--brand-600). Reversible by swapping the
+ *   leading token back.
  *
- * Load order: fonts → [defaults] → bridge → element-overrides, then
- * tokens/lasuite (Layer 3, --nldesign-* namespace).
+ * BASE, NOT DEPLOYED THEME: this file is the published Cunningham
+ * BLUE base (brand-600 #0659c5). The deployed La Suite VIOLET theme
+ * (brand-600 #534fc2, brand-650/logo #4844ad) is a separate,
+ * hand-authored, sourced override — see brand-override.css — layered
+ * after this file in the lasuite design-system bundle. This file must
+ * never hard-code the violet values.
+ *
+ * Only the `:root` (light) block below is active in the nldesign
+ * lasuite/cunningham bundles today; `.cunningham-theme--dark` is
+ * carried for upstream fidelity but nothing currently applies that
+ * class — it is not wired into nldesign's own dark-mode system.
  */
 
 :root {
+	--lasuite--contextuals--background--palette--blue-1--primary: var(--lasuite--globals--colors--blue-1-500);
+	--lasuite--contextuals--background--palette--blue-1--secondary: var(--lasuite--globals--colors--blue-1-350);
+	--lasuite--contextuals--background--palette--blue-1--tertiary: var(--lasuite--globals--colors--blue-1-150);
+	--lasuite--contextuals--background--palette--blue-2--primary: var(--lasuite--globals--colors--blue-2-500);
+	--lasuite--contextuals--background--palette--blue-2--secondary: var(--lasuite--globals--colors--blue-2-350);
+	--lasuite--contextuals--background--palette--blue-2--tertiary: var(--lasuite--globals--colors--blue-2-150);
+	--lasuite--contextuals--background--palette--brand--primary: var(--lasuite--globals--colors--brand-500);
+	--lasuite--contextuals--background--palette--brand--secondary: var(--lasuite--globals--colors--brand-350);
+	--lasuite--contextuals--background--palette--brand--tertiary: var(--lasuite--globals--colors--brand-150);
+	--lasuite--contextuals--background--palette--brown--primary: var(--lasuite--globals--colors--brown-500);
+	--lasuite--contextuals--background--palette--brown--secondary: var(--lasuite--globals--colors--brown-350);
+	--lasuite--contextuals--background--palette--brown--tertiary: var(--lasuite--globals--colors--brown-150);
+	--lasuite--contextuals--background--palette--gray--primary: var(--lasuite--globals--colors--gray-500);
+	--lasuite--contextuals--background--palette--gray--secondary: var(--lasuite--globals--colors--gray-350);
+	--lasuite--contextuals--background--palette--gray--tertiary: var(--lasuite--globals--colors--gray-150);
+	--lasuite--contextuals--background--palette--green--primary: var(--lasuite--globals--colors--green-500);
+	--lasuite--contextuals--background--palette--green--secondary: var(--lasuite--globals--colors--green-350);
+	--lasuite--contextuals--background--palette--green--tertiary: var(--lasuite--globals--colors--green-150);
+	--lasuite--contextuals--background--palette--orange--primary: var(--lasuite--globals--colors--orange-500);
+	--lasuite--contextuals--background--palette--orange--secondary: var(--lasuite--globals--colors--orange-350);
+	--lasuite--contextuals--background--palette--orange--tertiary: var(--lasuite--globals--colors--orange-150);
+	--lasuite--contextuals--background--palette--pink--primary: var(--lasuite--globals--colors--pink-500);
+	--lasuite--contextuals--background--palette--pink--secondary: var(--lasuite--globals--colors--pink-350);
+	--lasuite--contextuals--background--palette--pink--tertiary: var(--lasuite--globals--colors--pink-150);
+	--lasuite--contextuals--background--palette--purple--primary: var(--lasuite--globals--colors--purple-500);
+	--lasuite--contextuals--background--palette--purple--secondary: var(--lasuite--globals--colors--purple-350);
+	--lasuite--contextuals--background--palette--purple--tertiary: var(--lasuite--globals--colors--purple-150);
+	--lasuite--contextuals--background--palette--red--primary: var(--lasuite--globals--colors--red-500);
+	--lasuite--contextuals--background--palette--red--secondary: var(--lasuite--globals--colors--red-350);
+	--lasuite--contextuals--background--palette--red--tertiary: var(--lasuite--globals--colors--red-150);
+	--lasuite--contextuals--background--palette--yellow--primary: var(--lasuite--globals--colors--yellow-500);
+	--lasuite--contextuals--background--palette--yellow--secondary: var(--lasuite--globals--colors--yellow-350);
+	--lasuite--contextuals--background--palette--yellow--tertiary: var(--lasuite--globals--colors--yellow-150);
+	--lasuite--contextuals--background--semantic--brand--primary: var(--lasuite--globals--colors--brand-550);
+	--lasuite--contextuals--background--semantic--brand--primary-hover: var(--lasuite--globals--colors--brand-650);
+	--lasuite--contextuals--background--semantic--brand--secondary: var(--lasuite--globals--colors--brand-100);
+	--lasuite--contextuals--background--semantic--brand--secondary-hover: var(--lasuite--globals--colors--brand-150);
+	--lasuite--contextuals--background--semantic--brand--tertiary: var(--lasuite--globals--colors--brand-050);
+	--lasuite--contextuals--background--semantic--brand--tertiary-hover: var(--lasuite--globals--colors--brand-100);
+	--lasuite--contextuals--background--semantic--contextual--primary: var(--lasuite--globals--colors--black-050);
+	--lasuite--contextuals--background--semantic--contextual--primary-hover: var(--lasuite--globals--colors--black-100);
+	--lasuite--contextuals--background--semantic--disabled--primary: var(--lasuite--globals--colors--gray-100);
+	--lasuite--contextuals--background--semantic--disabled--secondary: var(--lasuite--globals--colors--gray-050);
+	--lasuite--contextuals--background--semantic--error--primary: var(--lasuite--globals--colors--error-550);
+	--lasuite--contextuals--background--semantic--error--primary-hover: var(--lasuite--globals--colors--error-650);
+	--lasuite--contextuals--background--semantic--error--secondary: var(--lasuite--globals--colors--error-100);
+	--lasuite--contextuals--background--semantic--error--secondary-hover: var(--lasuite--globals--colors--error-150);
+	--lasuite--contextuals--background--semantic--error--tertiary: var(--lasuite--globals--colors--error-050);
+	--lasuite--contextuals--background--semantic--error--tertiary-hover: var(--lasuite--globals--colors--error-100);
+	--lasuite--contextuals--background--semantic--info--primary: var(--lasuite--globals--colors--info-550);
+	--lasuite--contextuals--background--semantic--info--primary-hover: var(--lasuite--globals--colors--info-650);
+	--lasuite--contextuals--background--semantic--info--secondary: var(--lasuite--globals--colors--info-100);
+	--lasuite--contextuals--background--semantic--info--secondary-hover: var(--lasuite--globals--colors--info-150);
+	--lasuite--contextuals--background--semantic--info--tertiary: var(--lasuite--globals--colors--info-050);
+	--lasuite--contextuals--background--semantic--info--tertiary-hover: var(--lasuite--globals--colors--info-100);
+	--lasuite--contextuals--background--semantic--neutral--primary: var(--lasuite--globals--colors--gray-550);
+	--lasuite--contextuals--background--semantic--neutral--primary-hover: var(--lasuite--globals--colors--gray-650);
+	--lasuite--contextuals--background--semantic--neutral--secondary: var(--lasuite--globals--colors--gray-100);
+	--lasuite--contextuals--background--semantic--neutral--secondary-hover: var(--lasuite--globals--colors--gray-150);
+	--lasuite--contextuals--background--semantic--neutral--tertiary: var(--lasuite--globals--colors--gray-050);
+	--lasuite--contextuals--background--semantic--neutral--tertiary-hover: var(--lasuite--globals--colors--gray-100);
+	--lasuite--contextuals--background--semantic--success--primary: var(--lasuite--globals--colors--success-550);
+	--lasuite--contextuals--background--semantic--success--primary-hover: var(--lasuite--globals--colors--success-650);
+	--lasuite--contextuals--background--semantic--success--secondary: var(--lasuite--globals--colors--success-100);
+	--lasuite--contextuals--background--semantic--success--secondary-hover: var(--lasuite--globals--colors--success-150);
+	--lasuite--contextuals--background--semantic--success--tertiary: var(--lasuite--globals--colors--success-050);
+	--lasuite--contextuals--background--semantic--success--tertiary-hover: var(--lasuite--globals--colors--success-100);
+	--lasuite--contextuals--background--semantic--warning--primary: var(--lasuite--globals--colors--warning-550);
+	--lasuite--contextuals--background--semantic--warning--primary-hover: var(--lasuite--globals--colors--warning-650);
+	--lasuite--contextuals--background--semantic--warning--secondary: var(--lasuite--globals--colors--warning-100);
+	--lasuite--contextuals--background--semantic--warning--secondary-hover: var(--lasuite--globals--colors--warning-150);
+	--lasuite--contextuals--background--semantic--warning--tertiary: var(--lasuite--globals--colors--warning-050);
+	--lasuite--contextuals--background--semantic--warning--tertiary-hover: var(--lasuite--globals--colors--warning-100);
+	--lasuite--contextuals--background--surface--primary: var(--lasuite--globals--colors--gray-000);
+	--lasuite--contextuals--background--surface--secondary: var(--lasuite--globals--colors--gray-000);
+	--lasuite--contextuals--background--surface--tertiary: var(--lasuite--globals--colors--gray-025);
+	--lasuite--contextuals--background--text--primary: var(--lasuite--globals--colors--black-050);
+	--lasuite--contextuals--border--palette--blue-1--primary: var(--lasuite--globals--colors--blue-1-500);
+	--lasuite--contextuals--border--palette--blue-1--secondary: var(--lasuite--globals--colors--blue-1-350);
+	--lasuite--contextuals--border--palette--blue-1--tertiary: var(--lasuite--globals--colors--blue-1-150);
+	--lasuite--contextuals--border--palette--blue-2--primary: var(--lasuite--globals--colors--blue-2-500);
+	--lasuite--contextuals--border--palette--blue-2--secondary: var(--lasuite--globals--colors--blue-2-350);
+	--lasuite--contextuals--border--palette--blue-2--tertiary: var(--lasuite--globals--colors--blue-2-150);
+	--lasuite--contextuals--border--palette--brand--primary: var(--lasuite--globals--colors--brand-500);
+	--lasuite--contextuals--border--palette--brand--secondary: var(--lasuite--globals--colors--brand-350);
+	--lasuite--contextuals--border--palette--brand--tertiary: var(--lasuite--globals--colors--brand-150);
+	--lasuite--contextuals--border--palette--brown--primary: var(--lasuite--globals--colors--brown-500);
+	--lasuite--contextuals--border--palette--brown--secondary: var(--lasuite--globals--colors--brown-350);
+	--lasuite--contextuals--border--palette--brown--tertiary: var(--lasuite--globals--colors--brown-150);
+	--lasuite--contextuals--border--palette--gray--primary: var(--lasuite--globals--colors--gray-500);
+	--lasuite--contextuals--border--palette--gray--secondary: var(--lasuite--globals--colors--gray-350);
+	--lasuite--contextuals--border--palette--gray--tertiary: var(--lasuite--globals--colors--gray-150);
+	--lasuite--contextuals--border--palette--green--primary: var(--lasuite--globals--colors--green-500);
+	--lasuite--contextuals--border--palette--green--secondary: var(--lasuite--globals--colors--green-350);
+	--lasuite--contextuals--border--palette--green--tertiary: var(--lasuite--globals--colors--green-150);
+	--lasuite--contextuals--border--palette--orange--primary: var(--lasuite--globals--colors--orange-500);
+	--lasuite--contextuals--border--palette--orange--secondary: var(--lasuite--globals--colors--orange-350);
+	--lasuite--contextuals--border--palette--orange--tertiary: var(--lasuite--globals--colors--orange-150);
+	--lasuite--contextuals--border--palette--pink--primary: var(--lasuite--globals--colors--pink-500);
+	--lasuite--contextuals--border--palette--pink--secondary: var(--lasuite--globals--colors--pink-350);
+	--lasuite--contextuals--border--palette--pink--tertiary: var(--lasuite--globals--colors--pink-150);
+	--lasuite--contextuals--border--palette--purple--primary: var(--lasuite--globals--colors--purple-500);
+	--lasuite--contextuals--border--palette--purple--secondary: var(--lasuite--globals--colors--purple-350);
+	--lasuite--contextuals--border--palette--purple--tertiary: var(--lasuite--globals--colors--purple-150);
+	--lasuite--contextuals--border--palette--red--primary: var(--lasuite--globals--colors--red-500);
+	--lasuite--contextuals--border--palette--red--secondary: var(--lasuite--globals--colors--red-350);
+	--lasuite--contextuals--border--palette--red--tertiary: var(--lasuite--globals--colors--red-150);
+	--lasuite--contextuals--border--palette--yellow--primary: var(--lasuite--globals--colors--yellow-500);
+	--lasuite--contextuals--border--palette--yellow--secondary: var(--lasuite--globals--colors--yellow-350);
+	--lasuite--contextuals--border--palette--yellow--tertiary: var(--lasuite--globals--colors--yellow-150);
+	--lasuite--contextuals--border--semantic--brand--primary: var(--lasuite--globals--colors--brand-550);
+	--lasuite--contextuals--border--semantic--brand--secondary: var(--lasuite--globals--colors--brand-300);
+	--lasuite--contextuals--border--semantic--brand--tertiary: var(--lasuite--globals--colors--brand-150);
+	--lasuite--contextuals--border--semantic--contextual--primary: var(--lasuite--globals--colors--white-200);
+	--lasuite--contextuals--border--semantic--disabled--primary: var(--lasuite--globals--colors--gray-100);
+	--lasuite--contextuals--border--semantic--error--primary: var(--lasuite--globals--colors--error-550);
+	--lasuite--contextuals--border--semantic--error--secondary: var(--lasuite--globals--colors--error-300);
+	--lasuite--contextuals--border--semantic--error--tertiary: var(--lasuite--globals--colors--error-150);
+	--lasuite--contextuals--border--semantic--info--primary: var(--lasuite--globals--colors--info-550);
+	--lasuite--contextuals--border--semantic--info--secondary: var(--lasuite--globals--colors--info-300);
+	--lasuite--contextuals--border--semantic--info--tertiary: var(--lasuite--globals--colors--info-150);
+	--lasuite--contextuals--border--semantic--neutral--primary: var(--lasuite--globals--colors--gray-550);
+	--lasuite--contextuals--border--semantic--neutral--secondary: var(--lasuite--globals--colors--gray-300);
+	--lasuite--contextuals--border--semantic--neutral--tertiary: var(--lasuite--globals--colors--gray-150);
+	--lasuite--contextuals--border--semantic--success--primary: var(--lasuite--globals--colors--success-550);
+	--lasuite--contextuals--border--semantic--success--secondary: var(--lasuite--globals--colors--success-300);
+	--lasuite--contextuals--border--semantic--success--tertiary: var(--lasuite--globals--colors--success-150);
+	--lasuite--contextuals--border--semantic--warning--primary: var(--lasuite--globals--colors--warning-550);
+	--lasuite--contextuals--border--semantic--warning--secondary: var(--lasuite--globals--colors--warning-300);
+	--lasuite--contextuals--border--semantic--warning--tertiary: var(--lasuite--globals--colors--warning-150);
+	--lasuite--contextuals--border--surface--primary: var(--lasuite--globals--colors--gray-100);
+	--lasuite--contextuals--content--logo1: var(--lasuite--globals--colors--logo-1);
+	--lasuite--contextuals--content--logo2: var(--lasuite--globals--colors--logo-2);
+	--lasuite--contextuals--content--palette--blue-1--primary: var(--lasuite--globals--colors--blue-1-500);
+	--lasuite--contextuals--content--palette--blue-1--secondary: var(--lasuite--globals--colors--blue-1-350);
+	--lasuite--contextuals--content--palette--blue-1--tertiary: var(--lasuite--globals--colors--blue-1-150);
+	--lasuite--contextuals--content--palette--blue-2--primary: var(--lasuite--globals--colors--blue-2-500);
+	--lasuite--contextuals--content--palette--blue-2--secondary: var(--lasuite--globals--colors--blue-2-350);
+	--lasuite--contextuals--content--palette--blue-2--tertiary: var(--lasuite--globals--colors--blue-2-150);
+	--lasuite--contextuals--content--palette--brand--primary: var(--lasuite--globals--colors--brand-500);
+	--lasuite--contextuals--content--palette--brand--secondary: var(--lasuite--globals--colors--brand-350);
+	--lasuite--contextuals--content--palette--brand--tertiary: var(--lasuite--globals--colors--brand-150);
+	--lasuite--contextuals--content--palette--brown--primary: var(--lasuite--globals--colors--brown-500);
+	--lasuite--contextuals--content--palette--brown--secondary: var(--lasuite--globals--colors--brown-350);
+	--lasuite--contextuals--content--palette--brown--tertiary: var(--lasuite--globals--colors--brown-150);
+	--lasuite--contextuals--content--palette--gray--primary: var(--lasuite--globals--colors--gray-500);
+	--lasuite--contextuals--content--palette--gray--secondary: var(--lasuite--globals--colors--gray-350);
+	--lasuite--contextuals--content--palette--gray--tertiary: var(--lasuite--globals--colors--gray-150);
+	--lasuite--contextuals--content--palette--green--primary: var(--lasuite--globals--colors--green-500);
+	--lasuite--contextuals--content--palette--green--secondary: var(--lasuite--globals--colors--green-350);
+	--lasuite--contextuals--content--palette--green--tertiary: var(--lasuite--globals--colors--green-150);
+	--lasuite--contextuals--content--palette--orange--primary: var(--lasuite--globals--colors--orange-500);
+	--lasuite--contextuals--content--palette--orange--secondary: var(--lasuite--globals--colors--orange-350);
+	--lasuite--contextuals--content--palette--orange--tertiary: var(--lasuite--globals--colors--orange-150);
+	--lasuite--contextuals--content--palette--pink--primary: var(--lasuite--globals--colors--pink-500);
+	--lasuite--contextuals--content--palette--pink--secondary: var(--lasuite--globals--colors--pink-350);
+	--lasuite--contextuals--content--palette--pink--tertiary: var(--lasuite--globals--colors--pink-150);
+	--lasuite--contextuals--content--palette--purple--primary: var(--lasuite--globals--colors--purple-500);
+	--lasuite--contextuals--content--palette--purple--secondary: var(--lasuite--globals--colors--purple-350);
+	--lasuite--contextuals--content--palette--purple--tertiary: var(--lasuite--globals--colors--purple-150);
+	--lasuite--contextuals--content--palette--red--primary: var(--lasuite--globals--colors--red-500);
+	--lasuite--contextuals--content--palette--red--secondary: var(--lasuite--globals--colors--red-350);
+	--lasuite--contextuals--content--palette--red--tertiary: var(--lasuite--globals--colors--red-150);
+	--lasuite--contextuals--content--palette--yellow--primary: var(--lasuite--globals--colors--yellow-500);
+	--lasuite--contextuals--content--palette--yellow--secondary: var(--lasuite--globals--colors--yellow-350);
+	--lasuite--contextuals--content--palette--yellow--tertiary: var(--lasuite--globals--colors--yellow-150);
+	--lasuite--contextuals--content--semantic--brand--on-brand: var(--lasuite--globals--colors--brand-050);
+	--lasuite--contextuals--content--semantic--brand--primary: var(--lasuite--globals--colors--brand-700);
+	--lasuite--contextuals--content--semantic--brand--secondary: var(--lasuite--globals--colors--brand-600);
+	--lasuite--contextuals--content--semantic--brand--tertiary: var(--lasuite--globals--colors--brand-500);
+	--lasuite--contextuals--content--semantic--contextual--primary: var(--lasuite--globals--colors--white-950);
+	--lasuite--contextuals--content--semantic--disabled--primary: var(--lasuite--globals--colors--gray-300);
+	--lasuite--contextuals--content--semantic--disabled--secondary: var(--lasuite--globals--colors--white-500);
+	--lasuite--contextuals--content--semantic--error--on-error: var(--lasuite--globals--colors--error-050);
+	--lasuite--contextuals--content--semantic--error--primary: var(--lasuite--globals--colors--error-700);
+	--lasuite--contextuals--content--semantic--error--secondary: var(--lasuite--globals--colors--error-600);
+	--lasuite--contextuals--content--semantic--error--tertiary: var(--lasuite--globals--colors--error-500);
+	--lasuite--contextuals--content--semantic--info--on-info: var(--lasuite--globals--colors--info-050);
+	--lasuite--contextuals--content--semantic--info--primary: var(--lasuite--globals--colors--info-700);
+	--lasuite--contextuals--content--semantic--info--secondary: var(--lasuite--globals--colors--info-600);
+	--lasuite--contextuals--content--semantic--info--tertiary: var(--lasuite--globals--colors--info-500);
+	--lasuite--contextuals--content--semantic--neutral--on-neutral: var(--lasuite--globals--colors--gray-050);
+	--lasuite--contextuals--content--semantic--neutral--primary: var(--lasuite--globals--colors--gray-850);
+	--lasuite--contextuals--content--semantic--neutral--secondary: var(--lasuite--globals--colors--gray-600);
+	--lasuite--contextuals--content--semantic--neutral--tertiary: var(--lasuite--globals--colors--gray-500);
+	--lasuite--contextuals--content--semantic--success--on-success: var(--lasuite--globals--colors--success-050);
+	--lasuite--contextuals--content--semantic--success--primary: var(--lasuite--globals--colors--success-700);
+	--lasuite--contextuals--content--semantic--success--secondary: var(--lasuite--globals--colors--success-600);
+	--lasuite--contextuals--content--semantic--success--tertiary: var(--lasuite--globals--colors--success-500);
+	--lasuite--contextuals--content--semantic--warning--on-warning: var(--lasuite--globals--colors--warning-050);
+	--lasuite--contextuals--content--semantic--warning--primary: var(--lasuite--globals--colors--warning-700);
+	--lasuite--contextuals--content--semantic--warning--secondary: var(--lasuite--globals--colors--warning-600);
+	--lasuite--contextuals--content--semantic--warning--tertiary: var(--lasuite--globals--colors--warning-500);
+	--lasuite--globals--breakpoints--lg: 992px;
+	--lasuite--globals--breakpoints--md: 768px;
+	--lasuite--globals--breakpoints--sm: 576px;
+	--lasuite--globals--breakpoints--xl: 1200px;
+	--lasuite--globals--breakpoints--xs: 0;
+	--lasuite--globals--breakpoints--xxl: 1400px;
+	--lasuite--globals--colors--black-000: #00000000;
+	--lasuite--globals--colors--black-050: #0000000d;
+	--lasuite--globals--colors--black-100: #0000001a;
+	--lasuite--globals--colors--black-150: #00000026;
+	--lasuite--globals--colors--black-200: #00000033;
+	--lasuite--globals--colors--black-250: #00000040;
+	--lasuite--globals--colors--black-300: #0000004d;
+	--lasuite--globals--colors--black-350: #00000059;
+	--lasuite--globals--colors--black-400: #00000066;
+	--lasuite--globals--colors--black-450: #00000073;
+	--lasuite--globals--colors--black-500: #00000080;
+	--lasuite--globals--colors--black-550: #0000008c;
+	--lasuite--globals--colors--black-600: #00000099;
+	--lasuite--globals--colors--black-650: #000000a6;
+	--lasuite--globals--colors--black-700: #000000b3;
+	--lasuite--globals--colors--black-750: #000000bf;
+	--lasuite--globals--colors--black-800: #000000cc;
+	--lasuite--globals--colors--black-850: #000000d9;
+	--lasuite--globals--colors--black-900: #000000e6;
+	--lasuite--globals--colors--black-950: #000000f2;
+	--lasuite--globals--colors--blue-1-050: #ebf1ff;
+	--lasuite--globals--colors--blue-1-100: #d6e3fe;
+	--lasuite--globals--colors--blue-1-150: #c2d5fe;
+	--lasuite--globals--colors--blue-1-200: #adc7fe;
+	--lasuite--globals--colors--blue-1-250: #99b8fd;
+	--lasuite--globals--colors--blue-1-300: #84aafd;
+	--lasuite--globals--colors--blue-1-350: #6f9bfd;
+	--lasuite--globals--colors--blue-1-400: #5a8dfb;
+	--lasuite--globals--colors--blue-1-450: #437dfc;
+	--lasuite--globals--colors--blue-1-500: #3d71e4;
+	--lasuite--globals--colors--blue-1-550: #3665cc;
+	--lasuite--globals--colors--blue-1-600: #305ab5;
+	--lasuite--globals--colors--blue-1-650: #315093;
+	--lasuite--globals--colors--blue-1-700: #2e4675;
+	--lasuite--globals--colors--blue-1-750: #293b5e;
+	--lasuite--globals--colors--blue-1-800: #243048;
+	--lasuite--globals--colors--blue-1-850: #1e2635;
+	--lasuite--globals--colors--blue-1-900: #171c25;
+	--lasuite--globals--colors--blue-1-950: #0e1116;
+	--lasuite--globals--colors--blue-2-050: #e2f4f9;
+	--lasuite--globals--colors--blue-2-100: #c5e9f3;
+	--lasuite--globals--colors--blue-2-150: #a7dded;
+	--lasuite--globals--colors--blue-2-200: #88d1e6;
+	--lasuite--globals--colors--blue-2-250: #68c5e0;
+	--lasuite--globals--colors--blue-2-300: #48b8d9;
+	--lasuite--globals--colors--blue-2-350: #3baaca;
+	--lasuite--globals--colors--blue-2-400: #359cb9;
+	--lasuite--globals--colors--blue-2-450: #318ea9;
+	--lasuite--globals--colors--blue-2-500: #2c8199;
+	--lasuite--globals--colors--blue-2-550: #277389;
+	--lasuite--globals--colors--blue-2-600: #236679;
+	--lasuite--globals--colors--blue-2-650: #2a5866;
+	--lasuite--globals--colors--blue-2-700: #2a4b55;
+	--lasuite--globals--colors--blue-2-750: #283f47;
+	--lasuite--globals--colors--blue-2-800: #233337;
+	--lasuite--globals--colors--blue-2-850: #1d272a;
+	--lasuite--globals--colors--blue-2-900: #161c1e;
+	--lasuite--globals--colors--blue-2-950: #0e1112;
+	--lasuite--globals--colors--brand-050: #eaf1fb;
+	--lasuite--globals--colors--brand-100: #d5e4f7;
+	--lasuite--globals--colors--brand-150: #c0d6f4;
+	--lasuite--globals--colors--brand-200: #abc9f0;
+	--lasuite--globals--colors--brand-250: #96bcec;
+	--lasuite--globals--colors--brand-300: #80aee8;
+	--lasuite--globals--colors--brand-350: #6ca0e4;
+	--lasuite--globals--colors--brand-400: #5693e0;
+	--lasuite--globals--colors--brand-450: #4085dc;
+	--lasuite--globals--colors--brand-500: #2976d8;
+	--lasuite--globals--colors--brand-550: #1167d4;
+	--lasuite--globals--colors--brand-600: #0659c5;
+	--lasuite--globals--colors--brand-650: #1a509f;
+	--lasuite--globals--colors--brand-700: #20467f;
+	--lasuite--globals--colors--brand-750: #203c63;
+	--lasuite--globals--colors--brand-800: #1d314c;
+	--lasuite--globals--colors--brand-850: #1a2638;
+	--lasuite--globals--colors--brand-900: #141c28;
+	--lasuite--globals--colors--brand-950: #0c1117;
+	--lasuite--globals--colors--brown-050: #f3f0ef;
+	--lasuite--globals--colors--brown-100: #e7e1df;
+	--lasuite--globals--colors--brown-150: #dcd2cf;
+	--lasuite--globals--colors--brown-200: #d0c4bf;
+	--lasuite--globals--colors--brown-250: #c5b6b0;
+	--lasuite--globals--colors--brown-300: #baa7a1;
+	--lasuite--globals--colors--brown-350: #af9992;
+	--lasuite--globals--colors--brown-400: #a48b83;
+	--lasuite--globals--colors--brown-450: #997e74;
+	--lasuite--globals--colors--brown-500: #8f7065;
+	--lasuite--globals--colors--brown-550: #846357;
+	--lasuite--globals--colors--brown-600: #7a5649;
+	--lasuite--globals--colors--brown-650: #684c42;
+	--lasuite--globals--colors--brown-700: #57423c;
+	--lasuite--globals--colors--brown-750: #463833;
+	--lasuite--globals--colors--brown-800: #382e2a;
+	--lasuite--globals--colors--brown-850: #2b2422;
+	--lasuite--globals--colors--brown-900: #1f1b19;
+	--lasuite--globals--colors--brown-950: #121010;
+	--lasuite--globals--colors--error-050: #fceded;
+	--lasuite--globals--colors--error-100: #fadbdb;
+	--lasuite--globals--colors--error-150: #f7c9c9;
+	--lasuite--globals--colors--error-200: #f5b7b7;
+	--lasuite--globals--colors--error-250: #f2a4a4;
+	--lasuite--globals--colors--error-300: #ef9191;
+	--lasuite--globals--colors--error-350: #ec7d7d;
+	--lasuite--globals--colors--error-400: #e96868;
+	--lasuite--globals--colors--error-450: #e55050;
+	--lasuite--globals--colors--error-500: #e13131;
+	--lasuite--globals--colors--error-550: #d80000;
+	--lasuite--globals--colors--error-600: #c00101;
+	--lasuite--globals--colors--error-650: #9e2219;
+	--lasuite--globals--colors--error-700: #802820;
+	--lasuite--globals--colors--error-750: #662820;
+	--lasuite--globals--colors--error-800: #4f231e;
+	--lasuite--globals--colors--error-850: #3b1d19;
+	--lasuite--globals--colors--error-900: #2a1614;
+	--lasuite--globals--colors--error-950: #1a0e0c;
+	--lasuite--globals--colors--gray-000: #ffffff;
+	--lasuite--globals--colors--gray-025: #f7f8f8;
+	--lasuite--globals--colors--gray-050: #f0f1f2;
+	--lasuite--globals--colors--gray-100: #e1e2e5;
+	--lasuite--globals--colors--gray-1000: #000000;
+	--lasuite--globals--colors--gray-150: #d2d4d8;
+	--lasuite--globals--colors--gray-200: #c4c7cb;
+	--lasuite--globals--colors--gray-250: #b5b9be;
+	--lasuite--globals--colors--gray-300: #a7acb2;
+	--lasuite--globals--colors--gray-350: #999ea5;
+	--lasuite--globals--colors--gray-400: #8d9197;
+	--lasuite--globals--colors--gray-450: #80848a;
+	--lasuite--globals--colors--gray-500: #74777c;
+	--lasuite--globals--colors--gray-550: #686b6f;
+	--lasuite--globals--colors--gray-600: #5c5f63;
+	--lasuite--globals--colors--gray-650: #505356;
+	--lasuite--globals--colors--gray-700: #45474a;
+	--lasuite--globals--colors--gray-750: #3a3b3e;
+	--lasuite--globals--colors--gray-800: #2f3033;
+	--lasuite--globals--colors--gray-850: #252627;
+	--lasuite--globals--colors--gray-900: #1b1c1d;
+	--lasuite--globals--colors--gray-950: #101112;
+	--lasuite--globals--colors--green-050: #e2f6e5;
+	--lasuite--globals--colors--green-100: #c5ecca;
+	--lasuite--globals--colors--green-150: #a7e3af;
+	--lasuite--globals--colors--green-200: #89d894;
+	--lasuite--globals--colors--green-250: #67ce75;
+	--lasuite--globals--colors--green-300: #4dc25d;
+	--lasuite--globals--colors--green-350: #48b257;
+	--lasuite--globals--colors--green-400: #41a44f;
+	--lasuite--globals--colors--green-450: #3b9548;
+	--lasuite--globals--colors--green-500: #368741;
+	--lasuite--globals--colors--green-550: #30793a;
+	--lasuite--globals--colors--green-600: #2b6b33;
+	--lasuite--globals--colors--green-650: #2f5c34;
+	--lasuite--globals--colors--green-700: #2e4e31;
+	--lasuite--globals--colors--green-750: #2a412c;
+	--lasuite--globals--colors--green-800: #253426;
+	--lasuite--globals--colors--green-850: #1e281f;
+	--lasuite--globals--colors--green-900: #171d17;
+	--lasuite--globals--colors--green-950: #0f120f;
+	--lasuite--globals--colors--info-050: #eaf1fb;
+	--lasuite--globals--colors--info-100: #d5e4f7;
+	--lasuite--globals--colors--info-150: #c0d6f4;
+	--lasuite--globals--colors--info-200: #abc9f0;
+	--lasuite--globals--colors--info-250: #96bcec;
+	--lasuite--globals--colors--info-300: #80aee8;
+	--lasuite--globals--colors--info-350: #6ca0e4;
+	--lasuite--globals--colors--info-400: #5693e0;
+	--lasuite--globals--colors--info-450: #4085dc;
+	--lasuite--globals--colors--info-500: #2976d8;
+	--lasuite--globals--colors--info-550: #1167d4;
+	--lasuite--globals--colors--info-600: #0659c5;
+	--lasuite--globals--colors--info-650: #1a509f;
+	--lasuite--globals--colors--info-700: #20467f;
+	--lasuite--globals--colors--info-750: #203c63;
+	--lasuite--globals--colors--info-800: #1d314c;
+	--lasuite--globals--colors--info-850: #1a2638;
+	--lasuite--globals--colors--info-900: #141c28;
+	--lasuite--globals--colors--info-950: #0c1117;
+	--lasuite--globals--colors--logo-1: #377fdb;
+	--lasuite--globals--colors--logo-1-dark: #95abff;
+	--lasuite--globals--colors--logo-2: #377fdb;
+	--lasuite--globals--colors--logo-2-dark: #95abff;
+	--lasuite--globals--colors--orange-050: #fdeee2;
+	--lasuite--globals--colors--orange-100: #fcddc5;
+	--lasuite--globals--colors--orange-150: #facba8;
+	--lasuite--globals--colors--orange-200: #f8b98b;
+	--lasuite--globals--colors--orange-250: #f6a76a;
+	--lasuite--globals--colors--orange-300: #f4934b;
+	--lasuite--globals--colors--orange-350: #f27e27;
+	--lasuite--globals--colors--orange-400: #e76e12;
+	--lasuite--globals--colors--orange-450: #d26411;
+	--lasuite--globals--colors--orange-500: #be5b0f;
+	--lasuite--globals--colors--orange-550: #aa510e;
+	--lasuite--globals--colors--orange-600: #97480c;
+	--lasuite--globals--colors--orange-650: #7e431d;
+	--lasuite--globals--colors--orange-700: #673c22;
+	--lasuite--globals--colors--orange-750: #533422;
+	--lasuite--globals--colors--orange-800: #412c1f;
+	--lasuite--globals--colors--orange-850: #31231b;
+	--lasuite--globals--colors--orange-900: #221a14;
+	--lasuite--globals--colors--orange-950: #15100c;
+	--lasuite--globals--colors--pink-050: #fcedf5;
+	--lasuite--globals--colors--pink-100: #f9daea;
+	--lasuite--globals--colors--pink-150: #f7c7e0;
+	--lasuite--globals--colors--pink-200: #f4b4d5;
+	--lasuite--globals--colors--pink-250: #f1a1ca;
+	--lasuite--globals--colors--pink-300: #ee8cbf;
+	--lasuite--globals--colors--pink-350: #ea77b3;
+	--lasuite--globals--colors--pink-400: #e760a6;
+	--lasuite--globals--colors--pink-450: #e24797;
+	--lasuite--globals--colors--pink-500: #cd4089;
+	--lasuite--globals--colors--pink-550: #b8397b;
+	--lasuite--globals--colors--pink-600: #a3336d;
+	--lasuite--globals--colors--pink-650: #86355e;
+	--lasuite--globals--colors--pink-700: #6e334f;
+	--lasuite--globals--colors--pink-750: #582e42;
+	--lasuite--globals--colors--pink-800: #442834;
+	--lasuite--globals--colors--pink-850: #332028;
+	--lasuite--globals--colors--pink-900: #24181d;
+	--lasuite--globals--colors--pink-950: #160f12;
+	--lasuite--globals--colors--purple-050: #f6eeff;
+	--lasuite--globals--colors--purple-100: #ecdcff;
+	--lasuite--globals--colors--purple-150: #e3cbfe;
+	--lasuite--globals--colors--purple-200: #dab9fe;
+	--lasuite--globals--colors--purple-250: #d0a7fe;
+	--lasuite--globals--colors--purple-300: #c795fe;
+	--lasuite--globals--colors--purple-350: #bd83fd;
+	--lasuite--globals--colors--purple-400: #b36ffd;
+	--lasuite--globals--colors--purple-450: #a85bfd;
+	--lasuite--globals--colors--purple-500: #9b4bf3;
+	--lasuite--globals--colors--purple-550: #8b43da;
+	--lasuite--globals--colors--purple-600: #7b3cc1;
+	--lasuite--globals--colors--purple-650: #673c9b;
+	--lasuite--globals--colors--purple-700: #56387d;
+	--lasuite--globals--colors--purple-750: #463162;
+	--lasuite--globals--colors--purple-800: #382a4a;
+	--lasuite--globals--colors--purple-850: #2a2237;
+	--lasuite--globals--colors--purple-900: #1e1926;
+	--lasuite--globals--colors--purple-950: #121017;
+	--lasuite--globals--colors--red-050: #fdeded;
+	--lasuite--globals--colors--red-100: #fadbdb;
+	--lasuite--globals--colors--red-150: #f8c9c9;
+	--lasuite--globals--colors--red-200: #f5b7b6;
+	--lasuite--globals--colors--red-250: #f3a4a3;
+	--lasuite--globals--colors--red-300: #f09190;
+	--lasuite--globals--colors--red-350: #ee7c7b;
+	--lasuite--globals--colors--red-400: #eb6665;
+	--lasuite--globals--colors--red-450: #e74e4d;
+	--lasuite--globals--colors--red-500: #d83f3d;
+	--lasuite--globals--colors--red-550: #c23837;
+	--lasuite--globals--colors--red-600: #ac3231;
+	--lasuite--globals--colors--red-650: #8d3531;
+	--lasuite--globals--colors--red-700: #73332f;
+	--lasuite--globals--colors--red-750: #5b2f2b;
+	--lasuite--globals--colors--red-800: #472826;
+	--lasuite--globals--colors--red-850: #35211f;
+	--lasuite--globals--colors--red-900: #251817;
+	--lasuite--globals--colors--red-950: #160f0e;
+	--lasuite--globals--colors--success-050: #e4f7d4;
+	--lasuite--globals--colors--success-100: #c8eea8;
+	--lasuite--globals--colors--success-150: #aae579;
+	--lasuite--globals--colors--success-200: #89dc45;
+	--lasuite--globals--colors--success-250: #72cf27;
+	--lasuite--globals--colors--success-300: #6ac024;
+	--lasuite--globals--colors--success-350: #61b121;
+	--lasuite--globals--colors--success-400: #59a21e;
+	--lasuite--globals--colors--success-450: #51941c;
+	--lasuite--globals--colors--success-500: #4b851a;
+	--lasuite--globals--colors--success-550: #427816;
+	--lasuite--globals--colors--success-600: #3a6a14;
+	--lasuite--globals--colors--success-650: #385c1f;
+	--lasuite--globals--colors--success-700: #344d24;
+	--lasuite--globals--colors--success-750: #2e4022;
+	--lasuite--globals--colors--success-800: #27341f;
+	--lasuite--globals--colors--success-850: #20281a;
+	--lasuite--globals--colors--success-900: #181d15;
+	--lasuite--globals--colors--success-950: #10120e;
+	--lasuite--globals--colors--warning-050: #fff1bd;
+	--lasuite--globals--colors--warning-100: #ffe176;
+	--lasuite--globals--colors--warning-150: #ffcf25;
+	--lasuite--globals--colors--warning-200: #f4bf06;
+	--lasuite--globals--colors--warning-250: #e3b205;
+	--lasuite--globals--colors--warning-300: #d3a504;
+	--lasuite--globals--colors--warning-350: #c29805;
+	--lasuite--globals--colors--warning-400: #b28c03;
+	--lasuite--globals--colors--warning-450: #a27f03;
+	--lasuite--globals--colors--warning-500: #937303;
+	--lasuite--globals--colors--warning-550: #836703;
+	--lasuite--globals--colors--warning-600: #745b03;
+	--lasuite--globals--colors--warning-650: #625019;
+	--lasuite--globals--colors--warning-700: #524620;
+	--lasuite--globals--colors--warning-750: #443b20;
+	--lasuite--globals--colors--warning-800: #36301d;
+	--lasuite--globals--colors--warning-850: #2a2619;
+	--lasuite--globals--colors--warning-900: #1e1c13;
+	--lasuite--globals--colors--warning-950: #12110c;
+	--lasuite--globals--colors--white-000: #ffffff;
+	--lasuite--globals--colors--white-050: #ffffff0d;
+	--lasuite--globals--colors--white-100: #ffffff1a;
+	--lasuite--globals--colors--white-150: #ffffff26;
+	--lasuite--globals--colors--white-200: #ffffff33;
+	--lasuite--globals--colors--white-250: #ffffff40;
+	--lasuite--globals--colors--white-300: #ffffff4d;
+	--lasuite--globals--colors--white-350: #ffffff59;
+	--lasuite--globals--colors--white-400: #ffffff66;
+	--lasuite--globals--colors--white-450: #ffffff73;
+	--lasuite--globals--colors--white-500: #ffffff80;
+	--lasuite--globals--colors--white-550: #ffffff8c;
+	--lasuite--globals--colors--white-600: #ffffff99;
+	--lasuite--globals--colors--white-650: #ffffffa6;
+	--lasuite--globals--colors--white-700: #ffffffb3;
+	--lasuite--globals--colors--white-750: #ffffffbf;
+	--lasuite--globals--colors--white-800: #ffffffcc;
+	--lasuite--globals--colors--white-850: #ffffffd9;
+	--lasuite--globals--colors--white-900: #ffffffe6;
+	--lasuite--globals--colors--white-950: #fffffff2;
+	--lasuite--globals--colors--yellow-050: #faf0d3;
+	--lasuite--globals--colors--yellow-100: #f5e2a4;
+	--lasuite--globals--colors--yellow-150: #f0d275;
+	--lasuite--globals--colors--yellow-200: #ebc242;
+	--lasuite--globals--colors--yellow-250: #e4b213;
+	--lasuite--globals--colors--yellow-300: #d4a511;
+	--lasuite--globals--colors--yellow-350: #c39810;
+	--lasuite--globals--colors--yellow-400: #b38b0f;
+	--lasuite--globals--colors--yellow-450: #a37f0d;
+	--lasuite--globals--colors--yellow-500: #93730c;
+	--lasuite--globals--colors--yellow-550: #84670b;
+	--lasuite--globals--colors--yellow-600: #755b0a;
+	--lasuite--globals--colors--yellow-650: #63501c;
+	--lasuite--globals--colors--yellow-700: #534521;
+	--lasuite--globals--colors--yellow-750: #443a21;
+	--lasuite--globals--colors--yellow-800: #36301f;
+	--lasuite--globals--colors--yellow-850: #29261a;
+	--lasuite--globals--colors--yellow-900: #1d1c14;
+	--lasuite--globals--colors--yellow-950: #12110c;
+	--lasuite--globals--font--families--accent: "Roboto Flex Variable", sans-serif;
+	--lasuite--globals--font--families--base: "Roboto Flex Variable", sans-serif;
+	--lasuite--globals--font--sizes--h1: 2rem;
+	--lasuite--globals--font--sizes--h2: 1.75rem;
+	--lasuite--globals--font--sizes--h3: 1.5rem;
+	--lasuite--globals--font--sizes--h4: 1.375rem;
+	--lasuite--globals--font--sizes--h5: 1.25rem;
+	--lasuite--globals--font--sizes--h6: 1.125rem;
+	--lasuite--globals--font--sizes--lg: 1.125rem;
+	--lasuite--globals--font--sizes--lg-alt: 4.5rem;
+	--lasuite--globals--font--sizes--md: 1rem;
+	--lasuite--globals--font--sizes--md-alt: 4rem;
+	--lasuite--globals--font--sizes--ml: 0.938rem;
+	--lasuite--globals--font--sizes--s: 0.75rem;
+	--lasuite--globals--font--sizes--sm: 0.875rem;
+	--lasuite--globals--font--sizes--sm-alt: 3.5rem;
+	--lasuite--globals--font--sizes--t: 0.6875rem;
+	--lasuite--globals--font--sizes--xl: 1.25rem;
+	--lasuite--globals--font--sizes--xl-alt: 5rem;
+	--lasuite--globals--font--sizes--xs: 0.75rem;
+	--lasuite--globals--font--sizes--xs-alt: 3rem;
+	--lasuite--globals--font--weights--black: 800;
+	--lasuite--globals--font--weights--bold: 600;
+	--lasuite--globals--font--weights--extrabold: 700;
+	--lasuite--globals--font--weights--light: 300;
+	--lasuite--globals--font--weights--medium: 500;
+	--lasuite--globals--font--weights--regular: 400;
+	--lasuite--globals--font--weights--thin: 200;
+	--lasuite--globals--spacings--4xl: 4rem;
+	--lasuite--globals--spacings--4xs: 0.125rem;
+	--lasuite--globals--spacings--5xl: 4.5rem;
+	--lasuite--globals--spacings--6xl: 6rem;
+	--lasuite--globals--spacings--7xl: 7.5rem;
+	--lasuite--globals--spacings--b: 1.625rem;
+	--lasuite--globals--spacings--base: 1rem;
+	--lasuite--globals--spacings--l: 3rem;
+	--lasuite--globals--spacings--lg: 2rem;
+	--lasuite--globals--spacings--m: 0.8125rem;
+	--lasuite--globals--spacings--md: 1.5rem;
+	--lasuite--globals--spacings--s: 1rem;
+	--lasuite--globals--spacings--sm: 0.75rem;
+	--lasuite--globals--spacings--st: 0.25rem;
+	--lasuite--globals--spacings--t: 0.5rem;
+	--lasuite--globals--spacings--xl: 2.5rem;
+	--lasuite--globals--spacings--xs: 0.5rem;
+	--lasuite--globals--spacings--xxl: 3rem;
+	--lasuite--globals--spacings--xxs: 0.375rem;
+	--lasuite--globals--spacings--xxxl: 3.5rem;
+	--lasuite--globals--spacings--xxxs: 0.25rem;
+	--lasuite--globals--transitions--duration: 250ms;
+	--lasuite--globals--transitions--ease-in: cubic-bezier(0.32, 0, 0.67, 0);
+	--lasuite--globals--transitions--ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+	--lasuite--globals--transitions--ease-out: cubic-bezier(0.33, 1, 0.68, 1);
+
 	/* ===================================================================
-	 * BRAND SCALE
-	 * Source: --c--globals--colors--brand-* (Cunningham "light" root block).
-	 * brand-650 (#4844ad) is La Suite's own brand colour — also its
-	 * `--c--globals--colors--logo-1-light` value.
+	 * COMPATIBILITY ALIASES
+	 * Short --lasuite-* (single dash) names read by css/systems/lasuite/
+	 * bridge.css and element-overrides.css, mapped to their canonical
+	 * --lasuite--* (double dash) tokens above. Closed, explicitly-listed,
+	 * reviewed list — see COMPAT_ALIASES in scripts/generate-lasuite-
+	 * tokens.mjs. --lasuite-border-radius is the one literal: Cunningham
+	 * does not expose a border-radius custom property (baked into its
+	 * compiled component CSS instead), so 4px is carried forward from the
+	 * observed Cunningham button/input radius, not derived from a token.
+	 * --lasuite-font-family is defined separately in fonts.css (not here)
+	 * because it depends on the self-hosting/licensing story, not on any
+	 * generated Cunningham value.
 	 * =================================================================== */
-
-	--lasuite-color-brand-050: #eef1fa; /* --c--globals--colors--brand-050 */
-	--lasuite-color-brand-100: #dde2f5; /* --c--globals--colors--brand-100 */
-	--lasuite-color-brand-200: #bec5f0; /* --c--globals--colors--brand-200 */
-	--lasuite-color-brand-300: #a0a5f6; /* --c--globals--colors--brand-300 */
-	--lasuite-color-brand-400: #8184fc; /* --c--globals--colors--brand-400 */
-	--lasuite-color-brand-500: #6969df; /* --c--globals--colors--brand-500 */
-	--lasuite-color-brand-600: #534fc2; /* --c--globals--colors--brand-600 */
-	--lasuite-color-brand-650: #4844ad; /* --c--globals--colors--brand-650 — La Suite brand */
-	--lasuite-color-brand-700: #3e3b98; /* --c--globals--colors--brand-700 */
-	--lasuite-color-brand-750: #36347d; /* --c--globals--colors--brand-750 — button hover step */
-	--lasuite-color-brand-800: #2d2f5f; /* --c--globals--colors--brand-800 */
-	--lasuite-color-brand-900: #1c1e32; /* --c--globals--colors--brand-900 */
-	--lasuite-color-brand-950: #11131f; /* --c--globals--colors--brand-950 */
-
-	/* ===================================================================
-	 * GREYSCALE
-	 * Source: --c--globals--colors--gray-*. gray-000 is the white surface
-	 * Cunningham uses for cards/header (--c--contextuals--background--surface--primary).
-	 * =================================================================== */
-
-	--lasuite-color-gray-000: #ffffff; /* --c--globals--colors--gray-000 */
-	--lasuite-color-gray-025: #f8f8f9; /* --c--globals--colors--gray-025 */
-	--lasuite-color-gray-050: #f0f0f3; /* --c--globals--colors--gray-050 */
-	--lasuite-color-gray-100: #e2e2ea; /* --c--globals--colors--gray-100 */
-	--lasuite-color-gray-200: #c5c6d5; /* --c--globals--colors--gray-200 — hairline border */
-	--lasuite-color-gray-300: #a9a9bf; /* --c--globals--colors--gray-300 — input border */
-	--lasuite-color-gray-500: #75758a; /* --c--globals--colors--gray-500 */
-	--lasuite-color-gray-700: #454558; /* --c--globals--colors--gray-700 */
-	--lasuite-color-gray-900: #1b1b23; /* --c--globals--colors--gray-900 — body text */
-	--lasuite-color-gray-1000: #000000; /* --c--globals--colors--gray-1000 */
-
-	/* ===================================================================
-	 * SEMANTIC COLORS
-	 * The "-500" values are Cunningham's own NAMED swatches (the values the
-	 * spec/upstream docs refer to as "success-500" etc). Cunningham's actual
-	 * interactive fill token (--c--contextuals--background--semantic--{name}--primary)
-	 * resolves to the darker "-550" step instead — the "-500" swatch alone is
-	 * used for accents (borders, icons), not as a solid fill carrying white
-	 * text. Both are curated here: -500 for spec/accent fidelity, -550 as the
-	 * fill the bridge maps onto --nldesign-color-{status} (white text on -550
-	 * clears WCAG AA >=4.5:1 with margin; on the raw -500 swatch it does not).
-	 * =================================================================== */
-
-	--lasuite-color-success-500: #1e884a; /* --c--globals--colors--success-500 */
-	--lasuite-color-success-550: #027b3e; /* --c--globals--colors--success-550 (background--semantic--success--primary) */
-	--lasuite-color-warning-500: #cb5000; /* --c--globals--colors--warning-500 */
-	--lasuite-color-warning-550: #bc4200; /* --c--globals--colors--warning-550 (background--semantic--warning--primary) */
-	--lasuite-color-error-500: #e82322; /* --c--globals--colors--error-500 */
-	--lasuite-color-error-550: #d7010e; /* --c--globals--colors--error-550 (background--semantic--error--primary) */
-	--lasuite-color-error-650: #aa0000; /* --c--globals--colors--error-650 — hover step */
-	--lasuite-color-info-500: #0077de; /* --c--globals--colors--info-500 */
-	--lasuite-color-info-550: #0069cf; /* --c--globals--colors--info-550 (background--semantic--info--primary) */
-
-	/* Accessible text painted on the "-550" fills above (white — see comment
-	 * on the semantic block; not accessible on the raw "-500" swatch). */
-	--lasuite-color-on-success: var(--lasuite-color-gray-000);
-	--lasuite-color-on-warning: var(--lasuite-color-gray-000);
-	--lasuite-color-on-error: var(--lasuite-color-gray-000);
-	--lasuite-color-on-info: var(--lasuite-color-gray-000);
-
-	/* ===================================================================
-	 * BORDER RADIUS
-	 * Source: --c--components--button--border-radius /
-	 * --c--components--forms-input--border-radius (both 4px — Cunningham is
-	 * a flat 4px system across buttons, inputs and selects).
-	 * =================================================================== */
-
+	--lasuite-color-brand-050: var(--lasuite--globals--colors--brand-050);
+	--lasuite-color-brand-100: var(--lasuite--globals--colors--brand-100);
+	--lasuite-color-brand-650: var(--lasuite--globals--colors--brand-650);
+	--lasuite-color-brand-750: var(--lasuite--globals--colors--brand-750);
+	--lasuite-color-error-550: var(--lasuite--globals--colors--error-550);
+	--lasuite-color-error-650: var(--lasuite--globals--colors--error-650);
+	--lasuite-color-gray-000: var(--lasuite--globals--colors--gray-000);
+	--lasuite-color-gray-025: var(--lasuite--globals--colors--gray-025);
+	--lasuite-color-gray-050: var(--lasuite--globals--colors--gray-050);
+	--lasuite-color-gray-100: var(--lasuite--globals--colors--gray-100);
+	--lasuite-color-gray-200: var(--lasuite--globals--colors--gray-200);
+	--lasuite-color-gray-300: var(--lasuite--globals--colors--gray-300);
+	--lasuite-color-gray-500: var(--lasuite--globals--colors--gray-500);
+	--lasuite-color-gray-900: var(--lasuite--globals--colors--gray-900);
+	--lasuite-color-info-550: var(--lasuite--globals--colors--info-550);
+	--lasuite-color-info-650: var(--lasuite--globals--colors--info-650);
+	--lasuite-color-success-550: var(--lasuite--globals--colors--success-550);
+	--lasuite-color-success-650: var(--lasuite--globals--colors--success-650);
+	--lasuite-color-warning-550: var(--lasuite--globals--colors--warning-550);
+	--lasuite-color-warning-650: var(--lasuite--globals--colors--warning-650);
 	--lasuite-border-radius: 4px;
+}
 
-	/* ===================================================================
-	 * SPACING (base scale)
-	 * Source: --c--globals--spacings--xs/sm/base/md/lg.
-	 * =================================================================== */
-
-	--lasuite-spacing-xs: 0.5rem; /* --c--globals--spacings--xs */
-	--lasuite-spacing-sm: 0.75rem; /* --c--globals--spacings--sm */
-	--lasuite-spacing-base: 1rem; /* --c--globals--spacings--base */
-	--lasuite-spacing-md: 1.5rem; /* --c--globals--spacings--md */
-	--lasuite-spacing-lg: 2rem; /* --c--globals--spacings--lg */
+.cunningham-theme--dark {
+	--lasuite--contextuals--background--palette--blue-1--primary: var(--lasuite--globals--colors--blue-1-350);
+	--lasuite--contextuals--background--palette--blue-1--secondary: var(--lasuite--globals--colors--blue-1-450);
+	--lasuite--contextuals--background--palette--blue-1--tertiary: var(--lasuite--globals--colors--blue-1-550);
+	--lasuite--contextuals--background--palette--blue-2--primary: var(--lasuite--globals--colors--blue-2-350);
+	--lasuite--contextuals--background--palette--blue-2--secondary: var(--lasuite--globals--colors--blue-2-450);
+	--lasuite--contextuals--background--palette--blue-2--tertiary: var(--lasuite--globals--colors--blue-2-550);
+	--lasuite--contextuals--background--palette--brand--primary: var(--lasuite--globals--colors--brand-350);
+	--lasuite--contextuals--background--palette--brand--secondary: var(--lasuite--globals--colors--brand-450);
+	--lasuite--contextuals--background--palette--brand--tertiary: var(--lasuite--globals--colors--brand-550);
+	--lasuite--contextuals--background--palette--brown--primary: var(--lasuite--globals--colors--brown-350);
+	--lasuite--contextuals--background--palette--brown--secondary: var(--lasuite--globals--colors--brown-450);
+	--lasuite--contextuals--background--palette--brown--tertiary: var(--lasuite--globals--colors--brown-550);
+	--lasuite--contextuals--background--palette--gray--primary: var(--lasuite--globals--colors--gray-350);
+	--lasuite--contextuals--background--palette--gray--secondary: var(--lasuite--globals--colors--gray-450);
+	--lasuite--contextuals--background--palette--gray--tertiary: var(--lasuite--globals--colors--gray-550);
+	--lasuite--contextuals--background--palette--green--primary: var(--lasuite--globals--colors--green-350);
+	--lasuite--contextuals--background--palette--green--secondary: var(--lasuite--globals--colors--green-450);
+	--lasuite--contextuals--background--palette--green--tertiary: var(--lasuite--globals--colors--green-550);
+	--lasuite--contextuals--background--palette--orange--primary: var(--lasuite--globals--colors--orange-350);
+	--lasuite--contextuals--background--palette--orange--secondary: var(--lasuite--globals--colors--orange-450);
+	--lasuite--contextuals--background--palette--orange--tertiary: var(--lasuite--globals--colors--orange-550);
+	--lasuite--contextuals--background--palette--pink--primary: var(--lasuite--globals--colors--pink-350);
+	--lasuite--contextuals--background--palette--pink--secondary: var(--lasuite--globals--colors--pink-450);
+	--lasuite--contextuals--background--palette--pink--tertiary: var(--lasuite--globals--colors--pink-550);
+	--lasuite--contextuals--background--palette--purple--primary: var(--lasuite--globals--colors--purple-350);
+	--lasuite--contextuals--background--palette--purple--secondary: var(--lasuite--globals--colors--purple-450);
+	--lasuite--contextuals--background--palette--purple--tertiary: var(--lasuite--globals--colors--purple-550);
+	--lasuite--contextuals--background--palette--red--primary: var(--lasuite--globals--colors--red-350);
+	--lasuite--contextuals--background--palette--red--secondary: var(--lasuite--globals--colors--red-450);
+	--lasuite--contextuals--background--palette--red--tertiary: var(--lasuite--globals--colors--red-550);
+	--lasuite--contextuals--background--palette--yellow--primary: var(--lasuite--globals--colors--yellow-350);
+	--lasuite--contextuals--background--palette--yellow--secondary: var(--lasuite--globals--colors--yellow-450);
+	--lasuite--contextuals--background--palette--yellow--tertiary: var(--lasuite--globals--colors--yellow-550);
+	--lasuite--contextuals--background--semantic--brand--primary: var(--lasuite--globals--colors--brand-550);
+	--lasuite--contextuals--background--semantic--brand--primary-hover: var(--lasuite--globals--colors--brand-650);
+	--lasuite--contextuals--background--semantic--brand--secondary: var(--lasuite--globals--colors--brand-700);
+	--lasuite--contextuals--background--semantic--brand--secondary-hover: var(--lasuite--globals--colors--brand-750);
+	--lasuite--contextuals--background--semantic--brand--tertiary: var(--lasuite--globals--colors--brand-750);
+	--lasuite--contextuals--background--semantic--brand--tertiary-hover: var(--lasuite--globals--colors--brand-800);
+	--lasuite--contextuals--background--semantic--contextual--primary: var(--lasuite--globals--colors--white-050);
+	--lasuite--contextuals--background--semantic--contextual--primary-hover: var(--lasuite--globals--colors--white-100);
+	--lasuite--contextuals--background--semantic--disabled--primary: var(--lasuite--globals--colors--gray-750);
+	--lasuite--contextuals--background--semantic--disabled--secondary: var(--lasuite--globals--colors--gray-800);
+	--lasuite--contextuals--background--semantic--error--primary: var(--lasuite--globals--colors--error-550);
+	--lasuite--contextuals--background--semantic--error--primary-hover: var(--lasuite--globals--colors--error-650);
+	--lasuite--contextuals--background--semantic--error--secondary: var(--lasuite--globals--colors--error-700);
+	--lasuite--contextuals--background--semantic--error--secondary-hover: var(--lasuite--globals--colors--error-750);
+	--lasuite--contextuals--background--semantic--error--tertiary: var(--lasuite--globals--colors--error-750);
+	--lasuite--contextuals--background--semantic--error--tertiary-hover: var(--lasuite--globals--colors--error-800);
+	--lasuite--contextuals--background--semantic--info--primary: var(--lasuite--globals--colors--info-550);
+	--lasuite--contextuals--background--semantic--info--primary-hover: var(--lasuite--globals--colors--info-650);
+	--lasuite--contextuals--background--semantic--info--secondary: var(--lasuite--globals--colors--info-700);
+	--lasuite--contextuals--background--semantic--info--secondary-hover: var(--lasuite--globals--colors--info-750);
+	--lasuite--contextuals--background--semantic--info--tertiary: var(--lasuite--globals--colors--info-750);
+	--lasuite--contextuals--background--semantic--info--tertiary-hover: var(--lasuite--globals--colors--info-800);
+	--lasuite--contextuals--background--semantic--neutral--primary: var(--lasuite--globals--colors--gray-550);
+	--lasuite--contextuals--background--semantic--neutral--primary-hover: var(--lasuite--globals--colors--gray-650);
+	--lasuite--contextuals--background--semantic--neutral--secondary: var(--lasuite--globals--colors--gray-700);
+	--lasuite--contextuals--background--semantic--neutral--secondary-hover: var(--lasuite--globals--colors--gray-750);
+	--lasuite--contextuals--background--semantic--neutral--tertiary: var(--lasuite--globals--colors--gray-750);
+	--lasuite--contextuals--background--semantic--neutral--tertiary-hover: var(--lasuite--globals--colors--gray-800);
+	--lasuite--contextuals--background--semantic--success--primary: var(--lasuite--globals--colors--success-550);
+	--lasuite--contextuals--background--semantic--success--primary-hover: var(--lasuite--globals--colors--success-650);
+	--lasuite--contextuals--background--semantic--success--secondary: var(--lasuite--globals--colors--success-700);
+	--lasuite--contextuals--background--semantic--success--secondary-hover: var(--lasuite--globals--colors--success-750);
+	--lasuite--contextuals--background--semantic--success--tertiary: var(--lasuite--globals--colors--success-750);
+	--lasuite--contextuals--background--semantic--success--tertiary-hover: var(--lasuite--globals--colors--success-800);
+	--lasuite--contextuals--background--semantic--warning--primary: var(--lasuite--globals--colors--warning-550);
+	--lasuite--contextuals--background--semantic--warning--primary-hover: var(--lasuite--globals--colors--warning-650);
+	--lasuite--contextuals--background--semantic--warning--secondary: var(--lasuite--globals--colors--warning-700);
+	--lasuite--contextuals--background--semantic--warning--secondary-hover: var(--lasuite--globals--colors--warning-750);
+	--lasuite--contextuals--background--semantic--warning--tertiary: var(--lasuite--globals--colors--warning-750);
+	--lasuite--contextuals--background--semantic--warning--tertiary-hover: var(--lasuite--globals--colors--warning-800);
+	--lasuite--contextuals--background--surface--primary: var(--lasuite--globals--colors--gray-800);
+	--lasuite--contextuals--background--surface--secondary: var(--lasuite--globals--colors--gray-850);
+	--lasuite--contextuals--background--surface--tertiary: var(--lasuite--globals--colors--gray-900);
+	--lasuite--contextuals--border--palette--blue-1--primary: var(--lasuite--globals--colors--blue-1-350);
+	--lasuite--contextuals--border--palette--blue-1--secondary: var(--lasuite--globals--colors--blue-1-450);
+	--lasuite--contextuals--border--palette--blue-1--tertiary: var(--lasuite--globals--colors--blue-1-550);
+	--lasuite--contextuals--border--palette--blue-2--primary: var(--lasuite--globals--colors--blue-2-350);
+	--lasuite--contextuals--border--palette--blue-2--secondary: var(--lasuite--globals--colors--blue-2-450);
+	--lasuite--contextuals--border--palette--blue-2--tertiary: var(--lasuite--globals--colors--blue-2-550);
+	--lasuite--contextuals--border--palette--brand--primary: var(--lasuite--globals--colors--brand-350);
+	--lasuite--contextuals--border--palette--brand--secondary: var(--lasuite--globals--colors--brand-450);
+	--lasuite--contextuals--border--palette--brand--tertiary: var(--lasuite--globals--colors--brand-550);
+	--lasuite--contextuals--border--palette--brown--primary: var(--lasuite--globals--colors--brown-350);
+	--lasuite--contextuals--border--palette--brown--secondary: var(--lasuite--globals--colors--brown-450);
+	--lasuite--contextuals--border--palette--brown--tertiary: var(--lasuite--globals--colors--brown-550);
+	--lasuite--contextuals--border--palette--gray--primary: var(--lasuite--globals--colors--gray-350);
+	--lasuite--contextuals--border--palette--gray--secondary: var(--lasuite--globals--colors--gray-450);
+	--lasuite--contextuals--border--palette--gray--tertiary: var(--lasuite--globals--colors--gray-550);
+	--lasuite--contextuals--border--palette--green--primary: var(--lasuite--globals--colors--green-350);
+	--lasuite--contextuals--border--palette--green--secondary: var(--lasuite--globals--colors--green-450);
+	--lasuite--contextuals--border--palette--green--tertiary: var(--lasuite--globals--colors--green-550);
+	--lasuite--contextuals--border--palette--orange--primary: var(--lasuite--globals--colors--orange-350);
+	--lasuite--contextuals--border--palette--orange--secondary: var(--lasuite--globals--colors--orange-450);
+	--lasuite--contextuals--border--palette--orange--tertiary: var(--lasuite--globals--colors--orange-550);
+	--lasuite--contextuals--border--palette--pink--primary: var(--lasuite--globals--colors--pink-350);
+	--lasuite--contextuals--border--palette--pink--secondary: var(--lasuite--globals--colors--pink-450);
+	--lasuite--contextuals--border--palette--pink--tertiary: var(--lasuite--globals--colors--pink-550);
+	--lasuite--contextuals--border--palette--purple--primary: var(--lasuite--globals--colors--purple-350);
+	--lasuite--contextuals--border--palette--purple--secondary: var(--lasuite--globals--colors--purple-450);
+	--lasuite--contextuals--border--palette--purple--tertiary: var(--lasuite--globals--colors--purple-550);
+	--lasuite--contextuals--border--palette--red--primary: var(--lasuite--globals--colors--red-350);
+	--lasuite--contextuals--border--palette--red--secondary: var(--lasuite--globals--colors--red-450);
+	--lasuite--contextuals--border--palette--red--tertiary: var(--lasuite--globals--colors--red-550);
+	--lasuite--contextuals--border--palette--yellow--primary: var(--lasuite--globals--colors--yellow-350);
+	--lasuite--contextuals--border--palette--yellow--secondary: var(--lasuite--globals--colors--yellow-450);
+	--lasuite--contextuals--border--palette--yellow--tertiary: var(--lasuite--globals--colors--yellow-550);
+	--lasuite--contextuals--border--semantic--brand--primary: var(--lasuite--globals--colors--brand-450);
+	--lasuite--contextuals--border--semantic--brand--secondary: var(--lasuite--globals--colors--brand-600);
+	--lasuite--contextuals--border--semantic--brand--tertiary: var(--lasuite--globals--colors--brand-700);
+	--lasuite--contextuals--border--semantic--contextual--primary: var(--lasuite--globals--colors--black-200);
+	--lasuite--contextuals--border--semantic--disabled--primary: var(--lasuite--globals--colors--gray-800);
+	--lasuite--contextuals--border--semantic--error--primary: var(--lasuite--globals--colors--error-450);
+	--lasuite--contextuals--border--semantic--error--secondary: var(--lasuite--globals--colors--error-600);
+	--lasuite--contextuals--border--semantic--error--tertiary: var(--lasuite--globals--colors--error-700);
+	--lasuite--contextuals--border--semantic--info--primary: var(--lasuite--globals--colors--info-450);
+	--lasuite--contextuals--border--semantic--info--secondary: var(--lasuite--globals--colors--info-600);
+	--lasuite--contextuals--border--semantic--info--tertiary: var(--lasuite--globals--colors--info-700);
+	--lasuite--contextuals--border--semantic--neutral--primary: var(--lasuite--globals--colors--gray-450);
+	--lasuite--contextuals--border--semantic--neutral--secondary: var(--lasuite--globals--colors--gray-600);
+	--lasuite--contextuals--border--semantic--neutral--tertiary: var(--lasuite--globals--colors--gray-700);
+	--lasuite--contextuals--border--semantic--success--primary: var(--lasuite--globals--colors--success-450);
+	--lasuite--contextuals--border--semantic--success--secondary: var(--lasuite--globals--colors--success-600);
+	--lasuite--contextuals--border--semantic--success--tertiary: var(--lasuite--globals--colors--success-700);
+	--lasuite--contextuals--border--semantic--warning--primary: var(--lasuite--globals--colors--warning-450);
+	--lasuite--contextuals--border--semantic--warning--secondary: var(--lasuite--globals--colors--warning-600);
+	--lasuite--contextuals--border--semantic--warning--tertiary: var(--lasuite--globals--colors--warning-700);
+	--lasuite--contextuals--border--surface--primary: var(--lasuite--globals--colors--gray-750);
+	--lasuite--contextuals--content--logo1: var(--lasuite--globals--colors--logo-1-dark);
+	--lasuite--contextuals--content--logo2: var(--lasuite--globals--colors--logo-2-dark);
+	--lasuite--contextuals--content--palette--blue-1--primary: var(--lasuite--globals--colors--blue-1-350);
+	--lasuite--contextuals--content--palette--blue-1--secondary: var(--lasuite--globals--colors--blue-1-450);
+	--lasuite--contextuals--content--palette--blue-1--tertiary: var(--lasuite--globals--colors--blue-1-550);
+	--lasuite--contextuals--content--palette--blue-2--primary: var(--lasuite--globals--colors--blue-2-350);
+	--lasuite--contextuals--content--palette--blue-2--secondary: var(--lasuite--globals--colors--blue-2-450);
+	--lasuite--contextuals--content--palette--blue-2--tertiary: var(--lasuite--globals--colors--blue-2-550);
+	--lasuite--contextuals--content--palette--brand--primary: var(--lasuite--globals--colors--brand-350);
+	--lasuite--contextuals--content--palette--brand--secondary: var(--lasuite--globals--colors--brand-450);
+	--lasuite--contextuals--content--palette--brand--tertiary: var(--lasuite--globals--colors--brand-550);
+	--lasuite--contextuals--content--palette--brown--primary: var(--lasuite--globals--colors--brown-350);
+	--lasuite--contextuals--content--palette--brown--secondary: var(--lasuite--globals--colors--brown-450);
+	--lasuite--contextuals--content--palette--brown--tertiary: var(--lasuite--globals--colors--brown-550);
+	--lasuite--contextuals--content--palette--gray--primary: var(--lasuite--globals--colors--gray-350);
+	--lasuite--contextuals--content--palette--gray--secondary: var(--lasuite--globals--colors--gray-450);
+	--lasuite--contextuals--content--palette--gray--tertiary: var(--lasuite--globals--colors--gray-550);
+	--lasuite--contextuals--content--palette--green--primary: var(--lasuite--globals--colors--green-350);
+	--lasuite--contextuals--content--palette--green--secondary: var(--lasuite--globals--colors--green-450);
+	--lasuite--contextuals--content--palette--green--tertiary: var(--lasuite--globals--colors--green-550);
+	--lasuite--contextuals--content--palette--orange--primary: var(--lasuite--globals--colors--orange-350);
+	--lasuite--contextuals--content--palette--orange--secondary: var(--lasuite--globals--colors--orange-450);
+	--lasuite--contextuals--content--palette--orange--tertiary: var(--lasuite--globals--colors--orange-550);
+	--lasuite--contextuals--content--palette--pink--primary: var(--lasuite--globals--colors--pink-350);
+	--lasuite--contextuals--content--palette--pink--secondary: var(--lasuite--globals--colors--pink-450);
+	--lasuite--contextuals--content--palette--pink--tertiary: var(--lasuite--globals--colors--pink-550);
+	--lasuite--contextuals--content--palette--purple--primary: var(--lasuite--globals--colors--purple-350);
+	--lasuite--contextuals--content--palette--purple--secondary: var(--lasuite--globals--colors--purple-450);
+	--lasuite--contextuals--content--palette--purple--tertiary: var(--lasuite--globals--colors--purple-550);
+	--lasuite--contextuals--content--palette--red--primary: var(--lasuite--globals--colors--red-350);
+	--lasuite--contextuals--content--palette--red--secondary: var(--lasuite--globals--colors--red-450);
+	--lasuite--contextuals--content--palette--red--tertiary: var(--lasuite--globals--colors--red-550);
+	--lasuite--contextuals--content--palette--yellow--primary: var(--lasuite--globals--colors--yellow-350);
+	--lasuite--contextuals--content--palette--yellow--secondary: var(--lasuite--globals--colors--yellow-450);
+	--lasuite--contextuals--content--palette--yellow--tertiary: var(--lasuite--globals--colors--yellow-550);
+	--lasuite--contextuals--content--semantic--brand--on-brand: var(--lasuite--globals--colors--brand-050);
+	--lasuite--contextuals--content--semantic--brand--primary: var(--lasuite--globals--colors--brand-050);
+	--lasuite--contextuals--content--semantic--brand--secondary: var(--lasuite--globals--colors--brand-100);
+	--lasuite--contextuals--content--semantic--brand--tertiary: var(--lasuite--globals--colors--brand-250);
+	--lasuite--contextuals--content--semantic--contextual--primary: var(--lasuite--globals--colors--black-850);
+	--lasuite--contextuals--content--semantic--disabled--primary: var(--lasuite--globals--colors--gray-600);
+	--lasuite--contextuals--content--semantic--disabled--secondary: var(--lasuite--globals--colors--black-300);
+	--lasuite--contextuals--content--semantic--error--on-error: var(--lasuite--globals--colors--error-050);
+	--lasuite--contextuals--content--semantic--error--primary: var(--lasuite--globals--colors--error-050);
+	--lasuite--contextuals--content--semantic--error--secondary: var(--lasuite--globals--colors--error-100);
+	--lasuite--contextuals--content--semantic--error--tertiary: var(--lasuite--globals--colors--error-250);
+	--lasuite--contextuals--content--semantic--info--on-info: var(--lasuite--globals--colors--info-050);
+	--lasuite--contextuals--content--semantic--info--primary: var(--lasuite--globals--colors--info-050);
+	--lasuite--contextuals--content--semantic--info--secondary: var(--lasuite--globals--colors--info-100);
+	--lasuite--contextuals--content--semantic--info--tertiary: var(--lasuite--globals--colors--info-250);
+	--lasuite--contextuals--content--semantic--neutral--on-neutral: var(--lasuite--globals--colors--gray-050);
+	--lasuite--contextuals--content--semantic--neutral--primary: var(--lasuite--globals--colors--gray-050);
+	--lasuite--contextuals--content--semantic--neutral--secondary: var(--lasuite--globals--colors--gray-100);
+	--lasuite--contextuals--content--semantic--neutral--tertiary: var(--lasuite--globals--colors--gray-250);
+	--lasuite--contextuals--content--semantic--success--on-success: var(--lasuite--globals--colors--success-050);
+	--lasuite--contextuals--content--semantic--success--primary: var(--lasuite--globals--colors--success-050);
+	--lasuite--contextuals--content--semantic--success--secondary: var(--lasuite--globals--colors--success-100);
+	--lasuite--contextuals--content--semantic--success--tertiary: var(--lasuite--globals--colors--success-250);
+	--lasuite--contextuals--content--semantic--warning--on-warning: var(--lasuite--globals--colors--warning-050);
+	--lasuite--contextuals--content--semantic--warning--primary: var(--lasuite--globals--colors--warning-050);
+	--lasuite--contextuals--content--semantic--warning--secondary: var(--lasuite--globals--colors--warning-100);
+	--lasuite--contextuals--content--semantic--warning--tertiary: var(--lasuite--globals--colors--warning-250);
+	--lasuite--globals--breakpoints--lg: 992px;
+	--lasuite--globals--breakpoints--md: 768px;
+	--lasuite--globals--breakpoints--sm: 576px;
+	--lasuite--globals--breakpoints--xl: 1200px;
+	--lasuite--globals--breakpoints--xs: 0;
+	--lasuite--globals--breakpoints--xxl: 1400px;
+	--lasuite--globals--colors--black-000: #00000000;
+	--lasuite--globals--colors--black-050: #0000000d;
+	--lasuite--globals--colors--black-100: #0000001a;
+	--lasuite--globals--colors--black-150: #00000026;
+	--lasuite--globals--colors--black-200: #00000033;
+	--lasuite--globals--colors--black-250: #00000040;
+	--lasuite--globals--colors--black-300: #0000004d;
+	--lasuite--globals--colors--black-350: #00000059;
+	--lasuite--globals--colors--black-400: #00000066;
+	--lasuite--globals--colors--black-450: #00000073;
+	--lasuite--globals--colors--black-500: #00000080;
+	--lasuite--globals--colors--black-550: #0000008c;
+	--lasuite--globals--colors--black-600: #00000099;
+	--lasuite--globals--colors--black-650: #000000a6;
+	--lasuite--globals--colors--black-700: #000000b3;
+	--lasuite--globals--colors--black-750: #000000bf;
+	--lasuite--globals--colors--black-800: #000000cc;
+	--lasuite--globals--colors--black-850: #000000d9;
+	--lasuite--globals--colors--black-900: #000000e6;
+	--lasuite--globals--colors--black-950: #000000f2;
+	--lasuite--globals--colors--blue-1-050: #ebf1ff;
+	--lasuite--globals--colors--blue-1-100: #d6e3fe;
+	--lasuite--globals--colors--blue-1-150: #c2d5fe;
+	--lasuite--globals--colors--blue-1-200: #adc7fe;
+	--lasuite--globals--colors--blue-1-250: #99b8fd;
+	--lasuite--globals--colors--blue-1-300: #84aafd;
+	--lasuite--globals--colors--blue-1-350: #6f9bfd;
+	--lasuite--globals--colors--blue-1-400: #5a8dfb;
+	--lasuite--globals--colors--blue-1-450: #437dfc;
+	--lasuite--globals--colors--blue-1-500: #3d71e4;
+	--lasuite--globals--colors--blue-1-550: #3665cc;
+	--lasuite--globals--colors--blue-1-600: #305ab5;
+	--lasuite--globals--colors--blue-1-650: #315093;
+	--lasuite--globals--colors--blue-1-700: #2e4675;
+	--lasuite--globals--colors--blue-1-750: #293b5e;
+	--lasuite--globals--colors--blue-1-800: #243048;
+	--lasuite--globals--colors--blue-1-850: #1e2635;
+	--lasuite--globals--colors--blue-1-900: #171c25;
+	--lasuite--globals--colors--blue-1-950: #0e1116;
+	--lasuite--globals--colors--blue-2-050: #e2f4f9;
+	--lasuite--globals--colors--blue-2-100: #c5e9f3;
+	--lasuite--globals--colors--blue-2-150: #a7dded;
+	--lasuite--globals--colors--blue-2-200: #88d1e6;
+	--lasuite--globals--colors--blue-2-250: #68c5e0;
+	--lasuite--globals--colors--blue-2-300: #48b8d9;
+	--lasuite--globals--colors--blue-2-350: #3baaca;
+	--lasuite--globals--colors--blue-2-400: #359cb9;
+	--lasuite--globals--colors--blue-2-450: #318ea9;
+	--lasuite--globals--colors--blue-2-500: #2c8199;
+	--lasuite--globals--colors--blue-2-550: #277389;
+	--lasuite--globals--colors--blue-2-600: #236679;
+	--lasuite--globals--colors--blue-2-650: #2a5866;
+	--lasuite--globals--colors--blue-2-700: #2a4b55;
+	--lasuite--globals--colors--blue-2-750: #283f47;
+	--lasuite--globals--colors--blue-2-800: #233337;
+	--lasuite--globals--colors--blue-2-850: #1d272a;
+	--lasuite--globals--colors--blue-2-900: #161c1e;
+	--lasuite--globals--colors--blue-2-950: #0e1112;
+	--lasuite--globals--colors--brand-050: #eaf1fb;
+	--lasuite--globals--colors--brand-100: #d5e4f7;
+	--lasuite--globals--colors--brand-150: #c0d6f4;
+	--lasuite--globals--colors--brand-200: #abc9f0;
+	--lasuite--globals--colors--brand-250: #96bcec;
+	--lasuite--globals--colors--brand-300: #80aee8;
+	--lasuite--globals--colors--brand-350: #6ca0e4;
+	--lasuite--globals--colors--brand-400: #5693e0;
+	--lasuite--globals--colors--brand-450: #4085dc;
+	--lasuite--globals--colors--brand-500: #2976d8;
+	--lasuite--globals--colors--brand-550: #1167d4;
+	--lasuite--globals--colors--brand-600: #0659c5;
+	--lasuite--globals--colors--brand-650: #1a509f;
+	--lasuite--globals--colors--brand-700: #20467f;
+	--lasuite--globals--colors--brand-750: #203c63;
+	--lasuite--globals--colors--brand-800: #1d314c;
+	--lasuite--globals--colors--brand-850: #1a2638;
+	--lasuite--globals--colors--brand-900: #141c28;
+	--lasuite--globals--colors--brand-950: #0c1117;
+	--lasuite--globals--colors--brown-050: #f3f0ef;
+	--lasuite--globals--colors--brown-100: #e7e1df;
+	--lasuite--globals--colors--brown-150: #dcd2cf;
+	--lasuite--globals--colors--brown-200: #d0c4bf;
+	--lasuite--globals--colors--brown-250: #c5b6b0;
+	--lasuite--globals--colors--brown-300: #baa7a1;
+	--lasuite--globals--colors--brown-350: #af9992;
+	--lasuite--globals--colors--brown-400: #a48b83;
+	--lasuite--globals--colors--brown-450: #997e74;
+	--lasuite--globals--colors--brown-500: #8f7065;
+	--lasuite--globals--colors--brown-550: #846357;
+	--lasuite--globals--colors--brown-600: #7a5649;
+	--lasuite--globals--colors--brown-650: #684c42;
+	--lasuite--globals--colors--brown-700: #57423c;
+	--lasuite--globals--colors--brown-750: #463833;
+	--lasuite--globals--colors--brown-800: #382e2a;
+	--lasuite--globals--colors--brown-850: #2b2422;
+	--lasuite--globals--colors--brown-900: #1f1b19;
+	--lasuite--globals--colors--brown-950: #121010;
+	--lasuite--globals--colors--error-050: #fceded;
+	--lasuite--globals--colors--error-100: #fadbdb;
+	--lasuite--globals--colors--error-150: #f7c9c9;
+	--lasuite--globals--colors--error-200: #f5b7b7;
+	--lasuite--globals--colors--error-250: #f2a4a4;
+	--lasuite--globals--colors--error-300: #ef9191;
+	--lasuite--globals--colors--error-350: #ec7d7d;
+	--lasuite--globals--colors--error-400: #e96868;
+	--lasuite--globals--colors--error-450: #e55050;
+	--lasuite--globals--colors--error-500: #e13131;
+	--lasuite--globals--colors--error-550: #d80000;
+	--lasuite--globals--colors--error-600: #c00101;
+	--lasuite--globals--colors--error-650: #9e2219;
+	--lasuite--globals--colors--error-700: #802820;
+	--lasuite--globals--colors--error-750: #662820;
+	--lasuite--globals--colors--error-800: #4f231e;
+	--lasuite--globals--colors--error-850: #3b1d19;
+	--lasuite--globals--colors--error-900: #2a1614;
+	--lasuite--globals--colors--error-950: #1a0e0c;
+	--lasuite--globals--colors--gray-000: #ffffff;
+	--lasuite--globals--colors--gray-025: #f7f8f8;
+	--lasuite--globals--colors--gray-050: #f0f1f2;
+	--lasuite--globals--colors--gray-100: #e1e2e5;
+	--lasuite--globals--colors--gray-1000: #000000;
+	--lasuite--globals--colors--gray-150: #d2d4d8;
+	--lasuite--globals--colors--gray-200: #c4c7cb;
+	--lasuite--globals--colors--gray-250: #b5b9be;
+	--lasuite--globals--colors--gray-300: #a7acb2;
+	--lasuite--globals--colors--gray-350: #999ea5;
+	--lasuite--globals--colors--gray-400: #8d9197;
+	--lasuite--globals--colors--gray-450: #80848a;
+	--lasuite--globals--colors--gray-500: #74777c;
+	--lasuite--globals--colors--gray-550: #686b6f;
+	--lasuite--globals--colors--gray-600: #5c5f63;
+	--lasuite--globals--colors--gray-650: #505356;
+	--lasuite--globals--colors--gray-700: #45474a;
+	--lasuite--globals--colors--gray-750: #3a3b3e;
+	--lasuite--globals--colors--gray-800: #2f3033;
+	--lasuite--globals--colors--gray-850: #252627;
+	--lasuite--globals--colors--gray-900: #1b1c1d;
+	--lasuite--globals--colors--gray-950: #101112;
+	--lasuite--globals--colors--green-050: #e2f6e5;
+	--lasuite--globals--colors--green-100: #c5ecca;
+	--lasuite--globals--colors--green-150: #a7e3af;
+	--lasuite--globals--colors--green-200: #89d894;
+	--lasuite--globals--colors--green-250: #67ce75;
+	--lasuite--globals--colors--green-300: #4dc25d;
+	--lasuite--globals--colors--green-350: #48b257;
+	--lasuite--globals--colors--green-400: #41a44f;
+	--lasuite--globals--colors--green-450: #3b9548;
+	--lasuite--globals--colors--green-500: #368741;
+	--lasuite--globals--colors--green-550: #30793a;
+	--lasuite--globals--colors--green-600: #2b6b33;
+	--lasuite--globals--colors--green-650: #2f5c34;
+	--lasuite--globals--colors--green-700: #2e4e31;
+	--lasuite--globals--colors--green-750: #2a412c;
+	--lasuite--globals--colors--green-800: #253426;
+	--lasuite--globals--colors--green-850: #1e281f;
+	--lasuite--globals--colors--green-900: #171d17;
+	--lasuite--globals--colors--green-950: #0f120f;
+	--lasuite--globals--colors--info-050: #eaf1fb;
+	--lasuite--globals--colors--info-100: #d5e4f7;
+	--lasuite--globals--colors--info-150: #c0d6f4;
+	--lasuite--globals--colors--info-200: #abc9f0;
+	--lasuite--globals--colors--info-250: #96bcec;
+	--lasuite--globals--colors--info-300: #80aee8;
+	--lasuite--globals--colors--info-350: #6ca0e4;
+	--lasuite--globals--colors--info-400: #5693e0;
+	--lasuite--globals--colors--info-450: #4085dc;
+	--lasuite--globals--colors--info-500: #2976d8;
+	--lasuite--globals--colors--info-550: #1167d4;
+	--lasuite--globals--colors--info-600: #0659c5;
+	--lasuite--globals--colors--info-650: #1a509f;
+	--lasuite--globals--colors--info-700: #20467f;
+	--lasuite--globals--colors--info-750: #203c63;
+	--lasuite--globals--colors--info-800: #1d314c;
+	--lasuite--globals--colors--info-850: #1a2638;
+	--lasuite--globals--colors--info-900: #141c28;
+	--lasuite--globals--colors--info-950: #0c1117;
+	--lasuite--globals--colors--logo-1: #377fdb;
+	--lasuite--globals--colors--logo-1-dark: #95abff;
+	--lasuite--globals--colors--logo-2: #377fdb;
+	--lasuite--globals--colors--logo-2-dark: #95abff;
+	--lasuite--globals--colors--orange-050: #fdeee2;
+	--lasuite--globals--colors--orange-100: #fcddc5;
+	--lasuite--globals--colors--orange-150: #facba8;
+	--lasuite--globals--colors--orange-200: #f8b98b;
+	--lasuite--globals--colors--orange-250: #f6a76a;
+	--lasuite--globals--colors--orange-300: #f4934b;
+	--lasuite--globals--colors--orange-350: #f27e27;
+	--lasuite--globals--colors--orange-400: #e76e12;
+	--lasuite--globals--colors--orange-450: #d26411;
+	--lasuite--globals--colors--orange-500: #be5b0f;
+	--lasuite--globals--colors--orange-550: #aa510e;
+	--lasuite--globals--colors--orange-600: #97480c;
+	--lasuite--globals--colors--orange-650: #7e431d;
+	--lasuite--globals--colors--orange-700: #673c22;
+	--lasuite--globals--colors--orange-750: #533422;
+	--lasuite--globals--colors--orange-800: #412c1f;
+	--lasuite--globals--colors--orange-850: #31231b;
+	--lasuite--globals--colors--orange-900: #221a14;
+	--lasuite--globals--colors--orange-950: #15100c;
+	--lasuite--globals--colors--pink-050: #fcedf5;
+	--lasuite--globals--colors--pink-100: #f9daea;
+	--lasuite--globals--colors--pink-150: #f7c7e0;
+	--lasuite--globals--colors--pink-200: #f4b4d5;
+	--lasuite--globals--colors--pink-250: #f1a1ca;
+	--lasuite--globals--colors--pink-300: #ee8cbf;
+	--lasuite--globals--colors--pink-350: #ea77b3;
+	--lasuite--globals--colors--pink-400: #e760a6;
+	--lasuite--globals--colors--pink-450: #e24797;
+	--lasuite--globals--colors--pink-500: #cd4089;
+	--lasuite--globals--colors--pink-550: #b8397b;
+	--lasuite--globals--colors--pink-600: #a3336d;
+	--lasuite--globals--colors--pink-650: #86355e;
+	--lasuite--globals--colors--pink-700: #6e334f;
+	--lasuite--globals--colors--pink-750: #582e42;
+	--lasuite--globals--colors--pink-800: #442834;
+	--lasuite--globals--colors--pink-850: #332028;
+	--lasuite--globals--colors--pink-900: #24181d;
+	--lasuite--globals--colors--pink-950: #160f12;
+	--lasuite--globals--colors--purple-050: #f6eeff;
+	--lasuite--globals--colors--purple-100: #ecdcff;
+	--lasuite--globals--colors--purple-150: #e3cbfe;
+	--lasuite--globals--colors--purple-200: #dab9fe;
+	--lasuite--globals--colors--purple-250: #d0a7fe;
+	--lasuite--globals--colors--purple-300: #c795fe;
+	--lasuite--globals--colors--purple-350: #bd83fd;
+	--lasuite--globals--colors--purple-400: #b36ffd;
+	--lasuite--globals--colors--purple-450: #a85bfd;
+	--lasuite--globals--colors--purple-500: #9b4bf3;
+	--lasuite--globals--colors--purple-550: #8b43da;
+	--lasuite--globals--colors--purple-600: #7b3cc1;
+	--lasuite--globals--colors--purple-650: #673c9b;
+	--lasuite--globals--colors--purple-700: #56387d;
+	--lasuite--globals--colors--purple-750: #463162;
+	--lasuite--globals--colors--purple-800: #382a4a;
+	--lasuite--globals--colors--purple-850: #2a2237;
+	--lasuite--globals--colors--purple-900: #1e1926;
+	--lasuite--globals--colors--purple-950: #121017;
+	--lasuite--globals--colors--red-050: #fdeded;
+	--lasuite--globals--colors--red-100: #fadbdb;
+	--lasuite--globals--colors--red-150: #f8c9c9;
+	--lasuite--globals--colors--red-200: #f5b7b6;
+	--lasuite--globals--colors--red-250: #f3a4a3;
+	--lasuite--globals--colors--red-300: #f09190;
+	--lasuite--globals--colors--red-350: #ee7c7b;
+	--lasuite--globals--colors--red-400: #eb6665;
+	--lasuite--globals--colors--red-450: #e74e4d;
+	--lasuite--globals--colors--red-500: #d83f3d;
+	--lasuite--globals--colors--red-550: #c23837;
+	--lasuite--globals--colors--red-600: #ac3231;
+	--lasuite--globals--colors--red-650: #8d3531;
+	--lasuite--globals--colors--red-700: #73332f;
+	--lasuite--globals--colors--red-750: #5b2f2b;
+	--lasuite--globals--colors--red-800: #472826;
+	--lasuite--globals--colors--red-850: #35211f;
+	--lasuite--globals--colors--red-900: #251817;
+	--lasuite--globals--colors--red-950: #160f0e;
+	--lasuite--globals--colors--success-050: #e4f7d4;
+	--lasuite--globals--colors--success-100: #c8eea8;
+	--lasuite--globals--colors--success-150: #aae579;
+	--lasuite--globals--colors--success-200: #89dc45;
+	--lasuite--globals--colors--success-250: #72cf27;
+	--lasuite--globals--colors--success-300: #6ac024;
+	--lasuite--globals--colors--success-350: #61b121;
+	--lasuite--globals--colors--success-400: #59a21e;
+	--lasuite--globals--colors--success-450: #51941c;
+	--lasuite--globals--colors--success-500: #4b851a;
+	--lasuite--globals--colors--success-550: #427816;
+	--lasuite--globals--colors--success-600: #3a6a14;
+	--lasuite--globals--colors--success-650: #385c1f;
+	--lasuite--globals--colors--success-700: #344d24;
+	--lasuite--globals--colors--success-750: #2e4022;
+	--lasuite--globals--colors--success-800: #27341f;
+	--lasuite--globals--colors--success-850: #20281a;
+	--lasuite--globals--colors--success-900: #181d15;
+	--lasuite--globals--colors--success-950: #10120e;
+	--lasuite--globals--colors--warning-050: #fff1bd;
+	--lasuite--globals--colors--warning-100: #ffe176;
+	--lasuite--globals--colors--warning-150: #ffcf25;
+	--lasuite--globals--colors--warning-200: #f4bf06;
+	--lasuite--globals--colors--warning-250: #e3b205;
+	--lasuite--globals--colors--warning-300: #d3a504;
+	--lasuite--globals--colors--warning-350: #c29805;
+	--lasuite--globals--colors--warning-400: #b28c03;
+	--lasuite--globals--colors--warning-450: #a27f03;
+	--lasuite--globals--colors--warning-500: #937303;
+	--lasuite--globals--colors--warning-550: #836703;
+	--lasuite--globals--colors--warning-600: #745b03;
+	--lasuite--globals--colors--warning-650: #625019;
+	--lasuite--globals--colors--warning-700: #524620;
+	--lasuite--globals--colors--warning-750: #443b20;
+	--lasuite--globals--colors--warning-800: #36301d;
+	--lasuite--globals--colors--warning-850: #2a2619;
+	--lasuite--globals--colors--warning-900: #1e1c13;
+	--lasuite--globals--colors--warning-950: #12110c;
+	--lasuite--globals--colors--white-000: #ffffff;
+	--lasuite--globals--colors--white-050: #ffffff0d;
+	--lasuite--globals--colors--white-100: #ffffff1a;
+	--lasuite--globals--colors--white-150: #ffffff26;
+	--lasuite--globals--colors--white-200: #ffffff33;
+	--lasuite--globals--colors--white-250: #ffffff40;
+	--lasuite--globals--colors--white-300: #ffffff4d;
+	--lasuite--globals--colors--white-350: #ffffff59;
+	--lasuite--globals--colors--white-400: #ffffff66;
+	--lasuite--globals--colors--white-450: #ffffff73;
+	--lasuite--globals--colors--white-500: #ffffff80;
+	--lasuite--globals--colors--white-550: #ffffff8c;
+	--lasuite--globals--colors--white-600: #ffffff99;
+	--lasuite--globals--colors--white-650: #ffffffa6;
+	--lasuite--globals--colors--white-700: #ffffffb3;
+	--lasuite--globals--colors--white-750: #ffffffbf;
+	--lasuite--globals--colors--white-800: #ffffffcc;
+	--lasuite--globals--colors--white-850: #ffffffd9;
+	--lasuite--globals--colors--white-900: #ffffffe6;
+	--lasuite--globals--colors--white-950: #fffffff2;
+	--lasuite--globals--colors--yellow-050: #faf0d3;
+	--lasuite--globals--colors--yellow-100: #f5e2a4;
+	--lasuite--globals--colors--yellow-150: #f0d275;
+	--lasuite--globals--colors--yellow-200: #ebc242;
+	--lasuite--globals--colors--yellow-250: #e4b213;
+	--lasuite--globals--colors--yellow-300: #d4a511;
+	--lasuite--globals--colors--yellow-350: #c39810;
+	--lasuite--globals--colors--yellow-400: #b38b0f;
+	--lasuite--globals--colors--yellow-450: #a37f0d;
+	--lasuite--globals--colors--yellow-500: #93730c;
+	--lasuite--globals--colors--yellow-550: #84670b;
+	--lasuite--globals--colors--yellow-600: #755b0a;
+	--lasuite--globals--colors--yellow-650: #63501c;
+	--lasuite--globals--colors--yellow-700: #534521;
+	--lasuite--globals--colors--yellow-750: #443a21;
+	--lasuite--globals--colors--yellow-800: #36301f;
+	--lasuite--globals--colors--yellow-850: #29261a;
+	--lasuite--globals--colors--yellow-900: #1d1c14;
+	--lasuite--globals--colors--yellow-950: #12110c;
+	--lasuite--globals--font--families--accent: "Roboto Flex Variable", sans-serif;
+	--lasuite--globals--font--families--base: "Roboto Flex Variable", sans-serif;
+	--lasuite--globals--font--sizes--h1: 2rem;
+	--lasuite--globals--font--sizes--h2: 1.75rem;
+	--lasuite--globals--font--sizes--h3: 1.5rem;
+	--lasuite--globals--font--sizes--h4: 1.375rem;
+	--lasuite--globals--font--sizes--h5: 1.25rem;
+	--lasuite--globals--font--sizes--h6: 1.125rem;
+	--lasuite--globals--font--sizes--lg: 1.125rem;
+	--lasuite--globals--font--sizes--lg-alt: 4.5rem;
+	--lasuite--globals--font--sizes--md: 1rem;
+	--lasuite--globals--font--sizes--md-alt: 4rem;
+	--lasuite--globals--font--sizes--ml: 0.938rem;
+	--lasuite--globals--font--sizes--s: 0.75rem;
+	--lasuite--globals--font--sizes--sm: 0.875rem;
+	--lasuite--globals--font--sizes--sm-alt: 3.5rem;
+	--lasuite--globals--font--sizes--t: 0.6875rem;
+	--lasuite--globals--font--sizes--xl: 1.25rem;
+	--lasuite--globals--font--sizes--xl-alt: 5rem;
+	--lasuite--globals--font--sizes--xs: 0.75rem;
+	--lasuite--globals--font--sizes--xs-alt: 3rem;
+	--lasuite--globals--font--weights--black: 800;
+	--lasuite--globals--font--weights--bold: 600;
+	--lasuite--globals--font--weights--extrabold: 700;
+	--lasuite--globals--font--weights--light: 300;
+	--lasuite--globals--font--weights--medium: 500;
+	--lasuite--globals--font--weights--regular: 400;
+	--lasuite--globals--font--weights--thin: 200;
+	--lasuite--globals--spacings--4xl: 4rem;
+	--lasuite--globals--spacings--4xs: 0.125rem;
+	--lasuite--globals--spacings--5xl: 4.5rem;
+	--lasuite--globals--spacings--6xl: 6rem;
+	--lasuite--globals--spacings--7xl: 7.5rem;
+	--lasuite--globals--spacings--b: 1.625rem;
+	--lasuite--globals--spacings--base: 1rem;
+	--lasuite--globals--spacings--l: 3rem;
+	--lasuite--globals--spacings--lg: 2rem;
+	--lasuite--globals--spacings--m: 0.8125rem;
+	--lasuite--globals--spacings--md: 1.5rem;
+	--lasuite--globals--spacings--s: 1rem;
+	--lasuite--globals--spacings--sm: 0.75rem;
+	--lasuite--globals--spacings--st: 0.25rem;
+	--lasuite--globals--spacings--t: 0.5rem;
+	--lasuite--globals--spacings--xl: 2.5rem;
+	--lasuite--globals--spacings--xs: 0.5rem;
+	--lasuite--globals--spacings--xxl: 3rem;
+	--lasuite--globals--spacings--xxs: 0.375rem;
+	--lasuite--globals--spacings--xxxl: 3.5rem;
+	--lasuite--globals--spacings--xxxs: 0.25rem;
+	--lasuite--globals--transitions--duration: 250ms;
+	--lasuite--globals--transitions--ease-in: cubic-bezier(0.32, 0, 0.67, 0);
+	--lasuite--globals--transitions--ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+	--lasuite--globals--transitions--ease-out: cubic-bezier(0.33, 1, 0.68, 1);
 }

--- a/css/tokens/cunningham.css
+++ b/css/tokens/cunningham.css
@@ -1,0 +1,64 @@
+/**
+ * Cunningham (blue base) — Token Set
+ *
+ * Standard Layer-3 `--nldesign-*` overrides for the `cunningham` token set
+ * (REQ-TSET-005). This is the PUBLISHED Cunningham blue base — the artifact
+ * `@openfun/cunningham-tokens`/`@gouvfr-lasuite/ui-kit` actually distribute —
+ * as opposed to `lasuite.css`, which pins the deployed VIOLET brand no
+ * package ships. Both reuse the same generated
+ * css/systems/lasuite/defaults.css; this set's design system
+ * (`systems/lasuite/*` bundle minus `brand-override`) is what keeps the
+ * cascade blue. This is a deliberately PARTIAL set: it only pins the
+ * set-level identity values — everything else falls through to the shared
+ * lasuite bridge layer (css/systems/lasuite/bridge.css).
+ *
+ * Colour source: Cunningham (`@openfun/cunningham-tokens`, MIT) — see
+ * css/systems/lasuite/defaults.css for full attribution.
+ *
+ * PRIMARY = brand-650, not brand-600: the shared bridge.css/element-
+ * overrides.css (both files are REUSED as-is from the lasuite bundle) derive
+ * `--color-primary` and every brand-accent rule from `--lasuite-color-
+ * brand-650` specifically — the same step that resolves to the deployed
+ * violet #4844AD for lasuite. Pinning this file's `--nldesign-color-primary`
+ * to that same step (its blue-base value, #1a509f) keeps the swatch
+ * consistent with what the design system ACTUALLY renders, matching
+ * lasuite.css's own brand-650-based swatch.
+ */
+
+:root {
+	/* Cunningham brand — brand-650 (published blue base) */
+	--nldesign-color-primary: #1a509f;
+	--nldesign-color-primary-text: #ffffff;
+	--nldesign-color-primary-hover: #203c63;
+	--nldesign-color-primary-light: #eaf1fb;
+	--nldesign-color-primary-light-hover: #d5e4f7;
+
+	/* Background tones — Cunningham greyscale (gray-000/025/050). */
+	--nldesign-color-background-hover: #f0f1f2;
+	--nldesign-color-background-dark: #e1e2e5;
+	--nldesign-color-background-darker: #c4c7cb;
+
+	/* Header — white, matching the element-overrides hairline treatment. */
+	--nldesign-color-header-background: #ffffff;
+	--nldesign-color-header-text: #1b1c1d;
+	--nldesign-color-nav-background: #ffffff;
+
+	/* Text */
+	--nldesign-color-text: #1b1c1d;
+	--nldesign-color-text-muted: #74777c;
+	--nldesign-color-text-light: #ffffff;
+
+	/* Border */
+	--nldesign-color-border: #c4c7cb;
+	--nldesign-color-border-dark: #74777c;
+
+	/* Typography — Marianne (local-only) then self-hosted Inter, same stack
+	 * as lasuite (shared systems/lasuite/fonts stylesheet). */
+	--nldesign-font-family: Marianne, Inter, sans-serif;
+
+	/* Border radius — Cunningham is a flat 4px system. */
+	--nldesign-border-radius: 4px;
+	--nldesign-border-radius-small: 4px;
+	--nldesign-border-radius-large: 4px;
+	--nldesign-border-radius-rounded: 4px;
+}

--- a/design-systems.json
+++ b/design-systems.json
@@ -41,7 +41,19 @@
 	{
 		"id": "lasuite",
 		"name": "La Suite numérique",
-		"description": "Pixel-adjacent match to La Suite numérique's Cunningham design system (MIT) — the Docs/Meet/Chat suite behind MinBZK/mijn-bureau — so a Nextcloud core in a sovereign-workplace (EDIC) bundle shows no visual seam. Self-hosted Inter (SIL OFL 1.1) with Marianne resolved only via local() install; no Marianne files, no La Suite/state logos shipped.",
+		"description": "Pixel-adjacent match to La Suite numérique's Cunningham design system (MIT) — the Docs/Meet/Chat suite behind MinBZK/mijn-bureau — so a Nextcloud core in a sovereign-workplace (EDIC) bundle shows no visual seam. Self-hosted Inter (SIL OFL 1.1) with Marianne resolved only via local() install; no Marianne files, no La Suite/state logos shipped. Cunningham base is generated (1167 tokens, blue); the deployed violet brand is a separate, sourced override layer.",
+		"stylesheets": [
+			"systems/lasuite/fonts",
+			"systems/lasuite/defaults",
+			"systems/lasuite/brand-override",
+			"systems/lasuite/bridge",
+			"systems/lasuite/element-overrides"
+		]
+	},
+	{
+		"id": "cunningham",
+		"name": "Cunningham (blue base)",
+		"description": "The published Cunningham design system (MIT) as the npm packages actually distribute it — blue base (brand-600 #0659C5), no La Suite deployment override. Reuses the same generated defaults as lasuite, minus the sourced violet brand-override layer. Self-hosted Inter (SIL OFL 1.1) with Marianne resolved only via local() install; no Marianne files, no logos shipped.",
 		"stylesheets": [
 			"systems/lasuite/fonts",
 			"systems/lasuite/defaults",

--- a/docs/reference/contrast-report.md
+++ b/docs/reference/contrast-report.md
@@ -17,6 +17,7 @@ system reads `--nldesign-*` tokens, computed by `ContrastService` over
 | bodegraven-reeuwijk | 10.20:1 | 4.5:1 | 10.20:1 | 3.0:1 | pass |
 | borne | 10.20:1 | 4.5:1 | 10.20:1 | 3.0:1 | pass |
 | buren | 10.20:1 | 4.5:1 | 10.20:1 | 3.0:1 | pass |
+| cunningham | 7.80:1 | 4.5:1 | 7.80:1 | 3.0:1 | pass |
 | demodam | 10.20:1 | 4.5:1 | 10.20:1 | 3.0:1 | pass |
 | denhaag | 5.39:1 | 4.5:1 | 5.39:1 | 3.0:1 | pass |
 | dinkelland | 10.20:1 | 4.5:1 | 10.20:1 | 3.0:1 | pass |

--- a/openspec/changes/lasuite-token-completeness/design.md
+++ b/openspec/changes/lasuite-token-completeness/design.md
@@ -63,7 +63,15 @@ bundle simply omits `brand-override`, so it resolves to blue from the same `defa
 
 `token-sets.json` `lasuite.primary_color` stays `#4844AD` — it is display metadata for the admin
 dropdown/preview, and `#4844AD` is the violet brand-650/logo, which is the correct swatch to show for
-the deployed theme. `cunningham.primary_color` is `#0659C5` (blue brand-600).
+the deployed theme. `cunningham.primary_color` is `#1A509F` (blue brand-650, NOT brand-600
+`#0659C5`): the shared `bridge.css`/`element-overrides.css` (reused as-is, unmodified, from the
+lasuite bundle — see "Rewrite bridge/element-overrides to canonical names now" under Alternatives)
+derive `--color-primary` and every brand-accent rule from `--lasuite-color-brand-650` specifically,
+the same step that resolves to lasuite's deployed violet `#4844AD`. Pinning `cunningham.primary_color`
+to brand-650's blue value keeps the swatch honest about what the design system actually renders,
+matching the pattern `lasuite.primary_color` already establishes. (`brand-600 #0659C5` remains the
+correct value for the raw *generated token* `--lasuite--globals--colors--brand-600` in
+`defaults.css` — that fact is unrelated to and unaffected by this correction.)
 
 ## Bridge coverage model
 
@@ -93,8 +101,10 @@ Issue #181: the e2e instance falls over under heavy parallel navigation. The par
   the audit flagged).
 
 Reference values come from the Cunningham build for the **active** set: violet for `lasuite`
-(brand-650 `#4844ad`, radius `4px`, Inter/Marianne stack), blue for `cunningham` (brand-600 `#0659C5`).
-The spec reads the active token set and selects the matching reference table.
+(brand-650 `#4844ad`, radius `4px`, Inter/Marianne stack), blue for `cunningham` (brand-650
+`#1a509f`, same radius/font stack — the shared bridge/element-overrides derive every rendered
+brand-accent from brand-650, not brand-600). The spec reads the active token set and selects the
+matching reference table.
 
 ## Drift guard
 

--- a/openspec/changes/lasuite-token-completeness/proposal.md
+++ b/openspec/changes/lasuite-token-completeness/proposal.md
@@ -64,7 +64,9 @@ adds a **drift guard**. It also (secondarily) ships the published blue base as i
   brand-override → bridge → element-overrides`.
 - **Ship the blue base as an optional sibling set (secondary).** Add a `cunningham` design system
   (bundle `fonts → defaults → bridge → element-overrides`, **no** brand-override) and a `cunningham`
-  token set (`primary_color #0659C5`) that **reuses the same generated `defaults.css`**. This is the
+  token set (`primary_color #1A509F` — brand-650 of the blue base, the step the shared bridge/
+  element-overrides actually derive `--color-primary` from) that **reuses the same generated
+  `defaults.css`**. This is the
   artifact the npm packages actually publish; it is optional/secondary to `lasuite` and adds no new
   CSS beyond one token file + two manifest entries.
 - **Complete the bridge with provable coverage.** Audit every Nextcloud `--color-*` variable in the

--- a/openspec/changes/lasuite-token-completeness/specs/css-architecture/spec.md
+++ b/openspec/changes/lasuite-token-completeness/specs/css-architecture/spec.md
@@ -34,7 +34,9 @@ Shipped design systems are `none`, `nldesign`, `summer-breeze`, `high-contrast`,
 - THEN it MUST return a bundle of exactly four stylesheets in order: `systems/lasuite/fonts`,
   `systems/lasuite/defaults`, `systems/lasuite/bridge`, `systems/lasuite/element-overrides`
   (the same shared files as `lasuite`, **without** `systems/lasuite/brand-override`)
-- AND activating the `cunningham` token set MUST resolve the blue base (`--color-primary #0659C5`)
+- AND activating the `cunningham` token set MUST resolve the blue base (`--color-primary #1A509F`
+  — brand-650, the same scale step the shared bridge/element-overrides derive `--color-primary`
+  from for lasuite's violet `#4844AD`; `#0659C5` is brand-600, a different, unrendered step)
 
 #### Scenario: Unknown design system falls back safely
 

--- a/openspec/changes/lasuite-token-completeness/specs/lasuite-parity/spec.md
+++ b/openspec/changes/lasuite-token-completeness/specs/lasuite-parity/spec.md
@@ -92,7 +92,11 @@ behaviour.
 
 - GIVEN the `cunningham` token set is active
 - WHEN `--color-primary` is resolved
-- THEN it MUST resolve to the blue `#0659C5` from the shared generated `defaults.css`
+- THEN it MUST resolve to the blue base's brand-650 `#1A509F` from the shared generated
+  `defaults.css` (the same scale step `--color-primary` resolves to for lasuite's violet
+  `#4844AD` — the shared bridge/element-overrides derive `--color-primary` from
+  `--lasuite-color-brand-650` specifically, not brand-600; brand-600 `#0659C5` is the value of the
+  raw generated token `--lasuite--globals--colors--brand-600`, a different, unrendered step)
 - AND no `--lasuite/brand-override` stylesheet MUST be loaded for this set
 - AND activating `lasuite` afterwards MUST still resolve to the violet `#4844AD`
 
@@ -151,7 +155,9 @@ element) rather than heavy parallel navigation.
   header, and table
 - THEN each asserted property MUST equal the Cunningham reference value for the active set (violet
   brand-650 `#4844ad`, radius `4px`, the Inter/Marianne stack), after notation normalisation
-- AND for the `cunningham` set the reference table MUST use the blue base (brand-600 `#0659C5`)
+- AND for the `cunningham` set the reference table MUST use the blue base's brand-650 (`#1A509F` —
+  the same scale step the shared bridge/element-overrides derive every rendered brand-accent from
+  for lasuite's violet `#4844AD`; brand-600 `#0659C5` is a different, unrendered step)
 
 #### Scenario: Mismatch names the property and delta
 

--- a/openspec/changes/lasuite-token-completeness/specs/token-sets/spec.md
+++ b/openspec/changes/lasuite-token-completeness/specs/token-sets/spec.md
@@ -57,8 +57,10 @@ additionally ship the published Cunningham blue base as a `cunningham` set.
 - GIVEN the app ships the optional `cunningham` sibling set
 - WHEN the `cunningham` entry in `token-sets.json` is read
 - THEN it MUST declare `design_system: "cunningham"`
-- AND its `theming` object MUST contain `primary_color: "#0659C5"` (the published Cunningham blue
-  base) and `background_color: "#FFFFFF"`
+- AND its `theming` object MUST contain `primary_color: "#1A509F"` (brand-650 of the published
+  Cunningham blue base — the same scale step the shared bridge/element-overrides derive
+  `--color-primary` from for lasuite's violet `#4844AD`, so the swatch matches what actually
+  renders) and `background_color: "#FFFFFF"`
 - AND it MUST NOT contain a `logo` key
 - AND `css/tokens/cunningham.css` MUST exist as a standard Layer-3 `--nldesign-*` set pinning the blue
   identity, reusing the shared generated `defaults.css` via its design system bundle

--- a/openspec/changes/lasuite-token-completeness/tasks.md
+++ b/openspec/changes/lasuite-token-completeness/tasks.md
@@ -2,110 +2,142 @@
 
 ## 1. Cunningham token generation
 
-- [ ] 1.1 Add `@openfun/cunningham-tokens` (`^3.0.0`, MIT) to `devDependencies` in `package.json`;
+- [x] 1.1 Add `@openfun/cunningham-tokens` (`^3.0.0`, MIT) to `devDependencies` in `package.json`;
       run `npm install` and confirm `node_modules/@openfun/cunningham-tokens/dist/cunningham-tokens.css`
       exists with 1167 `--c--*` tokens.
-- [ ] 1.2 Write `scripts/generate-lasuite-tokens.mjs`: read the package's `dist/cunningham-tokens.css`,
+- [x] 1.2 Write `scripts/generate-lasuite-tokens.mjs`: read the package's `dist/cunningham-tokens.css`,
       parse every `--c--<path>: <value>;` on `:root`, rename `--c--` → `--lasuite--` (double-dash
       hierarchy separators preserved — the reversible prefix-swap documented in the file header), and
       emit `css/systems/lasuite/defaults.css` with all 1167 tokens on `:root`, sorted stably.
-- [ ] 1.3 Emit a provenance header on the generated file: source package name + resolved version (read
+      IMPLEMENTATION NOTE: the source ships tokens across TWO top-level blocks (`html { ... }` = 584
+      light + `.cunningham-theme--dark { ... }` = 583 dark, 584+583=1167) — the generator mirrors that
+      structure (`:root` for light, `.cunningham-theme--dark` for dark) rather than flattening both
+      into one `:root`, which would silently let dark values clobber light ones. See the module header
+      comment in generate-lasuite-tokens.mjs for the full rationale.
+- [x] 1.3 Emit a provenance header on the generated file: source package name + resolved version (read
       from the package's `package.json`), token count, the mapping rule, the generation date, and the
       MIT attribution.
-- [ ] 1.4 Append a closed, explicitly-listed **compatibility-alias** `:root` block mapping the ~37
-      short names the current `bridge.css` / `element-overrides.css` read
-      (`--lasuite-color-*`, `--lasuite-border-radius`, `--lasuite-spacing-*`, `--lasuite-font-family`
-      if applicable) to their canonical `--lasuite--*` tokens via `var()`.
-- [ ] 1.5 Accept an output-path arg/env (default the committed `defaults.css`) so the drift check can
+- [x] 1.4 Append a closed, explicitly-listed **compatibility-alias** block (merged into the same
+      `:root` as the canonical tokens — a separate `:root` block would trip stylelint's
+      no-duplicate-selectors rule) mapping the 20 short names `bridge.css`/`element-overrides.css`
+      actually read (verified by grep, not the ~37 stale names in the old hand-curated file) to their
+      canonical `--lasuite--*` tokens via `var()`. `--lasuite-font-family` is defined separately in
+      fonts.css (unaffected by regeneration); `--lasuite-border-radius` is the one literal (no
+      upstream border-radius token exists in the package at all).
+- [x] 1.5 Accept an output-path arg/env (default the committed `defaults.css`) so the drift check can
       generate to a temp file. Make output deterministic (stable order, fixed formatting).
-- [ ] 1.6 Run the generator; commit the regenerated `css/systems/lasuite/defaults.css`. Confirm the
+- [x] 1.6 Run the generator; commit the regenerated `css/systems/lasuite/defaults.css`. Confirm the
       base is **blue** (`--lasuite--globals--colors--brand-600: #0659C5`).
 
 ## 2. Sourced violet brand override
 
-- [ ] 2.1 Create `css/systems/lasuite/brand-override.css` with a provenance comment: "Observed in the
+- [x] 2.1 Create `css/systems/lasuite/brand-override.css` with a provenance comment: "Observed in the
       docs.numerique.gouv.fr La Suite Docs bundle, :root block 5 (violet override), 2026-07-24. Not
       present in any published Cunningham npm package."
-- [ ] 2.2 Redeclare on `:root` the violet tokens block 5 overrides: `brand-600 #534fc2`,
+- [x] 2.2 Redeclare on `:root` the violet tokens block 5 overrides: `brand-600 #534fc2`,
       `brand-650 #4844ad` (== logo), the dependent `brand-050…brand-950` scale, and the `logo-*`
-      tokens — plus their short-alias counterparts so the bridge resolves to violet. Use canonical
-      `--lasuite--*` names matching §1.2 so the override lands on the generated tokens.
-- [ ] 2.3 Add `systems/lasuite/brand-override` to the `lasuite` bundle in `design-systems.json`,
+      tokens (including `logo-1-light`/`logo-2-light`, which do not exist at all in the base package —
+      and the `--c--contextuals--content--logo1/2` redirect to them) — plus the four short-alias
+      counterparts (`--lasuite-color-brand-050/100/650/750`) so the bridge resolves to violet. Uses
+      canonical `--lasuite--*` names matching §1.2 so the override lands on the generated tokens.
+- [x] 2.3 Add `systems/lasuite/brand-override` to the `lasuite` bundle in `design-systems.json`,
       ordered **after** `systems/lasuite/defaults` and before `systems/lasuite/bridge`. Final order:
       `fonts, defaults, brand-override, bridge, element-overrides`.
-- [ ] 2.4 Leave `token-sets.json` `lasuite.theming.primary_color` as `#4844AD` and
+- [x] 2.4 Leave `token-sets.json` `lasuite.theming.primary_color` as `#4844AD` and
       `background_color` as `#FFFFFF`; do not add a `logo` key.
 
 ## 3. Optional blue-base `cunningham` sibling (SHOULD)
 
-- [ ] 3.1 Add a `cunningham` entry to `design-systems.json` with bundle
+- [x] 3.1 Add a `cunningham` entry to `design-systems.json` with bundle
       `systems/lasuite/fonts, systems/lasuite/defaults, systems/lasuite/bridge,
       systems/lasuite/element-overrides` (no brand-override — resolves blue from the shared defaults).
-- [ ] 3.2 Create `css/tokens/cunningham.css`: a standard Layer-3 `--nldesign-*` set pinning the blue
-      identity (`--nldesign-color-primary: #0659C5`, matching text/hover/light from the generated
-      blue scale), falling through to the bridge for the rest.
-- [ ] 3.3 Add a `cunningham` entry to `token-sets.json`: `design_system: "cunningham"`,
-      `theming.primary_color: "#0659C5"`, `background_color: "#FFFFFF"`, no `logo` key; name/description
-      make clear this is the published Cunningham blue base (MIT) vs the deployed violet `lasuite`.
+- [x] 3.2 Create `css/tokens/cunningham.css`: a standard Layer-3 `--nldesign-*` set pinning the blue
+      identity. CORRECTED during implementation: `--nldesign-color-primary` is `#1A509F` (brand-650),
+      not `#0659C5` (brand-600) as originally drafted here — the shared `bridge.css`/
+      `element-overrides.css` (reused unmodified from the lasuite bundle) derive `--color-primary`
+      and every brand-accent rule from `--lasuite-color-brand-650` specifically, the same step that
+      resolves to lasuite's deployed violet `#4844AD`; brand-600 is a different, unrendered step. See
+      the same correction reflected in design.md and the three spec deltas below.
+- [x] 3.3 Add a `cunningham` entry to `token-sets.json`: `design_system: "cunningham"`,
+      `theming.primary_color: "#1A509F"` (brand-650, corrected per 3.2 — NOT `#0659C5`),
+      `background_color: "#FFFFFF"`, no `logo` key; name/description make clear this is the published
+      Cunningham blue base (MIT) vs the deployed violet `lasuite`.
 
 ## 4. Complete the Nextcloud `--color-*` bridge
 
-- [ ] 4.1 Enumerate the audited Nextcloud `--color-*` surface from the `nextcloud-variable-mapping`
+- [x] 4.1 Enumerate the audited Nextcloud `--color-*` surface from the `nextcloud-variable-mapping`
       canonical audit — the concrete list is the 68 `--color-*` variables covered by
       `css/systems/nldesign/overrides.css` (cross-check `docs/reference/mappings.md`).
-- [ ] 4.2 In `css/systems/lasuite/bridge.css`, ensure **every** audited variable is present as either a
+- [x] 4.2 In `css/systems/lasuite/bridge.css`, ensure **every** audited variable is present as either a
       mapping to a `--lasuite--*`/short-alias token (with `!important` at `body[data-themes]`) or a
-      commented line with a reason.
-- [ ] 4.3 Keep the dark-mode-compat exclusions commented with their reason (REQ-CSS-007):
+      commented line with a reason. (68/68 — 44 mapped, 24 reasoned comments; also fixed the
+      `--nldesign-color-{error,warning,success,info}-rgb` literal triples and `--nldesign-color-focus`
+      rgba(), which were pre-existing but computed against the OLD hand-transcribed hex values and
+      would otherwise have gone out of sync with the regenerated defaults.css.)
+- [x] 4.3 Keep the dark-mode-compat exclusions commented with their reason (REQ-CSS-007):
       `--color-main-background`, `--color-main-background-rgb`, `--color-main-background-translucent`,
       `--color-background-plain`, `--background-invert-if-dark`, `--background-invert-if-bright` MUST NOT
       be overridden.
-- [ ] 4.4 Verify no circular `var()` references and that every fallback resolves to a concrete value or
+- [x] 4.4 Verify no circular `var()` references and that every fallback resolves to a concrete value or
       a token defined in `defaults.css`/`brand-override.css` (REQ-CSS-005).
 
 ## 5. Component-parity e2e
 
-- [ ] 5.1 Create `tests/e2e/spec-coverage/lasuite-parity.spec.ts` with the SPDX header and an
+- [x] 5.1 Create `tests/e2e/spec-coverage/lasuite-parity.spec.ts` with the SPDX header and an
       `@e2e openspec/specs/lasuite-parity/spec.md` tag.
-- [ ] 5.2 Configure `test.describe.configure({ mode: 'serial' })` and one `test()` per element
+- [x] 5.2 Configure `test.describe.configure({ mode: 'serial' })` and one `test()` per element
       (button, input, modal, header, table) — small and batchable for the load-fragile instance
       (issue #181).
-- [ ] 5.3 For each element, read **computed** styles via `page.evaluate(getComputedStyle)` and compare
-      `background-color`, `color`, `border-radius`, `font-family`, `font-size`, `font-weight`,
-      `padding`, `box-shadow` against the Cunningham reference table for the active set (violet for
-      `lasuite`, blue for `cunningham`).
-- [ ] 5.4 Normalise before compare (rgb()↔hex, whitespace in font-family/box-shadow) so notation
-      differences are not false deltas; on mismatch, throw an assertion message naming the exact
-      property and the expected-vs-actual delta.
-- [ ] 5.5 Ensure the spec activates the `lasuite` token set first (via the admin theming settings or a
-      test fixture) and restores the prior set on teardown.
+- [x] 5.3 For each element, read **computed** styles via `page.evaluate(getComputedStyle)` and compare
+      against the Cunningham reference table for the active set (violet for `lasuite`, blue for
+      `cunningham`). SCOPED: only the properties nldesign's own CSS actually sources for that selector
+      are compared per element (e.g. the button has no nldesign-authored padding/font-weight/box-shadow
+      — those are Nextcloud/Vue-component internals unrelated to this app's theming claims, so
+      asserting them would be guessing, not verifying). See the spec file's header comment.
+- [x] 5.4 Normalise before compare (hex→rgb() since getComputedStyle always reports rgb(), font-family
+      list whitespace/quoting/case) so notation differences are not false deltas; on mismatch, throw an
+      assertion message naming the exact property and the expected-vs-actual delta.
+- [x] 5.5 The spec activates `lasuite`/`cunningham` per test via `setTokenSet()` (reusing
+      `tests/e2e/workflows/_helpers.ts`), snapshots the prior set in `beforeAll`, and restores it in
+      `afterAll`.
 
 ## 6. Drift guard
 
-- [ ] 6.1 Add a `test:lasuite-tokens` script to `package.json` that runs
-      `scripts/generate-lasuite-tokens.mjs` into a temp file and `diff`s it against the committed
-      `css/systems/lasuite/defaults.css`, exiting non-zero (printing the first differing tokens) on any
-      difference.
-- [ ] 6.2 Follow the `tests/l10n/check-l10n-completeness.js` / `test:l10n:completeness` pattern so it
-      is wired into CI the same way; document it as the guard that a `package.json` upstream bump must
-      be accompanied by a regenerate + commit.
+- [x] 6.1 Add a `test:lasuite-tokens` script to `package.json` that runs
+      `scripts/generate-lasuite-tokens.mjs --check` (generates into a temp file internally and diffs
+      against the committed `css/systems/lasuite/defaults.css`), exiting non-zero (printing the first
+      20 differing lines) on any difference.
+- [x] 6.2 Follows the `tests/l10n/check-l10n-completeness.js` / `test:l10n:completeness` pattern
+      (single script, mode flag) so it is wired into CI the same way; documented in the generator's own
+      header comment as the guard that a `package.json` upstream bump must be accompanied by a
+      regenerate + commit.
 
 ## 7. Verify
 
-- [ ] 7.1 `npm run test:lasuite-tokens` passes on the committed file, and fails when a token in
-      `defaults.css` is manually edited (revert after proving).
-- [ ] 7.2 `npm run stylelint` passes on the new/changed CSS files.
-- [ ] 7.3 `node tests/validate-manifest.js` (`check:manifest`) passes with the new `cunningham` entries
-      and the 5-file `lasuite` bundle.
-- [ ] 7.4 On the 8080 dev instance, activate the `lasuite` set and confirm live in the browser:
-      `getComputedStyle(document.documentElement).getPropertyValue('--color-primary')` resolves to the
-      **violet** `#4844ad`; a primary button computes `border-radius: 4px` and the violet fill; the
-      header is white with a hairline border. Capture a screenshot.
-- [ ] 7.5 Activate the `cunningham` set and confirm `--color-primary` resolves to the **blue**
-      `#0659C5` from the same `defaults.css` with no violet override applied.
-- [ ] 7.6 Run `tests/e2e/spec-coverage/lasuite-parity.spec.ts` (serial, small batch) against the dev
-      instance and confirm all five element checks pass; confirm a deliberately wrong reference value
-      produces a failure naming the property + delta (revert after proving).
-- [ ] 7.7 Bridge coverage: assert the set of audited Nextcloud `--color-*` variables is fully present
-      in `bridge.css` (mapping or reasoned comment) — e.g. a small node/grep check diffing the variable
-      name sets against `css/systems/nldesign/overrides.css`.
+- [x] 7.1 `npm run test:lasuite-tokens` passes on the committed file. Drift detection proven during
+      implementation (hand-edited a token value, confirmed the check fails and names the exact line/
+      values, reverted) — see the builder's session log / PR description for the exact output.
+- [x] 7.2 `npx stylelint 'css/systems/lasuite/**/*.css' 'css/tokens/lasuite.css' 'css/tokens/
+      cunningham.css'` passes (0 problems). NOTE: `npm run stylelint` (whole-repo `css/**/*.css`) hits
+      one PRE-EXISTING, unrelated failure in `css/admin.css` (`Unclosed block`, not modified by this
+      change, last touched by an unrelated merge commit) — out of scope for this change; reported, not
+      fixed.
+- [x] 7.3 `node tests/validate-manifest.js` (`check:manifest`) passes — unaffected by this change (it
+      validates `src/manifest.json`, not `design-systems.json`/`token-sets.json`; there is no dedicated
+      schema validator for those two files in this app).
+- [ ] 7.4 DEFERRED — requires the live 8080 dev instance. Per the builder-brief ground rules ("SKIP
+      tasks that require the live 8080 instance"), not run in this worktree session; the shared
+      instance is load-fragile (#181) and other builders in this wave may be using it concurrently.
+      Do on the main checkout post-merge: activate `lasuite`, confirm
+      `getComputedStyle(document.documentElement).getPropertyValue('--color-primary')` = violet
+      `#4844ad`; primary button `border-radius: 4px` + violet fill; header white with hairline border.
+- [ ] 7.5 DEFERRED (same reason as 7.4). Activate `cunningham` and confirm `--color-primary` resolves
+      to the blue brand-650 `#1A509F` (corrected per task 3.2 — not brand-600 `#0659C5`).
+- [ ] 7.6 DEFERRED (same reason as 7.4). `tests/e2e/spec-coverage/lasuite-parity.spec.ts` is written,
+      committed, and verified to parse/list correctly under Playwright (`npx playwright test --list`
+      → 11 tests found, 0 errors) but not executed against the live instance.
+- [x] 7.7 Bridge coverage implemented TWICE, in two toolchains, both passing: `tests/css/check-lasuite-
+      bridge-coverage.js` (`npm run test:lasuite-bridge-coverage`) diffs the variable name sets between
+      `overrides.css` and `bridge.css`; `LasuiteDesignStackTest::testBridgeAccountsForEveryAuditedColor
+      Variable` (PHPUnit) asserts the same invariant so it is enforced from both the JS and PHP
+      toolchains.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
 		"test:l10n:write": "L10N_SRC_DIR=js node tests/l10n/check-l10n.js --write",
 		"test:l10n:completeness": "node tests/l10n/check-l10n-completeness.js",
 		"test:l10n:completeness:write": "node tests/l10n/check-l10n-completeness.js --write",
+		"generate:lasuite-tokens": "node scripts/generate-lasuite-tokens.mjs",
+		"test:lasuite-tokens": "node scripts/generate-lasuite-tokens.mjs --check",
+		"test:lasuite-bridge-coverage": "node tests/css/check-lasuite-bridge-coverage.js",
 		"build": "npm run build:fonts && npm run build:icons",
 		"build:fonts": "node scripts/build-fonts.js",
 		"build:icons": "node scripts/build-icons.js",
@@ -40,6 +43,7 @@
 	"devDependencies": {
 		"@conduction/nextcloud-vue": "^1.0.0-beta.218",
 		"@cyclonedx/cyclonedx-npm": "^4.2.1",
+		"@openfun/cunningham-tokens": "^3.0.0",
 		"@playwright/test": "^1.60.0",
 		"@vitest/coverage-v8": "^1.6.1",
 		"jsdom": "^29.1.1",

--- a/project.md
+++ b/project.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-NL Design is a Nextcloud theming app that applies Dutch government design standards (NL Design System) to the Nextcloud interface. It provides 43 token sets covering national government (Rijkshuisstijl), municipalities, organizations, and the European sovereign-workplace La Suite numérique (Cunningham) design system. Admins select a token set via a settings panel, and the app injects a design-system-driven CSS architecture that overrides Nextcloud's default styling with the selected organization's brand identity.
+NL Design is a Nextcloud theming app that applies Dutch government design standards (NL Design System) to the Nextcloud interface. It provides 44 token sets covering national government (Rijkshuisstijl), municipalities, organizations, and the European sovereign-workplace La Suite numérique (Cunningham) design system, plus its published blue base as an optional sibling. Admins select a token set via a settings panel, and the app injects a design-system-driven CSS architecture that overrides Nextcloud's default styling with the selected organization's brand identity.
 
 ## Architecture
 
@@ -34,14 +34,15 @@ NL Design is a Nextcloud theming app that applies Dutch government design standa
 | 6 | `css/overrides.css` | Maps Nextcloud `--color-*` vars to `--nldesign-*` |
 | 7 | `css/element-overrides.css` | Low-level element styling (fonts, containers) |
 
-## Token Sets (43)
+## Token Sets (44)
 
 - **National**: Rijkshuisstijl (default)
 - **Major cities**: Amsterdam, Utrecht, Rotterdam, Den Haag
 - **Municipalities**: 33 others (Haarlem, Leiden, Nijmegen, Tilburg, etc.)
 - **Organizations**: Demodam, Duo, Noaberkracht, VNG, xxllnc
 - **Provinces**: Zuid-Holland
-- **European sovereign-workplace**: La Suite numérique (Cunningham design system, MinBZK/mijn-bureau EDIC bundles)
+- **European sovereign-workplace**: La Suite numérique (Cunningham design system, MinBZK/mijn-bureau EDIC bundles) — deployed violet brand
+- **Published design system**: Cunningham (blue base) — the same Cunningham foundation as La Suite, without the deployed violet override
 
 ## Features
 

--- a/scripts/generate-lasuite-tokens.mjs
+++ b/scripts/generate-lasuite-tokens.mjs
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+
+/**
+ * Generate the La Suite numérique (Cunningham) token defaults layer.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * Reads the installed `@openfun/cunningham-tokens` devDependency's
+ * `dist/cunningham-tokens.css` (MIT licensed) and emits
+ * `css/systems/lasuite/defaults.css`: every `--c--*` Cunningham custom
+ * property, renamed to `--lasuite--*` via a documented, reversible prefix
+ * swap (`--c--<rest>` ⇄ `--lasuite--<rest>` — a prefix swap only, every `--`
+ * hierarchy separator preserved, no segment collapsing).
+ *
+ * SOURCE STRUCTURE (important — read before touching the block count below):
+ * the upstream file declares its tokens across TWO top-level blocks, not one:
+ *   - `html { ... }`                  — the light/base values (584 tokens)
+ *   - `.cunningham-theme--dark { ... }` — the dark-theme redeclarations (583
+ *     tokens; every light name except `--c--contextuals--background--text--
+ *     primary`, which the source only defines once)
+ * 584 + 583 = **1167** — the token count this generator (and the
+ * lasuite-parity spec) refers to throughout. It is NOT 1167 distinct names;
+ * flattening both blocks into one `:root` would silently let the dark
+ * redeclarations clobber the light base (last-write-wins in one selector),
+ * which is wrong (`--lasuite--globals--colors--brand-600` would stop being
+ * the published blue `#0659C5`) and would throw away real upstream fidelity
+ * (175 of the dark tokens carry genuinely different values, not just a
+ * shorthand notation). This generator therefore mirrors the source's own
+ * two-block shape: a `:root` block with the 584 light tokens (the ACTIVE
+ * base every consumer of this file reads — nothing in nldesign currently
+ * applies the `.cunningham-theme--dark` class, so that block is inert,
+ * upstream-faithful reference data, not wired into nldesign's own dark-mode
+ * system) and a `.cunningham-theme--dark` block with the 583 dark
+ * redeclarations, keeping the two concerns distinct instead of losing one.
+ *
+ * A closed, explicitly-listed compatibility-alias block follows, mapping the
+ * short `--lasuite-*` (single dash) names `css/systems/lasuite/bridge.css`
+ * and `element-overrides.css` read to their canonical `--lasuite--*`
+ * (double dash) tokens above, so those two existing consumers keep resolving
+ * without a rewrite.
+ *
+ * Usage:
+ *   node scripts/generate-lasuite-tokens.mjs [outputPath]
+ *   node scripts/generate-lasuite-tokens.mjs --check
+ *
+ * outputPath (positional arg, falls back to LASUITE_TOKENS_OUTPUT env var)
+ * defaults to the committed css/systems/lasuite/defaults.css — the drift
+ * guard (`npm run test:lasuite-tokens`) passes a temp path instead via
+ * --check (which generates to a temp file internally and diffs it against
+ * the committed file, printing the first differing tokens and exiting
+ * non-zero on any difference — mirrors tests/l10n/check-l10n-completeness.js's
+ * check/--write shape).
+ */
+
+import { readFileSync, writeFileSync, mkdtempSync } from 'fs'
+import { join, dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { tmpdir } from 'os'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const REPO_ROOT = resolve(__dirname, '..')
+
+const PACKAGE_DIR = join(REPO_ROOT, 'node_modules', '@openfun', 'cunningham-tokens')
+const SOURCE_CSS_PATH = join(PACKAGE_DIR, 'dist', 'cunningham-tokens.css')
+const PACKAGE_JSON_PATH = join(PACKAGE_DIR, 'package.json')
+const DEFAULT_OUTPUT_PATH = join(REPO_ROOT, 'css', 'systems', 'lasuite', 'defaults.css')
+
+/**
+ * The reversible mapping rule: a prefix swap only, every `--` hierarchy
+ * separator preserved, no segment collapsing.
+ *   --c--<rest>  ⇄  --lasuite--<rest>
+ * Applied identically to property names AND to `var(--c--...)` references
+ * inside values, since both are just occurrences of the same substring.
+ */
+export function renameCToLasuite(text) {
+	return text.replaceAll('--c--', '--lasuite--')
+}
+
+/**
+ * Lower-case hex colour literals (#RGB / #RRGGBB / #RRGGBBAA) for visual
+ * consistency with the rest of the app's hand-authored token files (which
+ * are lower-case throughout). No other value transformation is applied —
+ * var() references, keywords, lengths and numbers pass through unchanged.
+ */
+export function lowercaseHex(value) {
+	return value.replace(/#[0-9A-Fa-f]{3,8}\b/g, (m) => m.toLowerCase())
+}
+
+/**
+ * Extract the top-level block whose selector matches `selectorPattern`
+ * (a RegExp tested against the exact selector text, e.g. /^html$/ or
+ * /^\.cunningham-theme--dark$/) from `cssText`, returning its raw inner
+ * text (between the outermost matching `{` and `}`). Brace-balanced so it
+ * would also work if a value ever contained nested braces (none currently
+ * do in the light/dark blocks — declarations are single-line
+ * `--c--<path>: <value>;`).
+ */
+export function extractBlock(cssText, selectorPattern) {
+	// Find each "<selector>{" occurrence and test the selector text.
+	const re = /([^{}]+)\{/g
+	let match
+	while ((match = re.exec(cssText)) !== null) {
+		const selector = match[1].trim()
+		if (!selectorPattern.test(selector)) continue
+
+		const start = match.index + match[0].length
+		let depth = 1
+		let i = start
+		for (; i < cssText.length && depth > 0; i++) {
+			if (cssText[i] === '{') depth++
+			else if (cssText[i] === '}') depth--
+		}
+		if (depth !== 0) {
+			throw new Error(`extractBlock: unbalanced braces for selector "${selector}"`)
+		}
+		return cssText.slice(start, i - 1)
+	}
+	return null
+}
+
+/**
+ * Parse `--c--<path>: <value>;` declarations out of a block's raw inner
+ * text. Only matches lines that are themselves a custom-property
+ * declaration (ignores the block's own indentation/whitespace). Returns an
+ * array of `{ name, value }` with `name` still in `--c--` form (renaming
+ * happens in the caller so this function stays a pure, testable parser).
+ */
+export function parseDeclarations(blockText) {
+	const declarations = []
+	const lines = blockText.split('\n')
+	const lineRe = /^\s*(--c--[a-zA-Z0-9-]+)\s*:\s*(.+?);\s*$/
+	for (const line of lines) {
+		const m = line.match(lineRe)
+		if (m) {
+			declarations.push({ name: m[1], value: m[2] })
+		}
+	}
+	return declarations
+}
+
+/**
+ * Rename + hex-lower-case + alphabetically sort a list of `{ name, value }`
+ * declarations (still in `--c--` form). Sorting is by canonical
+ * `--lasuite--*` name — deterministic and stable across regenerations.
+ */
+function renameAndSort(declarations) {
+	return declarations
+		.map((d) => ({
+			name: renameCToLasuite(d.name),
+			value: lowercaseHex(renameCToLasuite(d.value)),
+		}))
+		.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))
+}
+
+/**
+ * Render a `{ selector, declarations }` list of `{name, value}` pairs
+ * (already renamed) as `\t${name}: ${value};` lines, WITHOUT the wrapping
+ * selector braces — callers assemble the final `selector { ... }` block so
+ * more than one declaration group (e.g. canonical tokens + compatibility
+ * aliases) can share a single `:root` selector. stylelint's
+ * `no-duplicate-selectors` rule would otherwise flag two separate `:root`
+ * rules in the same file.
+ */
+function renderDeclarationLines(declarations) {
+	return declarations.map(({ name, value }) => `\t${name}: ${value};`)
+}
+
+/**
+ * The closed, explicitly-listed compatibility-alias table: short
+ * `--lasuite-*` (single dash) name → either a canonical `--lasuite--*`
+ * (double dash) token to `var()`-reference, or (for `--lasuite-border-radius`
+ * only) a literal value, because Cunningham's published token file does not
+ * expose a border-radius custom property at all (component radii are baked
+ * into its compiled component CSS, never surfaced as a `--c--*` token) — the
+ * 4px value is the observed Cunningham button/input radius, carried forward
+ * from the previous hand-curated defaults.css and cross-checked against the
+ * live docs.numerique.gouv.fr bundle.
+ *
+ * Every other alias below was verified to exist as a real
+ * `--c--globals--colors--*` token in the installed package before being
+ * added here — this list is reviewed, not guessed.
+ */
+export const COMPAT_ALIASES = [
+	{ alias: '--lasuite-color-brand-050', canonical: '--lasuite--globals--colors--brand-050' },
+	{ alias: '--lasuite-color-brand-100', canonical: '--lasuite--globals--colors--brand-100' },
+	{ alias: '--lasuite-color-brand-650', canonical: '--lasuite--globals--colors--brand-650' },
+	{ alias: '--lasuite-color-brand-750', canonical: '--lasuite--globals--colors--brand-750' },
+	{ alias: '--lasuite-color-error-550', canonical: '--lasuite--globals--colors--error-550' },
+	{ alias: '--lasuite-color-error-650', canonical: '--lasuite--globals--colors--error-650' },
+	{ alias: '--lasuite-color-gray-000', canonical: '--lasuite--globals--colors--gray-000' },
+	{ alias: '--lasuite-color-gray-025', canonical: '--lasuite--globals--colors--gray-025' },
+	{ alias: '--lasuite-color-gray-050', canonical: '--lasuite--globals--colors--gray-050' },
+	{ alias: '--lasuite-color-gray-100', canonical: '--lasuite--globals--colors--gray-100' },
+	{ alias: '--lasuite-color-gray-200', canonical: '--lasuite--globals--colors--gray-200' },
+	{ alias: '--lasuite-color-gray-300', canonical: '--lasuite--globals--colors--gray-300' },
+	{ alias: '--lasuite-color-gray-500', canonical: '--lasuite--globals--colors--gray-500' },
+	{ alias: '--lasuite-color-gray-900', canonical: '--lasuite--globals--colors--gray-900' },
+	{ alias: '--lasuite-color-info-550', canonical: '--lasuite--globals--colors--info-550' },
+	{ alias: '--lasuite-color-info-650', canonical: '--lasuite--globals--colors--info-650' },
+	{ alias: '--lasuite-color-success-550', canonical: '--lasuite--globals--colors--success-550' },
+	{ alias: '--lasuite-color-success-650', canonical: '--lasuite--globals--colors--success-650' },
+	{ alias: '--lasuite-color-warning-550', canonical: '--lasuite--globals--colors--warning-550' },
+	{ alias: '--lasuite-color-warning-650', canonical: '--lasuite--globals--colors--warning-650' },
+	{ alias: '--lasuite-border-radius', literal: '4px' },
+]
+
+function renderAliasLines() {
+	const lines = [
+		'',
+		'\t/* ===================================================================',
+		'\t * COMPATIBILITY ALIASES',
+		'\t * Short --lasuite-* (single dash) names read by css/systems/lasuite/',
+		'\t * bridge.css and element-overrides.css, mapped to their canonical',
+		'\t * --lasuite--* (double dash) tokens above. Closed, explicitly-listed,',
+		'\t * reviewed list — see COMPAT_ALIASES in scripts/generate-lasuite-',
+		'\t * tokens.mjs. --lasuite-border-radius is the one literal: Cunningham',
+		'\t * does not expose a border-radius custom property (baked into its',
+		'\t * compiled component CSS instead), so 4px is carried forward from the',
+		'\t * observed Cunningham button/input radius, not derived from a token.',
+		'\t * --lasuite-font-family is defined separately in fonts.css (not here)',
+		'\t * because it depends on the self-hosting/licensing story, not on any',
+		'\t * generated Cunningham value.',
+		'\t * =================================================================== */',
+	]
+	for (const entry of COMPAT_ALIASES) {
+		if (entry.literal !== undefined) {
+			lines.push(`\t${entry.alias}: ${entry.literal};`)
+		} else {
+			lines.push(`\t${entry.alias}: var(${entry.canonical});`)
+		}
+	}
+	return lines
+}
+
+/**
+ * Read the installed package's resolved version from its own package.json.
+ */
+function readPackageVersion() {
+	const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, 'utf-8'))
+	return pkg.version
+}
+
+/**
+ * Build the full generated defaults.css text from the source Cunningham CSS.
+ *
+ * @param {string} sourceCss   Raw text of dist/cunningham-tokens.css.
+ * @param {string} packageVersion Resolved @openfun/cunningham-tokens version.
+ * @param {string} generationDate ISO date (YYYY-MM-DD) to stamp the header with.
+ */
+export function generate({ sourceCss, packageVersion, generationDate }) {
+	const lightBlockText = extractBlock(sourceCss, /^html$/)
+	const darkBlockText = extractBlock(sourceCss, /^\.cunningham-theme--dark$/)
+	if (lightBlockText === null) {
+		throw new Error('generate: could not find the light "html { ... }" block in the source CSS')
+	}
+	if (darkBlockText === null) {
+		throw new Error('generate: could not find the dark ".cunningham-theme--dark { ... }" block in the source CSS')
+	}
+
+	const lightDeclarations = renameAndSort(parseDeclarations(lightBlockText))
+	const darkDeclarations = renameAndSort(parseDeclarations(darkBlockText))
+	const totalCount = lightDeclarations.length + darkDeclarations.length
+
+	// Both the canonical light tokens AND the compatibility aliases must
+	// live in the SAME :root selector — stylelint's no-duplicate-selectors
+	// rule flags two separate `:root { ... }` rules in one file, and there
+	// is no functional reason to split them (aliases resolve identically
+	// either way; var() lookups are cascade-based, not declaration-order-
+	// based, so appending them after the canonical tokens in one rule is
+	// both lint-clean and semantically unambiguous).
+	const rootLines = [':root {', ...renderDeclarationLines(lightDeclarations), ...renderAliasLines(), '}']
+	const darkLines = ['.cunningham-theme--dark {', ...renderDeclarationLines(darkDeclarations), '}']
+
+	const header = [
+		'/**',
+		' * La Suite numérique — Cunningham Token Defaults Layer (GENERATED)',
+		' *',
+		' * Do not hand-edit — regenerate with:',
+		' *   node scripts/generate-lasuite-tokens.mjs',
+		' * A committed-file drift check runs as `npm run test:lasuite-tokens`.',
+		' *',
+		` * Source package: @openfun/cunningham-tokens@${packageVersion} (MIT licence)`,
+		' *   https://www.npmjs.com/package/@openfun/cunningham-tokens',
+		' *   Cunningham is the design system behind La Suite numérique',
+		' *   (Docs/Meet/Chat) — https://github.com/suitenumerique/cunningham',
+		' * Read from: dist/cunningham-tokens.css',
+		` * Generated: ${generationDate}`,
+		` * Token count: ${totalCount} (${lightDeclarations.length} light + ${darkDeclarations.length} dark —`,
+		' *   see the module header comment in generate-lasuite-tokens.mjs for',
+		' *   why the source splits into these two blocks instead of one).',
+		' * Mapping rule: --c--<rest> ⇄ --lasuite--<rest> — a prefix swap only,',
+		' *   every "--" hierarchy separator preserved, no segment collapsing',
+		' *   (e.g. --c--globals--colors--brand-600 →',
+		' *   --lasuite--globals--colors--brand-600). Reversible by swapping the',
+		' *   leading token back.',
+		' *',
+		' * BASE, NOT DEPLOYED THEME: this file is the published Cunningham',
+		' * BLUE base (brand-600 #0659c5). The deployed La Suite VIOLET theme',
+		' * (brand-600 #534fc2, brand-650/logo #4844ad) is a separate,',
+		' * hand-authored, sourced override — see brand-override.css — layered',
+		' * after this file in the lasuite design-system bundle. This file must',
+		' * never hard-code the violet values.',
+		' *',
+		' * Only the `:root` (light) block below is active in the nldesign',
+		' * lasuite/cunningham bundles today; `.cunningham-theme--dark` is',
+		' * carried for upstream fidelity but nothing currently applies that',
+		' * class — it is not wired into nldesign\'s own dark-mode system.',
+		' */',
+		'',
+	].join('\n')
+
+	return [header, rootLines.join('\n'), '', darkLines.join('\n'), ''].join('\n')
+}
+
+/**
+ * CLI entry point.
+ */
+function main() {
+	const args = process.argv.slice(2)
+	const checkMode = args.includes('--check')
+	const positional = args.find((a) => !a.startsWith('--'))
+	const outputPath = positional
+		? resolve(process.cwd(), positional)
+		: (process.env.LASUITE_TOKENS_OUTPUT ? resolve(process.cwd(), process.env.LASUITE_TOKENS_OUTPUT) : DEFAULT_OUTPUT_PATH)
+
+	const sourceCss = readFileSync(SOURCE_CSS_PATH, 'utf-8')
+	const packageVersion = readPackageVersion()
+	const generationDate = (process.env.LASUITE_TOKENS_GENERATION_DATE || new Date().toISOString().slice(0, 10))
+
+	const output = generate({ sourceCss, packageVersion, generationDate })
+
+	if (!checkMode) {
+		writeFileSync(outputPath, output)
+		console.log(`[generate-lasuite-tokens] wrote ${outputPath}`)
+		return
+	}
+
+	// --check: generate into a temp file, diff against the committed file
+	// (ignoring only the "Generated: <date>" line, which legitimately
+	// changes every run), report, exit non-zero on any real difference.
+	const committedPath = DEFAULT_OUTPUT_PATH
+	let committed
+	try {
+		committed = readFileSync(committedPath, 'utf-8')
+	} catch {
+		console.error(`[test:lasuite-tokens] committed file not found: ${committedPath}`)
+		process.exit(1)
+	}
+
+	const stripDate = (text) => text.replace(/^ \* Generated: .*$/m, ' * Generated: <normalised>')
+	const normalisedCommitted = stripDate(committed)
+	const normalisedGenerated = stripDate(output)
+
+	if (normalisedCommitted === normalisedGenerated) {
+		console.log('[test:lasuite-tokens] OK — committed defaults.css matches the generator output.')
+		process.exit(0)
+	}
+
+	const tmpDir = mkdtempSync(join(tmpdir(), 'lasuite-tokens-'))
+	const tmpPath = join(tmpDir, 'defaults.css')
+	writeFileSync(tmpPath, output)
+
+	console.error('[test:lasuite-tokens] DRIFT DETECTED — committed defaults.css does not match the generator.')
+	const committedLines = normalisedCommitted.split('\n')
+	const generatedLines = normalisedGenerated.split('\n')
+	const maxLines = Math.max(committedLines.length, generatedLines.length)
+	let printed = 0
+	for (let i = 0; i < maxLines && printed < 20; i++) {
+		if (committedLines[i] !== generatedLines[i]) {
+			console.error(`  line ${i + 1}:`)
+			console.error(`    committed:  ${committedLines[i] ?? '(missing)'}`)
+			console.error(`    generated:  ${generatedLines[i] ?? '(missing)'}`)
+			printed++
+		}
+	}
+	console.error(`[test:lasuite-tokens] full generated output written to ${tmpPath} for inspection`)
+	console.error(`  diff ${tmpPath} ${committedPath}`)
+	process.exit(1)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main()
+}

--- a/tests/Unit/LasuiteDesignStackTest.php
+++ b/tests/Unit/LasuiteDesignStackTest.php
@@ -16,6 +16,7 @@
  *
  * @spec openspec/specs/css-architecture/spec.md
  * @spec openspec/specs/token-sets/spec.md
+ * @spec openspec/specs/lasuite-parity/spec.md
  */
 
 declare(strict_types=1);
@@ -83,12 +84,14 @@ class LasuiteDesignStackTest extends TestCase
     }//end tokenSetService()
 
     /**
-     * `DesignSystemService::getDesignSystem('lasuite')` resolves the four
-     * stylesheets in the exact declared order.
+     * `DesignSystemService::getDesignSystem('lasuite')` resolves the five
+     * stylesheets in the exact declared order (fonts → defaults →
+     * brand-override → bridge → element-overrides).
      *
      * @spec openspec/specs/css-architecture/spec.md
+     * @spec openspec/specs/lasuite-parity/spec.md
      */
-    public function testLasuiteDesignSystemResolvesFourStylesheetsInOrder(): void
+    public function testLasuiteDesignSystemResolvesFiveStylesheetsInOrder(): void
     {
         $system = $this->designSystemService()->getDesignSystem('lasuite');
 
@@ -97,13 +100,45 @@ class LasuiteDesignStackTest extends TestCase
             [
                 'systems/lasuite/fonts',
                 'systems/lasuite/defaults',
+                'systems/lasuite/brand-override',
                 'systems/lasuite/bridge',
                 'systems/lasuite/element-overrides',
             ],
             $system['stylesheets'],
-            'The lasuite bundle must declare exactly these four stylesheets, in this order.'
+            'The lasuite bundle must declare exactly these five stylesheets, in this order.'
         );
-    }//end testLasuiteDesignSystemResolvesFourStylesheetsInOrder()
+    }//end testLasuiteDesignSystemResolvesFiveStylesheetsInOrder()
+
+    /**
+     * `DesignSystemService::getDesignSystem('cunningham')` resolves the same
+     * shared fonts/defaults/bridge/element-overrides files as lasuite, but
+     * WITHOUT brand-override — so it stays on the published Cunningham blue
+     * base instead of the deployed violet.
+     *
+     * @spec openspec/specs/css-architecture/spec.md
+     * @spec openspec/specs/lasuite-parity/spec.md
+     */
+    public function testCunninghamDesignSystemResolvesFourStylesheetsWithoutBrandOverride(): void
+    {
+        $system = $this->designSystemService()->getDesignSystem('cunningham');
+
+        $this->assertSame('cunningham', $system['id']);
+        $this->assertSame(
+            [
+                'systems/lasuite/fonts',
+                'systems/lasuite/defaults',
+                'systems/lasuite/bridge',
+                'systems/lasuite/element-overrides',
+            ],
+            $system['stylesheets'],
+            'The cunningham bundle must reuse the shared lasuite files, minus brand-override.'
+        );
+        $this->assertNotContains(
+            'systems/lasuite/brand-override',
+            $system['stylesheets'],
+            'The cunningham bundle must never load the violet brand-override layer.'
+        );
+    }//end testCunninghamDesignSystemResolvesFourStylesheetsWithoutBrandOverride()
 
     /**
      * Every stylesheet declared in the lasuite bundle has a backing CSS file
@@ -129,6 +164,192 @@ class LasuiteDesignStackTest extends TestCase
             'The lasuite Layer-3 token file must exist.'
         );
     }//end testDeclaredStylesheetsHaveBackingFiles()
+
+    /**
+     * Every stylesheet declared in the cunningham bundle has a backing CSS
+     * file, and the cunningham Layer-3 token file exists.
+     *
+     * @spec openspec/specs/css-architecture/spec.md
+     * @spec openspec/specs/token-sets/spec.md
+     */
+    public function testCunninghamDeclaredStylesheetsHaveBackingFiles(): void
+    {
+        $system = $this->designSystemService()->getDesignSystem('cunningham');
+
+        foreach ($system['stylesheets'] as $stylesheet) {
+            $path = $this->repoRoot().'/css/'.$stylesheet.'.css';
+            $this->assertFileExists($path, "Declared stylesheet '{$stylesheet}' has no backing CSS file.");
+        }
+
+        $this->assertFileExists(
+            $this->repoRoot().'/css/tokens/cunningham.css',
+            'The cunningham Layer-3 token file must exist.'
+        );
+    }//end testCunninghamDeclaredStylesheetsHaveBackingFiles()
+
+    /**
+     * `token-sets.json`'s `cunningham` entry declares `design_system:
+     * "cunningham"` and the published blue base, distinct from lasuite's
+     * deployed violet. The swatch is brand-650 (#1A509F), not brand-600
+     * (#0659C5): the shared bridge.css/element-overrides.css (reused as-is
+     * from the lasuite bundle) derive `--color-primary` from
+     * `--lasuite-color-brand-650` specifically — the same step that
+     * resolves to lasuite's deployed violet #4844AD — so the swatch must
+     * match what actually renders, not Cunningham's own "-600" named step.
+     *
+     * @spec openspec/specs/token-sets/spec.md
+     * @spec openspec/specs/lasuite-parity/spec.md
+     */
+    public function testTokenSetMetaDeclaresCunninghamDesignSystem(): void
+    {
+        $meta = $this->designSystemService()->getTokenSetMeta('cunningham');
+
+        $this->assertSame('cunningham', $meta['design_system'] ?? null);
+        $this->assertSame('#1A509F', $meta['theming']['primary_color'] ?? null);
+        $this->assertSame('#FFFFFF', $meta['theming']['background_color'] ?? null);
+        $this->assertArrayNotHasKey(
+            'logo',
+            $meta['theming'] ?? [],
+            'The cunningham theming block must not carry a logo key.'
+        );
+    }//end testTokenSetMetaDeclaresCunninghamDesignSystem()
+
+    /**
+     * The generated defaults.css defines the published Cunningham BLUE base
+     * (brand-600) — the violet deployment values live only in
+     * brand-override.css, never here.
+     *
+     * @spec openspec/specs/lasuite-parity/spec.md
+     */
+    public function testGeneratedDefaultsDefineTheBlueBaseNotTheViolet(): void
+    {
+        $defaults = (string) file_get_contents($this->repoRoot().'/css/systems/lasuite/defaults.css');
+
+        $this->assertStringContainsString(
+            '--lasuite--globals--colors--brand-600: #0659c5;',
+            $defaults,
+            'defaults.css must define the published Cunningham blue brand-600.'
+        );
+        // Checked as an active DECLARATION VALUE (": #hex;"), not a blanket
+        // substring — the file's own provenance header legitimately mentions
+        // these violet hex values in PROSE (documenting what brand-override.css
+        // changes), which must not trip this guard.
+        $this->assertDoesNotMatchRegularExpression(
+            '/:\s*#534fc2\s*;/i',
+            $defaults,
+            'defaults.css must never hard-code the deployed violet brand-600 (#534fc2) as a declaration value — that belongs in brand-override.css.'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/:\s*#4844ad\s*;/i',
+            $defaults,
+            'defaults.css must never hard-code the deployed violet brand-650/logo (#4844ad) as a declaration value — that belongs in brand-override.css.'
+        );
+    }//end testGeneratedDefaultsDefineTheBlueBaseNotTheViolet()
+
+    /**
+     * The generated defaults.css carries a provenance header naming the
+     * source package, its version, the token count and the mapping rule.
+     *
+     * @spec openspec/specs/lasuite-parity/spec.md
+     */
+    public function testGeneratedDefaultsCarryProvenanceHeader(): void
+    {
+        $defaults = (string) file_get_contents($this->repoRoot().'/css/systems/lasuite/defaults.css');
+
+        $this->assertStringContainsString('@openfun/cunningham-tokens@', $defaults);
+        $this->assertStringContainsString('MIT licence', $defaults);
+        $this->assertStringContainsString('Token count: 1167', $defaults);
+        $this->assertStringContainsString('--c--<rest>', $defaults);
+        $this->assertStringContainsString('--lasuite--<rest>', $defaults);
+    }//end testGeneratedDefaultsCarryProvenanceHeader()
+
+    /**
+     * `brand-override.css` is sourced (not generated) and carries a
+     * provenance comment naming the observed live bundle, the block, and the
+     * observation date; loading it after defaults.css resolves the brand
+     * scale and logo tokens to the deployed violet.
+     *
+     * @spec openspec/specs/lasuite-parity/spec.md
+     */
+    public function testBrandOverrideIsSourcedAndResolvesViolet(): void
+    {
+        $override = (string) file_get_contents($this->repoRoot().'/css/systems/lasuite/brand-override.css');
+
+        $this->assertStringContainsString('docs.numerique.gouv.fr', $override);
+        $this->assertStringContainsString('block 5', $override);
+        $this->assertStringContainsString('2026-07-24', $override);
+        $this->assertStringContainsString(
+            '--lasuite--globals--colors--brand-600: #534fc2;',
+            $override,
+            'brand-override.css must redeclare brand-600 to the deployed violet.'
+        );
+        $this->assertStringContainsString(
+            '--lasuite--globals--colors--brand-650: #4844ad;',
+            $override,
+            'brand-override.css must redeclare brand-650 (also the logo colour) to the deployed violet.'
+        );
+    }//end testBrandOverrideIsSourcedAndResolvesViolet()
+
+    /**
+     * The lasuite bridge accounts for every one of the 68 audited Nextcloud
+     * `--color-*` variables (the `nextcloud-variable-mapping` canonical
+     * surface, the same set css/systems/nldesign/overrides.css covers) as
+     * either an active mapping or a commented, reasoned line. Mirrors
+     * `tests/css/check-lasuite-bridge-coverage.js` (the Node drift-style
+     * check `npm run test:lasuite-bridge-coverage` runs) as a PHPUnit
+     * regression so the same invariant is enforced from both toolchains.
+     *
+     * @spec openspec/specs/lasuite-parity/spec.md
+     */
+    public function testBridgeAccountsForEveryAuditedColorVariable(): void
+    {
+        $overrides = (string) file_get_contents($this->repoRoot().'/css/systems/nldesign/overrides.css');
+        $bridge    = (string) file_get_contents($this->repoRoot().'/css/systems/lasuite/bridge.css');
+
+        preg_match_all('/^\s*(--color-[a-zA-Z0-9-]+)\s*:/m', $overrides, $mappedMatches);
+        preg_match_all('/\/\*\s*(--color-[a-zA-Z0-9-]+)\s*:/', $overrides, $commentedMatches);
+        $audited = array_unique(array_merge($mappedMatches[1], $commentedMatches[1]));
+
+        $this->assertGreaterThanOrEqual(
+            68,
+            \count($audited),
+            'The audited --color-* surface in overrides.css must be at least 68 variables.'
+        );
+
+        preg_match_all('/^\s*(--color-[a-zA-Z0-9-]+)\s*:/m', $bridge, $bridgeMapped);
+        preg_match_all('/\/\*\s*(--color-[a-zA-Z0-9-]+)\s*:/', $bridge, $bridgeCommented);
+        $bridgeCovered = array_unique(array_merge($bridgeMapped[1], $bridgeCommented[1]));
+
+        $missing = array_values(array_diff($audited, $bridgeCovered));
+
+        $this->assertSame(
+            [],
+            $missing,
+            'Every audited --color-* variable must appear in bridge.css as a mapping or a reasoned comment. Missing: '.implode(', ', $missing)
+        );
+    }//end testBridgeAccountsForEveryAuditedColorVariable()
+
+    /**
+     * The shared bridge.css derives `--color-primary` (and every brand-accent
+     * rule in element-overrides.css) from `--lasuite-color-brand-650`
+     * specifically. This is the load-bearing fact behind the brand-650 (not
+     * brand-600) swatch choice for the cunningham sibling — pinned as a
+     * regression guard so a future edit that switches the mapping to a
+     * different scale step does not silently strand token-sets.json's
+     * cunningham/lasuite swatches out of sync with what actually renders.
+     *
+     * @spec openspec/specs/lasuite-parity/spec.md
+     */
+    public function testBridgeDerivesColorPrimaryFromBrand650(): void
+    {
+        $bridge = (string) file_get_contents($this->repoRoot().'/css/systems/lasuite/bridge.css');
+
+        $this->assertMatchesRegularExpression(
+            '/--color-primary:\s*var\(--lasuite-color-brand-650\)\s*!important;/',
+            $bridge,
+            'bridge.css must derive --color-primary from --lasuite-color-brand-650 (both lasuite and cunningham share this file).'
+        );
+    }//end testBridgeDerivesColorPrimaryFromBrand650()
 
     /**
      * `token-sets.json`'s `lasuite` entry declares `design_system: "lasuite"`
@@ -211,9 +432,12 @@ class LasuiteDesignStackTest extends TestCase
      * `--nldesign-color-{error,warning,success,info}` (Cunningham's own
      * "-550" background token, not the raw "-500" swatch) carry white text
      * at WCAG AA. Guards the deliberate -550-over-500 choice documented in
-     * css/systems/lasuite/defaults.css.
+     * css/systems/lasuite/bridge.css. Values are the GENERATED Cunningham
+     * package's own "-550" step (css/systems/lasuite/defaults.css) — status
+     * colours are untouched by the violet brand-override.
      *
      * @spec openspec/specs/css-architecture/spec.md
+     * @spec openspec/specs/lasuite-parity/spec.md
      */
     public function testStatusFillsCarryWhiteTextAtAa(): void
     {
@@ -222,10 +446,10 @@ class LasuiteDesignStackTest extends TestCase
         $this->assertNotNull($white);
 
         $fills = [
-            'error-550'   => '#D7010E',
-            'warning-550' => '#BC4200',
-            'success-550' => '#027B3E',
-            'info-550'    => '#0069CF',
+            'error-550'   => '#D80000',
+            'warning-550' => '#836703',
+            'success-550' => '#427816',
+            'info-550'    => '#1167D4',
         ];
 
         foreach ($fills as $name => $hex) {
@@ -330,23 +554,56 @@ class LasuiteDesignStackTest extends TestCase
     {
         $bridge = (string) file_get_contents($this->repoRoot().'/css/systems/lasuite/bridge.css');
 
+        // Since the bridge-coverage completion (lasuite-parity), these six
+        // variables are individually documented as commented, reasoned lines
+        // (task 4.3) rather than only mentioned in the file's header prose —
+        // so the check below must distinguish an ACTIVE declaration
+        // (forbidden) from a commented one (required, and asserted present).
         foreach (
             [
-                '--color-main-background:',
-                '--color-main-background-rgb:',
-                '--color-main-background-translucent:',
-                '--color-background-plain:',
-                '--background-invert-if-dark:',
-                '--background-invert-if-bright:',
-            ] as $forbidden
+                '--color-main-background',
+                '--color-main-background-rgb',
+                '--color-main-background-translucent',
+                '--color-background-plain',
+                '--background-invert-if-dark',
+                '--background-invert-if-bright',
+            ] as $name
         ) {
-            $this->assertStringNotContainsString(
-                $forbidden,
+            $this->assertDoesNotMatchRegularExpression(
+                '/^\s*'.preg_quote($name, '/').'\s*:/m',
                 $bridge,
-                "bridge.css must not set {$forbidden} (REQ-CSS-007 dark-mode compatibility)."
+                "bridge.css must not ACTIVELY set {$name} (REQ-CSS-007 dark-mode compatibility)."
             );
         }
     }//end testBridgeNeverSetsDarkModeCompatibilityVariables()
+
+    /**
+     * The four dark-mode-compat `--color-*` variables that ARE part of the
+     * 68-variable audited surface (`--background-invert-if-*` are not
+     * `--color-*` prefixed, so they fall outside that surface) are present
+     * as commented, reasoned lines — not silently absent.
+     *
+     * @spec openspec/specs/lasuite-parity/spec.md
+     */
+    public function testBridgeDocumentsDarkModeCompatVariablesWithAReason(): void
+    {
+        $bridge = (string) file_get_contents($this->repoRoot().'/css/systems/lasuite/bridge.css');
+
+        foreach (
+            [
+                '--color-main-background',
+                '--color-main-background-rgb',
+                '--color-main-background-translucent',
+                '--color-background-plain',
+            ] as $name
+        ) {
+            $this->assertMatchesRegularExpression(
+                '/\/\*\s*'.preg_quote($name, '/').'\s*:/',
+                $bridge,
+                "bridge.css must document {$name} as a commented, reasoned line."
+            );
+        }
+    }//end testBridgeDocumentsDarkModeCompatVariablesWithAReason()
 
     /**
      * The fonts layer never declares a `url()` source for Marianne — only

--- a/tests/css/check-lasuite-bridge-coverage.js
+++ b/tests/css/check-lasuite-bridge-coverage.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: EUPL-1.2
+// SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+//
+// lasuite bridge coverage check.
+//
+// css/systems/nldesign/overrides.css is the audited Nextcloud `--color-*`
+// variable surface (the `nextcloud-variable-mapping` canonical audit — 68
+// variables, mapped or reasoned-comment). This script asserts that
+// css/systems/lasuite/bridge.css accounts for every one of those 68
+// variables too — as an active mapping OR a commented line with a reason —
+// so the lasuite bridge can never silently leave a Nextcloud variable at its
+// stock value. Also enforces REQ-CSS-007: the six dark-mode-compatibility
+// variables must never be ACTIVELY set by the bridge (comment-only).
+//
+// Mirrors tests/l10n/check-l10n-completeness.js's dependency-free, pure-Node
+// pattern so it needs no build step and no Nextcloud runtime.
+//
+// Usage:
+//   node tests/css/check-lasuite-bridge-coverage.js
+//
+// Exit codes:
+//   0  every audited --color-* variable is accounted for in bridge.css
+//   1  one or more audited variables are missing from bridge.css (or a
+//      dark-mode-compat variable is actively overridden)
+//
+// @spec openspec/specs/lasuite-parity/spec.md
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const ROOT = path.resolve(__dirname, '..', '..')
+const AUDITED_FILE = path.join(ROOT, 'css', 'systems', 'nldesign', 'overrides.css')
+const BRIDGE_FILE = path.join(ROOT, 'css', 'systems', 'lasuite', 'bridge.css')
+
+// REQ-CSS-007: Nextcloud derives dark-mode calculations from these — the
+// bridge must never actively set them, only ever leave them as a reasoned
+// comment.
+const DARK_MODE_COMPAT_VARS = [
+	'--color-main-background',
+	'--color-main-background-rgb',
+	'--color-main-background-translucent',
+	'--color-background-plain',
+	'--background-invert-if-dark',
+	'--background-invert-if-bright',
+]
+
+/**
+ * Extract the set of `--color-*` variable names that appear in `text` either
+ * as an active declaration (`--color-x: ...;` at the start of a line) or as
+ * a commented-out declaration (`/* --color-x: ... `).
+ */
+function extractColorVarNames(text) {
+	const mapped = new Set()
+	const commented = new Set()
+
+	for (const line of text.split('\n')) {
+		const activeMatch = line.match(/^\s*(--color-[a-zA-Z0-9-]+)\s*:/)
+		if (activeMatch) {
+			mapped.add(activeMatch[1])
+			continue
+		}
+		const commentMatch = line.match(/\/\*\s*(--color-[a-zA-Z0-9-]+)\s*:/)
+		if (commentMatch) {
+			commented.add(commentMatch[1])
+		}
+	}
+
+	return { mapped, commented, all: new Set([...mapped, ...commented]) }
+}
+
+function readFile(p) {
+	if (!fs.existsSync(p)) {
+		console.error(`[lasuite-bridge-coverage] file not found: ${p}`)
+		process.exit(2)
+	}
+	return fs.readFileSync(p, 'utf8')
+}
+
+function main() {
+	const audited = extractColorVarNames(readFile(AUDITED_FILE))
+	const bridge = extractColorVarNames(readFile(BRIDGE_FILE))
+
+	const missing = [...audited.all].filter((name) => !bridge.all.has(name)).sort()
+
+	const activelyOverriddenCompatVars = DARK_MODE_COMPAT_VARS.filter((name) => bridge.mapped.has(name))
+
+	let failed = false
+
+	if (missing.length > 0) {
+		failed = true
+		console.error(
+			`[lasuite-bridge-coverage] FAIL — ${missing.length} audited --color-* variable(s) missing from bridge.css (neither mapped nor commented):`,
+		)
+		for (const name of missing) {
+			console.error(`  - ${name}`)
+		}
+	}
+
+	if (activelyOverriddenCompatVars.length > 0) {
+		failed = true
+		console.error(
+			'[lasuite-bridge-coverage] FAIL — REQ-CSS-007 violation: the following dark-mode-compatibility variables are ACTIVELY set in bridge.css (must be comment-only):',
+		)
+		for (const name of activelyOverriddenCompatVars) {
+			console.error(`  - ${name}`)
+		}
+	}
+
+	if (failed) {
+		process.exit(1)
+	}
+
+	console.log(
+		`[lasuite-bridge-coverage] OK — all ${audited.all.size} audited --color-* variables are accounted for in bridge.css (${bridge.mapped.size} mapped, ${bridge.commented.size} reasoned comments), and no dark-mode-compat variable is actively overridden.`,
+	)
+	process.exit(0)
+}
+
+main()

--- a/tests/e2e/spec-coverage/lasuite-parity.spec.ts
+++ b/tests/e2e/spec-coverage/lasuite-parity.spec.ts
@@ -1,0 +1,313 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @e2e openspec/specs/lasuite-parity/spec.md
+ *
+ * Component-parity check for the `lasuite` and `cunningham` design systems:
+ * renders real Nextcloud elements under each active set and asserts their
+ * COMPUTED styles equal the Cunningham reference values sourced directly
+ * from css/systems/lasuite/{defaults,brand-override,bridge,element-
+ * overrides}.css — i.e. "does the CSS this app ships actually apply as
+ * authored", not an independently-invented pixel spec.
+ *
+ * SCOPE HONESTY: nldesign's own admin panel is vanilla JS (no Vue), and its
+ * element-overrides.css styles only a handful of real NC selectors
+ * concretely (button.primary, input[type=text], #header, .modal-container,
+ * plus the shared body font-family rule). For each of the five elements
+ * below, the reference table only lists the properties this app's CSS
+ * ACTUALLY sets for that selector — asserting an un-sourced property (e.g.
+ * a button's padding, which nldesign never declares and NC's own Cn* button
+ * component owns) would test Nextcloud/Vue-library internals unrelated to
+ * this app's own claims, and would be brittle across NC versions.
+ *
+ * GLOBAL STATE: activating `lasuite`/`cunningham` mutates the INSTANCE-WIDE
+ * active token set (same class of mutation as tests/e2e/workflows/*). The
+ * prior token set is snapshotted in beforeAll and RESTORED in afterAll.
+ *
+ * LOAD-FRAGILE INSTANCE (issue #181): runs `mode: 'serial'`, one `test()`
+ * per element, small and batchable — a flake isolates to one element, not
+ * the whole suite.
+ */
+import { test, expect, Page } from '@playwright/test'
+import { requestToken, getTokenSet, setTokenSet } from '../workflows/_helpers'
+
+const THEMING_URL = '/settings/admin/theming'
+
+type StyleRef = Partial<{
+	backgroundColor: string // hex, e.g. '#4844ad'
+	color: string // hex
+	borderColor: string // hex
+	borderWidth: string // e.g. '1px'
+	borderStyle: string // e.g. 'solid'
+	borderRadius: string // e.g. '4px'
+	fontFamily: string[] // lower-cased family list, e.g. ['marianne', 'inter', 'sans-serif']
+	fontWeight: string // e.g. '600'
+}>
+
+interface ElementRef {
+	/** Human-readable element name for assertion messages. */
+	name: string
+	/** CSS selector for the element under test (must exist on THEMING_URL). */
+	selector: string
+	ref: StyleRef
+}
+
+// Reference values sourced from css/systems/lasuite/{defaults,brand-override,
+// bridge,element-overrides}.css. gray-200/gray-300 are unaffected by
+// brand-override.css (only brand-*/logo-* are overridden), so they are IDENTICAL
+// across both sets; only the brand-650-derived colours differ.
+const GRAY_200 = '#c4c7cb' // --lasuite-color-gray-200 (hairline borders)
+const GRAY_300 = '#a7acb2' // --lasuite-color-gray-300 (input borders)
+const GRAY_000 = '#ffffff' // --lasuite-color-gray-000
+const BORDER_RADIUS = '4px' // --lasuite-border-radius (literal — no upstream token)
+const FONT_STACK = ['marianne', 'inter', 'sans-serif'] // --lasuite-font-family
+
+const BRAND_650: Record<'lasuite' | 'cunningham', string> = {
+	lasuite: '#4844ad', // brand-override.css — deployed violet
+	cunningham: '#1a509f', // defaults.css blue base (brand-override.css not loaded)
+}
+
+function referenceTable(set: 'lasuite' | 'cunningham'): ElementRef[] {
+	const brand650 = BRAND_650[set]
+	return [
+		{
+			name: 'primary button',
+			// #nldesign-group-theming-save ships class="button primary" in
+			// templates/settings/admin.php, matching element-overrides.css's
+			// `button[class*="primary"]` / `button.primary` rules.
+			selector: '#nldesign-group-theming-save',
+			ref: {
+				backgroundColor: brand650,
+				color: GRAY_000,
+				borderColor: brand650,
+				borderRadius: BORDER_RADIUS,
+			},
+		},
+		{
+			name: 'text input',
+			// #nldesign-upload-name is a real input[type="text"] in
+			// templates/settings/admin.php.
+			selector: '#nldesign-upload-name',
+			ref: {
+				borderColor: GRAY_300,
+				borderWidth: '1px',
+				borderStyle: 'solid',
+				borderRadius: BORDER_RADIUS,
+				fontFamily: FONT_STACK,
+			},
+		},
+		{
+			name: 'header app name',
+			// #header .header-appname is Nextcloud's own header app-name
+			// label — always present in stock chrome.
+			selector: '#header .header-appname',
+			ref: {
+				color: brand650,
+				fontWeight: '600',
+			},
+		},
+		{
+			name: 'header bar',
+			selector: '#header',
+			ref: {
+				backgroundColor: GRAY_000,
+				borderColor: GRAY_200, // border-bottom-color
+				borderWidth: '1px', // border-bottom-width
+				borderStyle: 'solid', // border-bottom-style
+			},
+		},
+		{
+			name: 'audit-log table',
+			// #nldesign-audit-table is a real, always-rendered <table> in
+			// templates/settings/admin.php (theming audit log).
+			selector: '#nldesign-audit-table',
+			ref: {
+				// The only property nldesign's CSS actually sources for a bare
+				// <table>: font-family, inherited through the shared body/
+				// .app-content font-family rule (element-overrides.css). No
+				// nldesign rule targets table borders/background/padding, so
+				// they are intentionally NOT asserted here.
+				fontFamily: FONT_STACK,
+			},
+		},
+	]
+}
+
+/** #rrggbb → 'rgb(r, g, b)' — getComputedStyle always reports colours as rgb(). */
+function hexToRgb(hex: string): string {
+	const h = hex.replace('#', '')
+	const r = parseInt(h.slice(0, 2), 16)
+	const g = parseInt(h.slice(2, 4), 16)
+	const b = parseInt(h.slice(4, 6), 16)
+	return `rgb(${r}, ${g}, ${b})`
+}
+
+/** Normalise a computed font-family list for comparison: split, trim, lower-case, strip quotes. */
+function normaliseFontFamily(computed: string): string[] {
+	return computed.split(',').map((f) => f.trim().replace(/^['"]|['"]$/g, '').toLowerCase())
+}
+
+interface ComputedSubset {
+	backgroundColor: string
+	color: string
+	borderColor: string
+	borderWidth: string
+	borderStyle: string
+	borderRadius: string
+	fontFamily: string
+	fontWeight: string
+}
+
+/** Read the subset of computed styles this spec ever compares, for one element. */
+async function readComputedStyle(page: Page, selector: string): Promise<ComputedSubset> {
+	return page.evaluate((sel) => {
+		const el = document.querySelector(sel)
+		if (!el) throw new Error(`Element not found: ${sel}`)
+		const cs = getComputedStyle(el)
+		return {
+			backgroundColor: cs.backgroundColor,
+			color: cs.color,
+			// For elements whose reference only cares about ONE border edge
+			// (header's border-bottom, input's full border), reading the
+			// bottom edge is a superset-safe choice: for elements with a
+			// uniform border (input) top/right/bottom/left are identical, so
+			// borderBottomColor equals the value a full `border` shorthand
+			// check would report too.
+			borderColor: cs.borderBottomColor,
+			borderWidth: cs.borderBottomWidth,
+			borderStyle: cs.borderBottomStyle,
+			borderRadius: cs.borderRadius,
+			fontFamily: cs.fontFamily,
+			fontWeight: cs.fontWeight,
+		}
+	}, selector)
+}
+
+/**
+ * Compare computed styles against a reference, asserting only the
+ * properties present on `ref`. On mismatch, throws naming the exact
+ * property and the expected-vs-actual delta.
+ */
+function assertMatchesReference(elementName: string, computed: ComputedSubset, ref: StyleRef): void {
+	if (ref.backgroundColor !== undefined) {
+		expect(computed.backgroundColor, `${elementName}: background-color — expected ${ref.backgroundColor} (${hexToRgb(ref.backgroundColor)}), got ${computed.backgroundColor}`)
+			.toBe(hexToRgb(ref.backgroundColor))
+	}
+	if (ref.color !== undefined) {
+		expect(computed.color, `${elementName}: color — expected ${ref.color} (${hexToRgb(ref.color)}), got ${computed.color}`)
+			.toBe(hexToRgb(ref.color))
+	}
+	if (ref.borderColor !== undefined) {
+		expect(computed.borderColor, `${elementName}: border-color — expected ${ref.borderColor} (${hexToRgb(ref.borderColor)}), got ${computed.borderColor}`)
+			.toBe(hexToRgb(ref.borderColor))
+	}
+	if (ref.borderWidth !== undefined) {
+		expect(computed.borderWidth, `${elementName}: border-width — expected ${ref.borderWidth}, got ${computed.borderWidth}`)
+			.toBe(ref.borderWidth)
+	}
+	if (ref.borderStyle !== undefined) {
+		expect(computed.borderStyle, `${elementName}: border-style — expected ${ref.borderStyle}, got ${computed.borderStyle}`)
+			.toBe(ref.borderStyle)
+	}
+	if (ref.borderRadius !== undefined) {
+		expect(computed.borderRadius, `${elementName}: border-radius — expected ${ref.borderRadius}, got ${computed.borderRadius}`)
+			.toBe(ref.borderRadius)
+	}
+	if (ref.fontFamily !== undefined) {
+		const actual = normaliseFontFamily(computed.fontFamily)
+		expect(actual, `${elementName}: font-family — expected [${ref.fontFamily.join(', ')}], got [${actual.join(', ')}]`)
+			.toEqual(ref.fontFamily)
+	}
+	if (ref.fontWeight !== undefined) {
+		expect(computed.fontWeight, `${elementName}: font-weight — expected ${ref.fontWeight}, got ${computed.fontWeight}`)
+			.toBe(ref.fontWeight)
+	}
+}
+
+let baselineTokenSet: string | null = null
+
+test.describe('lasuite-parity', () => {
+	test.describe.configure({ mode: 'serial' })
+
+	// @e2e exclude openspec/specs/lasuite-parity/spec.md#mismatch-names-the-property-and-delta
+	// Proven by manually reverting a reference value and observing the
+	// Playwright assertion message during development (see PR description);
+	// asserting a DELIBERATE failure is not something a passing CI suite can
+	// carry permanently.
+
+	test.beforeAll(async ({ browser }) => {
+		const page = await browser.newPage()
+		await page.goto(THEMING_URL)
+		await page.waitForLoadState('networkidle')
+		const token = await requestToken(page)
+		baselineTokenSet = await getTokenSet(page, token)
+		await page.close()
+	})
+
+	test.afterAll(async ({ browser }) => {
+		if (baselineTokenSet === null) return
+		const page = await browser.newPage()
+		await page.goto(THEMING_URL)
+		await page.waitForLoadState('networkidle')
+		const token = await requestToken(page)
+		await setTokenSet(page, token, baselineTokenSet)
+		await page.close()
+	})
+
+	for (const set of ['lasuite', 'cunningham'] as const) {
+		for (const element of referenceTable(set)) {
+			test(`${set}: ${element.name} matches the Cunningham reference`, async ({ page }) => {
+				await page.goto(THEMING_URL)
+				await page.waitForLoadState('networkidle')
+				const token = await requestToken(page)
+				await setTokenSet(page, token, set)
+				await page.reload()
+				await page.waitForLoadState('networkidle')
+
+				await page.waitForSelector(element.selector, { timeout: 15_000 })
+				const computed = await readComputedStyle(page, element.selector)
+				assertMatchesReference(`${set} ${element.name}`, computed, element.ref)
+			})
+		}
+	}
+
+	test('unified-search modal, when present, matches the shared radius token', async ({ page }) => {
+		// .modal-container is styled defensively by element-overrides.css
+		// (theming NC-core's OWN native modal component) but nldesign's own
+		// vanilla-JS admin panel never renders one itself — so this check
+		// must trigger a REAL NC-core modal to have anything to assert.
+		// Unified search is the most stable, single-click native trigger
+		// already referenced by this app's own CSS
+		// (#header .unified-search__button in element-overrides.css). If the
+		// installed NC version does not surface `.modal-container` for it
+		// (implementation detail that varies by NC release), skip rather
+		// than fail on something unrelated to this app's theming code.
+		const token = await requestToken(page)
+		await setTokenSet(page, token, 'lasuite')
+		await page.goto(THEMING_URL)
+		await page.waitForLoadState('networkidle')
+
+		const searchButton = page.locator('#header .unified-search__button')
+		if (await searchButton.count() === 0) {
+			test.skip(true, 'unified-search trigger not present in header on this NC version')
+			return
+		}
+		await searchButton.click()
+
+		const modal = page.locator('.modal-container')
+		try {
+			await modal.first().waitFor({ state: 'visible', timeout: 5_000 })
+		} catch {
+			test.skip(true, '.modal-container did not appear for unified search on this NC version')
+			return
+		}
+
+		const borderRadius = await modal.first().evaluate((el) => getComputedStyle(el).borderRadius)
+		expect(borderRadius, `modal: border-radius — expected ${BORDER_RADIUS}, got ${borderRadius}`).toBe(BORDER_RADIUS)
+
+		// Best-effort cleanup — close the dialog so it doesn't linger for the
+		// next test in this serial run.
+		await page.keyboard.press('Escape').catch(() => {})
+	})
+})

--- a/tests/vitest/generateLasuiteTokens.spec.js
+++ b/tests/vitest/generateLasuiteTokens.spec.js
@@ -1,0 +1,189 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * Unit tests for scripts/generate-lasuite-tokens.mjs — the pure parsing /
+ * renaming / rendering functions the La Suite token generator is built from.
+ * Exercises the reversible --c-- ⇄ --lasuite-- prefix swap, the light/dark
+ * block extraction (the source ships tokens across TWO top-level blocks —
+ * `html { ... }` and `.cunningham-theme--dark { ... }` — see the module's
+ * own header comment for why), and the closed compatibility-alias list,
+ * against small fixture strings rather than the full installed package (fast
+ * and does not depend on node_modules content beyond the module import).
+ *
+ * @spec openspec/specs/lasuite-parity/spec.md
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+	renameCToLasuite,
+	lowercaseHex,
+	extractBlock,
+	parseDeclarations,
+	generate,
+	COMPAT_ALIASES,
+} from '../../scripts/generate-lasuite-tokens.mjs'
+
+describe('renameCToLasuite', () => {
+	it('renames a bare --c-- custom-property name, preserving all -- separators', () => {
+		expect(renameCToLasuite('--c--globals--colors--brand-600')).toBe(
+			'--lasuite--globals--colors--brand-600',
+		)
+	})
+
+	it('renames every --c-- occurrence inside a value (var() references)', () => {
+		expect(renameCToLasuite('var(--c--globals--colors--brand-600)')).toBe(
+			'var(--lasuite--globals--colors--brand-600)',
+		)
+	})
+
+	it('is reversible by swapping the leading token back', () => {
+		const original = '--c--components--button--primary--background-color'
+		const renamed = renameCToLasuite(original)
+		expect(renamed.replace('--lasuite--', '--c--')).toBe(original)
+	})
+
+	it('leaves text with no --c-- occurrence unchanged', () => {
+		expect(renameCToLasuite('4px')).toBe('4px')
+		expect(renameCToLasuite('#0659c5')).toBe('#0659c5')
+	})
+})
+
+describe('lowercaseHex', () => {
+	it('lower-cases a 6-digit hex colour', () => {
+		expect(lowercaseHex('#0659C5')).toBe('#0659c5')
+	})
+
+	it('lower-cases a 3-digit hex colour', () => {
+		expect(lowercaseHex('#FFF')).toBe('#fff')
+	})
+
+	it('leaves non-hex values (var(), keywords, lengths) unchanged', () => {
+		expect(lowercaseHex('var(--lasuite--globals--colors--brand-600)')).toBe(
+			'var(--lasuite--globals--colors--brand-600)',
+		)
+		expect(lowercaseHex('4px')).toBe('4px')
+		expect(lowercaseHex('transparent')).toBe('transparent')
+	})
+})
+
+describe('extractBlock', () => {
+	const fixture = `html {
+	--c--globals--colors--brand-600: #0659C5;
+	--c--globals--colors--brand-650: #1A509F;
+}
+.cunningham-theme--dark{
+	--c--globals--colors--brand-600: #0659C5;
+	--c--globals--colors--brand-650: #204A87;
+}
+.clr-brand-600 { color: var(--c--globals--colors--brand-600); }
+`
+
+	it('extracts the light "html { ... }" block by exact selector match', () => {
+		const block = extractBlock(fixture, /^html$/)
+		expect(block).toContain('--c--globals--colors--brand-600: #0659C5;')
+		expect(block).not.toContain('.clr-brand-600')
+	})
+
+	it('extracts the ".cunningham-theme--dark { ... }" block even with no space before "{"', () => {
+		const block = extractBlock(fixture, /^\.cunningham-theme--dark$/)
+		expect(block).toContain('--c--globals--colors--brand-650: #204A87;')
+	})
+
+	it('returns null when the selector is not present', () => {
+		expect(extractBlock(fixture, /^\.does-not-exist$/)).toBeNull()
+	})
+})
+
+describe('parseDeclarations', () => {
+	it('parses every --c--<path>: <value>; declaration on its own line', () => {
+		const block = `
+	--c--globals--colors--brand-600: #0659C5;
+	--c--globals--colors--brand-650: #1A509F;
+`
+		const decls = parseDeclarations(block)
+		expect(decls).toEqual([
+			{ name: '--c--globals--colors--brand-600', value: '#0659C5' },
+			{ name: '--c--globals--colors--brand-650', value: '#1A509F' },
+		])
+	})
+
+	it('ignores non-declaration lines (selectors, comments, blank lines)', () => {
+		const block = `
+	/* a comment */
+	--c--globals--colors--brand-600: #0659C5;
+
+	.not-a-declaration { color: red; }
+`
+		const decls = parseDeclarations(block)
+		expect(decls).toEqual([{ name: '--c--globals--colors--brand-600', value: '#0659C5' }])
+	})
+
+	it('handles a var() reference as the value', () => {
+		const block = '\t--c--contextuals--content--logo1: var(--c--globals--colors--logo-1);\n'
+		const decls = parseDeclarations(block)
+		expect(decls).toEqual([
+			{ name: '--c--contextuals--content--logo1', value: 'var(--c--globals--colors--logo-1)' },
+		])
+	})
+})
+
+describe('generate', () => {
+	const sourceCss = `html {
+	--c--globals--colors--brand-600: #0659C5;
+	--c--globals--colors--brand-650: #1A509F;
+}
+.cunningham-theme--dark{
+	--c--globals--colors--brand-600: #0659C5;
+	--c--globals--colors--brand-650: #204A87;
+}
+.clr-brand-600 { color: var(--c--globals--colors--brand-600); }
+`
+
+	function build() {
+		return generate({ sourceCss, packageVersion: '3.0.0', generationDate: '2026-07-24' })
+	}
+
+	it('emits one --lasuite--* token for every --c--* declaration in both blocks', () => {
+		const out = build()
+		expect(out).toContain(':root {')
+		expect(out).toContain('--lasuite--globals--colors--brand-600: #0659c5;')
+		expect(out).toContain('.cunningham-theme--dark {')
+		expect(out).toContain('--lasuite--globals--colors--brand-650: #204a87;')
+	})
+
+	it('records the source package, version and token count in a provenance header', () => {
+		const out = build()
+		expect(out).toContain('@openfun/cunningham-tokens@3.0.0')
+		expect(out).toContain('MIT licence')
+		expect(out).toContain('Token count: 4 (2 light + 2 dark')
+		expect(out).toContain('Generated: 2026-07-24')
+	})
+
+	it('appends the closed compatibility-alias block with every listed alias', () => {
+		const out = build()
+		for (const entry of COMPAT_ALIASES) {
+			expect(out).toContain(`${entry.alias}:`)
+		}
+		// The one literal alias (no upstream border-radius token exists).
+		expect(out).toContain('--lasuite-border-radius: 4px;')
+		// A var()-derived alias resolves to its canonical token.
+		expect(out).toContain('--lasuite-color-brand-650: var(--lasuite--globals--colors--brand-650);')
+	})
+
+	it('is deterministic — regenerating from the same input yields byte-identical output', () => {
+		expect(build()).toBe(build())
+	})
+
+	it('throws a clear error when the light block is missing from the source', () => {
+		expect(() =>
+			generate({ sourceCss: '.cunningham-theme--dark{ --c--x: 1; }', packageVersion: '3.0.0', generationDate: '2026-07-24' }),
+		).toThrow(/light "html/)
+	})
+
+	it('throws a clear error when the dark block is missing from the source', () => {
+		expect(() =>
+			generate({ sourceCss: 'html{ --c--x: 1; }', packageVersion: '3.0.0', generationDate: '2026-07-24' }),
+		).toThrow(/dark ".cunningham-theme--dark/)
+	})
+})

--- a/token-sets.json
+++ b/token-sets.json
@@ -405,5 +405,15 @@
 			"primary_color": "#4844AD",
 			"background_color": "#FFFFFF"
 		}
+	},
+	{
+		"id": "cunningham",
+		"name": "Cunningham (blue base)",
+		"description": "The published Cunningham design system (MIT, @openfun/cunningham-tokens) as distributed — blue base (brand-650 #1A509F, the same scale step the shared bridge/element-overrides derive --color-primary from for lasuite's violet #4844AD), self-hosted Inter. Secondary/optional sibling of lasuite: same generated token base, without the deployed violet La Suite brand override. No logo bundled.",
+		"design_system": "cunningham",
+		"theming": {
+			"primary_color": "#1A509F",
+			"background_color": "#FFFFFF"
+		}
 	}
 ]


### PR DESCRIPTION
## What / Why

The shipped `lasuite` design system claimed pixel-adjacent La Suite parity but its Cunningham
foundation (`css/systems/lasuite/defaults.css`) was hand-transcribed and only 4.6% complete (37 of
1167 tokens). This PR replaces transcription with generation, separates the sourced violet
deployment override from the generated blue base, completes the Nextcloud variable bridge, and adds
drift/coverage guards plus a component-parity e2e spec. Foundation for the rest of the La Suite
pixel-parity wave.

- **Generator**: `scripts/generate-lasuite-tokens.mjs` reads `@openfun/cunningham-tokens` (new
  devDependency, MIT) and emits all 1167 `--lasuite--*` tokens (584 light `:root` + 583 dark
  `.cunningham-theme--dark`, mirroring the source's own two-block structure — flattening them would
  silently clobber light with dark) plus a closed compatibility-alias block for the existing
  bridge/element-overrides consumers.
- **Sourced violet override**: `css/systems/lasuite/brand-override.css` (new) reproduces the deployed
  La Suite violet theme observed in the `docs.numerique.gouv.fr` bundle (`:root` block 5,
  2026-07-24) — no npm package ships it. Loads after `defaults`, before `bridge`.
- **Bridge completion**: `css/systems/lasuite/bridge.css` now covers all 68 audited Nextcloud
  `--color-*` variables (was ~30) as mapping or reasoned comment; also fixed 4 `--nldesign-color-*-rgb`
  literal triples that were stale against the old hand-transcribed hex values.
- **Optional `cunningham` sibling**: the published Cunningham blue base as its own selectable design
  system/token set, reusing the same generated `defaults.css`.
- **Drift + coverage guards**: `npm run test:lasuite-tokens` (regenerate-and-diff) and
  `npm run test:lasuite-bridge-coverage` (variable-set diff, mirrored in PHPUnit).
- **Component-parity e2e**: `tests/e2e/spec-coverage/lasuite-parity.spec.ts` (serial, small, per
  issue #181 load-fragility).

### Discovered & fixed inconsistency
The change's own spec artifacts (design.md, 3 spec deltas) assumed `cunningham`'s rendered
`--color-primary` would be brand-600 `#0659C5`. It doesn't: the shared bridge/element-overrides
(reused unmodified from `lasuite`) derive `--color-primary` from `--lasuite-color-brand-650`
specifically — the same step that resolves to lasuite's deployed violet `#4844AD`. Corrected
`cunningham`'s swatch/rendered primary to `#1A509F` (brand-650 blue) consistently across
`token-sets.json`, `css/tokens/cunningham.css`, the PHPUnit regression, and the spec deltas.

## Tests

- `npx vitest run`: **74/74 passed** (19 new: `tests/vitest/generateLasuiteTokens.spec.js`)
- PHPUnit (docker `nextcloud:34.0.0-apache`, shadow-mounted worktree): `LasuiteDesignStackTest`
  **21/21 passed** (was 12); full non-Mail `tests/Unit` suite **457/457 passed, 3270 assertions**
- `composer check:strict`: lint/phpcs/phpmd/psalm/phpstan all clean, exit 0 ("ALL CHECKS PASSED");
  `test:all` step soft-fails on the known `OC\Mail\EMailTemplate` harness limitation (documented,
  unrelated to this change)
- `npm run test:lasuite-tokens`: OK (drift detection manually proven during development, reverted)
- `npm run test:lasuite-bridge-coverage`: OK — 68/68 audited variables accounted for
- `npx stylelint` on all new/changed CSS: 0 problems (whole-repo `npm run stylelint` hits one
  **pre-existing, unrelated** failure in `css/admin.css`, not touched by this PR)
- `npm run check:manifest`: PASS (unaffected — validates `src/manifest.json`, unrelated file)

## Deferred (live 8080 instance, per builder-brief ground rules)

- [ ] 7.4 Live-verify `lasuite` renders violet `--color-primary: #4844ad`
- [ ] 7.5 Live-verify `cunningham` renders blue `--color-primary: #1a509f`
- [ ] 7.6 Run `lasuite-parity.spec.ts` against the dev instance (verified it parses/lists correctly
      under Playwright — 11 tests — but not executed live; the shared instance is load-fragile per
      issue #181 and other builders in this wave may be using it concurrently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)