### PR TITLE
fix(icons): Dutch-government sets resolve Dutch icons (default missing design_system)

### DIFF
--- a/lib/Service/DesignSystemService.php
+++ b/lib/Service/DesignSystemService.php
@@ -220,9 +220,22 @@ class DesignSystemService
             return $tokenSetPack;
         }
 
-        $designSystemId = ($tokenSetMeta['design_system'] ?? null);
-        if (is_string($designSystemId) === false || $designSystemId === '') {
+        // An UNKNOWN token set (no manifest entry at all → empty meta) is not
+        // themed, so it resolves to no pack.
+        if ($tokenSetMeta === []) {
             return [];
+        }
+
+        // A KNOWN token set that merely OMITS design_system defaults to
+        // `nldesign` — the same fallback TokenSetService::getAvailableTokenSets()
+        // and Capabilities apply. Without this, the ~33 Dutch-government sets
+        // that omit the field (rijkshuisstijl and the municipality sets carry
+        // id/name/description/theming but no design_system) would resolve to NO
+        // icon pack instead of the Dutch packs, silently breaking the
+        // "Dutch government → Dutch icons" contract.
+        $designSystemId = ($tokenSetMeta['design_system'] ?? '');
+        if (is_string($designSystemId) === false || $designSystemId === '') {
+            $designSystemId = 'nldesign';
         }
 
         return $this->getIconPacks(designSystemId: $designSystemId);

--- a/tests/Unit/DesignSystemServiceTest.php
+++ b/tests/Unit/DesignSystemServiceTest.php
@@ -86,6 +86,9 @@ class DesignSystemServiceTest extends TestCase
                     ['id' => 'lasuite', 'design_system' => 'lasuite'],
                     ['id' => 'nextcloud', 'design_system' => 'none'],
                     ['id' => 'ghost-system', 'design_system' => 'does-not-exist'],
+                    // A real Dutch municipality set: the manifest OMITS
+                    // design_system, relying on the app-wide 'nldesign' default.
+                    ['id' => 'gemeente-zonder-ds'],
                 ]
             )
         );
@@ -199,6 +202,21 @@ class DesignSystemServiceTest extends TestCase
     {
         $this->assertSame(['rvo', 'open-gemeenten', 'den-haag'], $this->service()->resolveActiveIconPacks('rijkshuisstijl'));
     }//end testResolveActiveIconPacksNldesignDefault()
+
+    /**
+     * A token set that OMITS design_system (the ~33 Dutch municipality sets)
+     * must default to the `nldesign` design system — and therefore resolve
+     * the Dutch icon packs, not an empty list. Regression: the resolver
+     * previously returned [] for a missing field, silently stripping the
+     * Dutch government's own icons.
+     */
+    public function testResolveActiveIconPacksDefaultsMissingDesignSystemToNldesign(): void
+    {
+        $this->assertSame(
+            ['rvo', 'open-gemeenten', 'den-haag'],
+            $this->service()->resolveActiveIconPacks('gemeente-zonder-ds')
+        );
+    }//end testResolveActiveIconPacksDefaultsMissingDesignSystemToNldesign()
 
     /**
      * A `none` (stock) design system resolves to no pack.


### PR DESCRIPTION
Live-verification bug: the ~33 Dutch sets that omit design_system resolved to NO icon pack, breaking the per-government icon promise. Now default a KNOWN design_system-less set to nldesign (→ Dutch packs), while an UNKNOWN id still yields none. 527 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)