### PR TITLE
feat(config): NL Design theme as a shareable config type (federated-config)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ on air-gapped government instances.
 Free and open source under the EUPL-1.2 license.
 Gratis en open source onder de EUPL-1.2 licentie.
 	]]></description>
-	<version>0.1.3-unstable.15</version>
+	<version>0.1.3-unstable.16</version>
 	<licence>EUPL-1.2</licence>
 	<author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
 	<namespace>NLDesign</namespace>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -109,7 +109,7 @@ class Application extends App implements IBootstrap
         if (class_exists(\OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent::class) === true) {
             $context->registerEventListener(
                 \OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent::class,
-                \OCA\NlDesign\Listener\ShareableConfigTypeListener::class
+                \OCA\NLDesign\Listener\ShareableConfigTypeListener::class
             );
         }
     }//end register()

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -87,6 +87,12 @@ class Application extends App implements IBootstrap
      */
     public function register(IRegistrationContext $context): void
     {
+        // Load the app's composer autoloader so this app's classes are resolvable
+        // process-wide, not only inside this app's own container — required so a
+        // cross-app event listener (e.g. the OpenRegister federated-config type)
+        // can be constructed by another app's dispatcher. Mirrors hermiq.
+        include_once __DIR__.'/../../vendor/autoload.php';
+
         // Health endpoint served by the thin Controller\HealthController
         // subclass of the AppHost engine — no explicit registration needed.
         // Public huisstijl capability — see lib/Capabilities.php.
@@ -95,6 +101,17 @@ class Application extends App implements IBootstrap
         // Event-driven CSS injection — see lib/Listener/ThemeInjectionListener.php.
         $context->registerEventListener(BeforeTemplateRenderedEvent::class, ThemeInjectionListener::class);
         $context->registerEventListener(BeforeLoginTemplateRenderedEvent::class, ThemeInjectionListener::class);
+
+        // Federated configuration sharing (openregister): contribute the NL Design
+        // theme as a shareable config type so a theme can be published to and
+        // installed from GitHub over OpenRegister's one fleet mechanism. Guarded
+        // on the event class so an instance without OpenRegister still boots.
+        if (class_exists(\OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent::class) === true) {
+            $context->registerEventListener(
+                \OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent::class,
+                \OCA\NlDesign\Listener\ShareableConfigTypeListener::class
+            );
+        }
     }//end register()
 
     /**

--- a/lib/Listener/ShareableConfigTypeListener.php
+++ b/lib/Listener/ShareableConfigTypeListener.php
@@ -12,7 +12,7 @@
  * SPDX-License-Identifier: EUPL-1.2
  *
  * @category Listener
- * @package  OCA\NlDesign\Listener
+ * @package  OCA\NLDesign\Listener
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
@@ -25,9 +25,9 @@
 
 declare(strict_types=1);
 
-namespace OCA\NlDesign\Listener;
+namespace OCA\NLDesign\Listener;
 
-use OCA\NlDesign\Service\Config\NlDesignThemeShareableConfigType;
+use OCA\NLDesign\Service\Config\NlDesignThemeShareableConfigType;
 use OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;

--- a/lib/Listener/ShareableConfigTypeListener.php
+++ b/lib/Listener/ShareableConfigTypeListener.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Contributes NL Design's theme type to OpenRegister's federated-config engine.
+ *
+ * Registered only when OpenRegister's shareable-config event exists (a
+ * class_exists guard in Application.php), so an instance without OpenRegister —
+ * or with an older one — still boots. The same guarded-contribution pattern the
+ * app uses for OpenRegister's integration registry.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Listener
+ * @package  OCA\NlDesign\Listener
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NlDesign\Listener;
+
+use OCA\NlDesign\Service\Config\NlDesignThemeShareableConfigType;
+use OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * Registers the NL Design theme shareable-config type.
+ *
+ * @template-implements IEventListener<RegisterShareableConfigTypesEvent>
+ */
+class ShareableConfigTypeListener implements IEventListener
+{
+    /**
+     * Constructor.
+     *
+     * @param NlDesignThemeShareableConfigType $theme The theme type.
+     */
+    public function __construct(private readonly NlDesignThemeShareableConfigType $theme)
+    {
+
+    }//end __construct()
+
+    /**
+     * Contribute the theme type.
+     *
+     * @param Event $event The dispatched event.
+     *
+     * @return void
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function handle(Event $event): void
+    {
+        if (($event instanceof RegisterShareableConfigTypesEvent) === false) {
+            return;
+        }
+
+        $event->registerType(type: $this->theme);
+
+    }//end handle()
+}//end class

--- a/lib/Service/Config/NlDesignThemeShareableConfigType.php
+++ b/lib/Service/Config/NlDesignThemeShareableConfigType.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * NL Design themes as a shareable configuration type.
+ *
+ * This is the case that proves the federated-config standard is genuinely
+ * storage-agnostic. Every other shareable type so far stores its configuration
+ * as OpenRegister objects; NL Design's theme configuration lives in Nextcloud's
+ * own `IConfig`, exported and imported by this app's `ConfigBundleService`. Yet
+ * a theme shares exactly the same way a flow or a register does — because a type
+ * owns its own (de)serialisation, and OpenRegister owns only the engine.
+ *
+ * So an admin can publish their NL Design theme (token sets, overrides, footer
+ * and email theming, custom fonts) to GitHub and another instance can install
+ * it, over the one fleet mechanism, with no migration onto OpenRegister objects.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @category Service
+ * @package  OCA\NlDesign\Service\Config
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NlDesign\Service\Config;
+
+use OCA\NlDesign\Service\ConfigBundleService;
+use OCA\OpenRegister\Service\Config\IShareableConfigType;
+
+/**
+ * Shares an NL Design theme through the federated-config engine.
+ */
+class NlDesignThemeShareableConfigType implements IShareableConfigType
+{
+    /**
+     * Constructor.
+     *
+     * @param ConfigBundleService $bundle Exports and imports the theme config.
+     */
+    public function __construct(private readonly ConfigBundleService $bundle)
+    {
+
+    }//end __construct()
+
+    /**
+     * The type id.
+     *
+     * @return string The id.
+     */
+    public function getId(): string
+    {
+        return 'nldesign.theme';
+
+    }//end getId()
+
+    /**
+     * The display name.
+     *
+     * @return string The name.
+     */
+    public function getDisplayName(): string
+    {
+        return 'NL Design theme';
+
+    }//end getDisplayName()
+
+    /**
+     * The discovery topic.
+     *
+     * @return string The topic.
+     */
+    public function getTopic(): string
+    {
+        return 'nldesign-theme';
+
+    }//end getTopic()
+
+    /**
+     * Package the instance's NL Design theme into a portable bundle.
+     *
+     * The selection is ignored: a theme is the instance's one theme
+     * configuration, which `ConfigBundleService` already exports as a
+     * self-describing, portable bundle (no secrets — theming carries none).
+     *
+     * @param array $selection Unused for themes.
+     *
+     * @return array `{type, version, bundle}`.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function serialise(array $selection): array
+    {
+        return [
+            'type'    => $this->getId(),
+            'version' => '1.0',
+            'bundle'  => $this->bundle->export(),
+        ];
+
+    }//end serialise()
+
+    /**
+     * Apply a shared NL Design theme to this instance.
+     *
+     * @param array $bundle A bundle produced by this type.
+     *
+     * @return array `{installed: ['nldesign-theme'], import: {...}}`.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
+     */
+    public function deserialise(array $bundle): array
+    {
+        $result = $this->bundle->import((array) ($bundle['bundle'] ?? []), false);
+
+        return [
+            'installed' => ['nldesign-theme'],
+            'import'    => $result,
+        ];
+
+    }//end deserialise()
+}//end class

--- a/lib/Service/Config/NlDesignThemeShareableConfigType.php
+++ b/lib/Service/Config/NlDesignThemeShareableConfigType.php
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: EUPL-1.2
  *
  * @category Service
- * @package  OCA\NlDesign\Service\Config
+ * @package  OCA\NLDesign\Service\Config
  *
  * @author    Conduction Development Team <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
@@ -31,10 +31,11 @@
 
 declare(strict_types=1);
 
-namespace OCA\NlDesign\Service\Config;
+namespace OCA\NLDesign\Service\Config;
 
-use OCA\NlDesign\Service\ConfigBundleService;
+use OCA\NLDesign\Service\ConfigBundleService;
 use OCA\OpenRegister\Service\Config\IShareableConfigType;
+use Psr\Container\ContainerInterface;
 
 /**
  * Shares an NL Design theme through the federated-config engine.
@@ -44,12 +45,30 @@ class NlDesignThemeShareableConfigType implements IShareableConfigType
     /**
      * Constructor.
      *
-     * @param ConfigBundleService $bundle Exports and imports the theme config.
+     * The `ConfigBundleService` is resolved lazily rather than injected: this
+     * type is constructed whenever the shareable-type catalogue is read (which a
+     * cross-app request does), but the bundle service — with its deep theming
+     * dependency chain — is only needed when a theme is actually serialised or
+     * installed. Resolving it eagerly would drag that whole chain into every
+     * catalogue read, in a container context that may not autowire it.
+     *
+     * @param ContainerInterface $container Resolves the bundle service on demand.
      */
-    public function __construct(private readonly ConfigBundleService $bundle)
+    public function __construct(private readonly ContainerInterface $container)
     {
 
     }//end __construct()
+
+    /**
+     * The theme export/import service, resolved on first use.
+     *
+     * @return ConfigBundleService The bundle service.
+     */
+    private function bundle(): ConfigBundleService
+    {
+        return $this->container->get(ConfigBundleService::class);
+
+    }//end bundle()
 
     /**
      * The type id.
@@ -102,7 +121,7 @@ class NlDesignThemeShareableConfigType implements IShareableConfigType
         return [
             'type'    => $this->getId(),
             'version' => '1.0',
-            'bundle'  => $this->bundle->export(),
+            'bundle'  => $this->bundle()->export(),
         ];
 
     }//end serialise()
@@ -118,7 +137,7 @@ class NlDesignThemeShareableConfigType implements IShareableConfigType
      */
     public function deserialise(array $bundle): array
     {
-        $result = $this->bundle->import((array) ($bundle['bundle'] ?? []), false);
+        $result = $this->bundle()->import((array) ($bundle['bundle'] ?? []), false);
 
         return [
             'installed' => ['nldesign-theme'],


### PR DESCRIPTION
Contributes NL Design's theme configuration to OpenRegister's **federated configuration sharing** engine (openregister#2134/#2135), so a theme can be published to and installed from GitHub over the fleet's one sharing mechanism. This is the case that proves the standard is **storage-agnostic** — NL Design config lives in Nextcloud's `IConfig`, not OpenRegister objects, yet shares the same way a flow or a register does.

## What
- `NlDesignThemeShareableConfigType` implements `OCA\OpenRegister\Service\Config\IShareableConfigType`, wrapping the existing `ConfigBundleService::export()/import()` as its (de)serialiser. No secrets (theming carries none).
- `ShareableConfigTypeListener` registers it on `RegisterShareableConfigTypesEvent`, guarded on the event class existing (boots fine without OpenRegister).
- `Application::register()` now `include_once`s the app's composer autoloader so the cross-app listener is resolvable process-wide — the same mechanism hermiq uses to contribute flow nodes.

## Status — review before merge
The code follows hermiq's **identical, proven** cross-app contribution pattern (guarded event listener + vendor-autoload include), which resolves and runs over HTTP. On the shared dev instance the listener's cross-app autoload did **not** activate (even after a full container restart + `occ upgrade`), so I could not complete a live round-trip and did **not** merge it. Opened for review / verification on a clean deploy. phpcs clean; php lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)