### PR TITLE
fix(ci): composer check:strict has been exiting 1 for weeks — phpmd was the only failing leg

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
 		"phpcs": "./vendor/bin/phpcs --standard=phpcs.xml",
 		"phpcs:fix": "./vendor/bin/phpcbf --standard=phpcs.xml",
 		"phpcs:output": "./vendor/bin/phpcs --standard=phpcs.xml --report=json lib/ 2>/dev/null | tail -1 > phpcs-output.json",
-		"phpmd": "phpmd lib text phpmd.xml",
+		"phpmd": "./vendor/bin/phpmd lib text phpmd.xml --baseline-file phpmd.baseline.xml",
 		"phpmetrics": "./vendor/bin/phpmetrics --report-html=phpmetrics lib/",
 		"phpmetrics:violations": "./vendor/bin/phpmetrics --violations-xml=phpmetrics/violations.xml lib/",
 		"psalm": "./vendor/bin/psalm --threads=1 --no-cache",
@@ -64,7 +64,7 @@
 		"test:coverage": "./vendor/bin/phpunit --coverage-html=coverage/html --coverage-clover=coverage/clover.xml --colors=always",
 		"coverage:check": "php -r \"\\$xml = simplexml_load_file('coverage/clover.xml'); \\$metrics = \\$xml->project->metrics; \\$statements = (int)\\$metrics['statements']; \\$covered = (int)\\$metrics['coveredstatements']; \\$percentage = \\$statements > 0 ? round((\\$covered / \\$statements) * 100, 2) : 0; echo 'Coverage: ' . \\$percentage . '%' . PHP_EOL; exit(\\$percentage < 75 ? 1 : 0);\"",
 		"quality:phpcs-score": "./vendor/bin/phpcs --standard=phpcs.xml --report=json lib/ | php -r \"\\$json = json_decode(file_get_contents('php://stdin'), true); \\$errors = \\$json['totals']['errors'] ?? 0; \\$warnings = \\$json['totals']['warnings'] ?? 0; \\$score = 1000 - \\$errors - (\\$warnings / 2); echo 'PHPCS Score: ' . \\$score . ' (Errors: ' . \\$errors . ', Warnings: ' . \\$warnings . ')' . PHP_EOL;\"",
-		"quality:phpmd-score": "phpmd lib/ json phpmd.xml | php -r \"\\$input = file_get_contents('php://stdin'); \\$json = json_decode(\\$input, true); \\$violations = count(\\$json['files'] ?? []); \\$score = 1000 - (\\$violations * 10); echo 'PHPMD Score: ' . \\$score . ' (Violations: ' . \\$violations . ')' . PHP_EOL;\" || echo 'PHPMD not available'",
+		"quality:phpmd-score": "./vendor/bin/phpmd lib/ json phpmd.xml --baseline-file phpmd.baseline.xml | php -r \"\\$input = file_get_contents('php://stdin'); \\$json = json_decode(\\$input, true); \\$violations = count(\\$json['files'] ?? []); \\$score = 1000 - (\\$violations * 10); echo 'PHPMD Score: ' . \\$score . ' (Violations: ' . \\$violations . ')' . PHP_EOL;\" || echo 'PHPMD not available'",
 		"quality:psalm-score": "./vendor/bin/psalm --output-format=json --no-cache | php -r \"\\$input = file_get_contents('php://stdin'); \\$json = json_decode(\\$input, true); \\$errors = count(\\$json ?? []); \\$score = 1000 - (\\$errors * 5); echo 'Psalm Score: ' . \\$score . ' (Errors: ' . \\$errors . ')' . PHP_EOL;\" || echo 'Psalm not available'",
 		"quality:phpstan-score": "./vendor/bin/phpstan analyse --memory-limit=1G --error-format=json --no-progress | php -r \"\\$input = file_get_contents('php://stdin'); \\$json = json_decode(\\$input, true); \\$errors = \\$json['totals']['file_errors'] ?? 0; \\$score = 1000 - (\\$errors * 5); echo 'PHPStan Score: ' . \\$score . ' (Errors: ' . \\$errors . ')' . PHP_EOL;\" || echo 'PHPStan not available'",
 		"quality:score": [

--- a/phpmd.baseline.xml
+++ b/phpmd.baseline.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!--
+  PHPMD baseline — created 2026-08-02 to make `composer phpmd` (and therefore
+  `composer check:strict`) pass honestly instead of failing silently.
+
+  CONTEXT: unlike most of the fleet, nldesign's phpmd script never had the
+  `|| echo '…skipping…'` escape hatch, so `composer check:strict` has been
+  exiting 1 — and the shared CI workflow's "PHP Quality (phpmd)" job has been
+  FAILING on every run — since at least 2026-07-25. Nobody acted on it. The
+  other three analysers were already clean and are unchanged by this baseline:
+      phpcs   0 findings, exit 0
+      psalm   0 findings, exit 0
+      phpstan 0 findings, exit 0 (with the pre-existing phpstan-baseline.neon)
+
+  The 9 entries below are the complete phpmd output, measured in
+  nextcloud:32-apache (PHP 8.3.32). Reasons, per entry:
+
+  * CouplingBetweenObjects / CyclomaticComplexity / NpathComplexity
+    (CssInjectionService::inject, CustomCssValidator::validate,
+    CustomCssValidator::bracesAreBalanced) — 6 entries.
+    Complexity thresholds, not defects. `bracesAreBalanced()` is a character
+    scanner and `validate()` is a flat list of independent guard clauses; both
+    are branchy by nature and splitting them would obscure rather than clarify.
+    Baselined as accepted debt, not as a claim that they are ideal.
+
+  * ShortVariable + UnusedLocalVariable (CustomCssValidator, the `$m` capture
+    on line 115) — 2 entries.
+    NOT cosmetic, and deliberately NOT silently swallowed: chasing this pair is
+    what surfaced a real validation bypass — a single `data:` URI anywhere in
+    the stylesheet disables the external-`url()` block for every non-http(s)
+    scheme. Filed as
+    https://github.com/ConductionNL/nldesign/issues/193 and left unfixed here
+    only because a security fix does not belong in a CI-plumbing PR. Both
+    entries should be deleted when #193 is fixed.
+
+  From this commit on the baseline is a RATCHET: any NEW phpmd violation fails
+  the gate. Do not regenerate this file to silence a new finding.
+-->
+<phpmd-baseline>
+  <violation rule="PHPMD\Rule\Design\CouplingBetweenObjects" file="lib/Service/CssInjectionService.php"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/CssInjectionService.php" method="inject"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/CssInjectionService.php" method="inject"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/CustomCssValidator.php" method="validate"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/CustomCssValidator.php" method="validate"/>
+  <violation rule="PHPMD\Rule\Naming\ShortVariable" file="lib/Service/CustomCssValidator.php"/>
+  <violation rule="PHPMD\Rule\UnusedLocalVariable" file="lib/Service/CustomCssValidator.php"/>
+  <violation rule="PHPMD\Rule\CyclomaticComplexity" file="lib/Service/CustomCssValidator.php" method="bracesAreBalanced"/>
+  <violation rule="PHPMD\Rule\Design\NpathComplexity" file="lib/Service/CustomCssValidator.php" method="bracesAreBalanced"/>
+</phpmd-baseline>


### PR DESCRIPTION
## What this does

Makes `composer check:strict` pass honestly. This repo's gate was **RED, not dead** — and had been for weeks with nobody acting on it.

## Branch note, read this first

This PR targets **`development`**, not `main`. GitHub reports `main` as the default branch, but `main` is **378 commits behind** `development` and its last commits are Codeberg-archival artefacts ("chore: absorbeer GitHub-archiverings-banner-commit"). All development, all CI activity and the current `code-quality.yml` live on `development`.

That matters for the survey this work started from, which described nldesign's `phpstan`/`psalm` scripts as already plain. On **`main`** they are not — they end `|| echo '… not installed, skipping...'`, `composer.lock` is missing every dev tool (`composer install` exits 4), and `code-quality.yml` is a local matrix rather than the shared workflow. On **`development`**, which is what actually runs, the survey is correct. Measuring `main` would have produced a confidently wrong report.

## Analysis-path verification

- All analysers run inside **`nextcloud:32-apache`** (`PHP 8.3.32`, imagick present).
- `vendor/` from a **real `composer install` from `composer.lock`** in a fresh worktree.
- OCP-stub trap checked: `vendor/nextcloud/ocp/OCP` is a **real directory with 132 entries**, not a dangling symlink, no `OCP.bak/`.
- Configured paths exist: `phpcs.xml`/`psalm.xml`/`phpstan.neon`/phpmd all point at `lib`, which holds **61 PHP files**.

## Does CI run the gate? Yes, and it has been failing

`.github/workflows/code-quality.yml` calls the shared `quality.yml`, whose matrix runs `composer phpmd` / `psalm` / `phpstan` / `phpcs`. The **`PHP Quality (phpmd)` job has failed on every run since at least 2026-07-25**. Run 30334512599:

```
Script phpmd lib text phpmd.xml handling the phpmd event returned with error code 2
##[error]Process completed with exit code 2.
```

`psalm`, `phpstan`, `phpcs`, `lint`, `phpmetrics` all reported `success` in that same run. phpmd was the only red PHP leg — and stayed red.

## The bare-`phpmd` hypothesis was wrong

The brief for this work assumed `phpmd lib text phpmd.xml` (a bare binary name) fails because `phpmd` is not on `PATH`, making `check:strict` red "for a silly reason". **That is not what is happening.** The exit code is **2 (violations found)**, not 127 (command not found).

Verified directly rather than inferred: I built a throwaway package with a script `"bareprobe": "myprobetool --hello"` and an executable `vendor/bin/myprobetool` that exits 7.

```
$ composer bareprobe
> myprobetool --hello
PATH-RESOLVED-OK args=--hello
Script myprobetool --hello ... returned with error code 7   # exit 7

$ sh -c 'myprobetool --hello'
sh: 1: myprobetool: not found                               # exit 127  ← positive control
```

Composer prepends `vendor/bin` to `PATH` for scripts. The bare form worked. Moving to `./vendor/bin/phpmd` here is for robustness when the command is run outside composer (the old `main` workflow invoked `./vendor/bin/phpmd` directly) and for consistency with the other three scripts — **not** because the old form was broken. Claiming otherwise would have been a fabricated bug.

## Pre-repair measurements

| tool | findings | exit |
| --- | ---: | ---: |
| phpcs | 0 | 0 |
| phpmd | **9** | **2** |
| psalm | 0 | 0 |
| phpstan | 0 | 0 (with the existing `phpstan-baseline.neon`) |
| `composer check:strict` | — | **1 (RED)** |

All 9 phpmd findings, in full:

| rule | count | where |
| --- | ---: | --- |
| CyclomaticComplexity | 3 | `CssInjectionService::inject`, `CustomCssValidator::validate`, `CustomCssValidator::bracesAreBalanced` |
| NPathComplexity | 3 | same three methods |
| CouplingBetweenObjects | 1 | `CssInjectionService` (13) |
| ShortVariable | 1 | `CustomCssValidator:115` (`$m`) |
| UnusedLocalVariable | 1 | `CustomCssValidator:115` (`$m`) |

## composer.json shape chosen: (b) plain `./vendor/bin/X`

`phpcs`, `psalm` and `phpstan` are already plain here; phpmd was the outlier. An `if [ -f vendor/bin/X ]` guard would re-introduce exactly the "tool missing = silently skipped" failure mode this programme is removing. Also fixed the same bare-binary form in `quality:phpmd-score`.

## Baseline and its reasons

New `phpmd.baseline.xml`, **9 entries**, reasoning written into the file:

- **6 complexity entries** — `bracesAreBalanced()` is a character scanner and `validate()` is a flat list of independent guard clauses; both are branchy by nature and splitting them would obscure rather than clarify. Accepted debt, not a claim that they are ideal. General lint-debt cleanup is already tracked in **#98**.
- **2 entries for `$m`** (`ShortVariable` + `UnusedLocalVariable`) — explicitly *not* swallowed. See below. They should be deleted when #193 is fixed.

The baseline is a **ratchet**: any new phpmd violation fails the gate.

## Real defect found — #193

Chasing the `UnusedLocalVariable $m` surfaced a genuine validation bypass in `CustomCssValidator::validate()`. The regex captures the offending `url(...)` match into `$m` and then throws it away; the follow-up checks are run against the **whole document** instead of against that match. So **one `data:` URI anywhere in the stylesheet disables the external-`url()` block for every non-`http(s)` scheme**.

Probed directly against the three `preg_match` calls as written:

| input | result |
| --- | --- |
| `url(ftp://evil.example/x)` | REJECTED ✅ |
| `url(https://evil.example/x)` | REJECTED ✅ |
| `url(data:…)` | ACCEPTED ✅ (intended) |
| `url(data:…)` + `url(ftp://evil.example/x)` | **ACCEPTED ❌** |
| `url(data:…)` + `url(chrome-extension://abc/x)` | **ACCEPTED ❌** |
| `url(data:…)` + `url(https://evil.example/x)` | REJECTED ✅ |

Moderate, not critical: the `https:`/`//` channel the docblock cares most about is still caught, and the setting is admin-only. Filed as **#193** with the reproduction. Deliberately not fixed here — a security fix does not belong in a CI-plumbing PR.

## `test:all` — measured, deliberately not flipped

Left ending `|| echo`. Unlike openbuild, here the stated reason is **true**: the suite fatals without a Nextcloud server tree —

```
Message:  Class "OC\Mail\EMailTemplate" not found
Location: /app/lib/Mail/NLDesignEMailTemplate.php:48
```

## Vacuous-green control

A deliberately broken `lib/ProbeGateLive.php` (undefined method call, unused local variable, non-conforming formatting) was dropped in, and **all four repaired analysers failed on it** — including phpmd, proving the new baseline does not mask new findings:

| tool | exit with probe | names the probe file |
| --- | ---: | ---: |
| phpcs | **2** | yes (5 lines) |
| phpmd | **2** | yes |
| psalm | **2** | yes |
| phpstan | **1** | yes (2 lines) |

Probe deleted; `git status` then showed only `composer.json` modified plus the new `phpmd.baseline.xml`, no leftovers.

Post-repair: `composer phpmd` exit 0, `composer check:strict` **exit 0 — ALL CHECKS PASSED**.

## Also checked

No class-level `@method` docblocks anywhere in `lib/`, so the openregister-style stale-annotation / named-argument fatal cannot be hiding here.

## Not done / not verified

- The #193 security fix itself.
- The 6 complexity findings — baselined, not refactored.
- `main` is left 378 commits behind `development`; reconciling those branches is out of scope but somebody should decide which is canonical, because GitHub's default-branch setting currently points at the stale one.
- `test:all` not flipped.
- Timings are wall-clock at host load average 20–55.

Recent merges land on **GitHub** (`Merge pull request #NNN from ConductionNL/...`); Codeberg is a mirror.
