### PR TITLE
fix(security): judge every url() on its own scheme instead of asking the document (#193)

### DIFF
--- a/lib/Service/CustomCssValidator.php
+++ b/lib/Service/CustomCssValidator.php
@@ -112,12 +112,12 @@ class CustomCssValidator
         // background-image, @font-face src, cursor or list-style-image.
         // Relative/same-origin references and data: URIs cannot reach another
         // origin, so those remain available for legitimate theming.
-        if (preg_match('#url\(\s*[\'"]?\s*(?:[a-z][a-z0-9+.-]*:|//)#i', $css, $m) === 1) {
-            if (preg_match('#url\(\s*[\'"]?\s*data:#i', $css) !== 1
-                || preg_match('#url\(\s*[\'"]?\s*(?:https?:|//)#i', $css) === 1
-            ) {
-                $errors[] = 'External url() references are not allowed; use a relative path or a data: URI.';
-            }
+        $offendingScheme = $this->firstDisallowedUrlScheme(css: $css);
+        if ($offendingScheme !== null) {
+            $errors[] = sprintf(
+                'External url() references are not allowed (found "%s"); use a relative path or a data: URI.',
+                $offendingScheme
+            );
         }
 
         // Legacy script-execution vectors. Modern engines ignore them, but
@@ -153,6 +153,51 @@ class CustomCssValidator
         return $errors;
 
     }//end validate()
+
+    /**
+     * Return the first url() scheme in the document that is not permitted.
+     *
+     * EVERY url() occurrence is judged on its own target. The predecessor of
+     * this method asked two DOCUMENT-GLOBAL questions instead — "does a data:
+     * URI appear anywhere?" and "does an http(s)/protocol-relative reference
+     * appear anywhere?" — so a single legitimate data: URI satisfied the first
+     * question and, absent a second http(s)-specific hit, accepted every other
+     * scheme in the same stylesheet (`ftp://`, `chrome-extension://`, …). That
+     * bypass is issue #193; a per-occurrence scan is the only shape that
+     * cannot be disarmed by an unrelated, allowed reference elsewhere.
+     *
+     * Only `data:` is allowed to carry a scheme. Relative and root-relative
+     * references (`../img/logo.svg`, `/apps/nldesign/img/logo.svg`) carry no
+     * scheme at all, so they never match the scan and stay usable.
+     *
+     * @param string $css The admin-submitted CSS.
+     *
+     * @return string|null The first disallowed scheme (e.g. `ftp:` or `//`),
+     *                     or NULL when every url() target is permitted.
+     *
+     * @spec openspec/specs/custom-css-freeform/spec.md
+     */
+    private function firstDisallowedUrlScheme(string $css): ?string
+    {
+        $found = preg_match_all(
+            '#url\(\s*[\'"]?\s*([a-z][a-z0-9+.-]*:|//)#i',
+            $css,
+            $matches
+        );
+
+        if ($found === false || $found === 0) {
+            return null;
+        }
+
+        foreach ($matches[1] as $scheme) {
+            if (strcasecmp($scheme, 'data:') !== 0) {
+                return $scheme;
+            }
+        }
+
+        return null;
+
+    }//end firstDisallowedUrlScheme()
 
     /**
      * Report whether every `{` has a matching `}`.

--- a/tests/Unit/Service/CustomCssValidatorTest.php
+++ b/tests/Unit/Service/CustomCssValidatorTest.php
@@ -159,6 +159,90 @@ class CustomCssValidatorTest extends TestCase
 
 
     /**
+     * A legitimate data: URI must not disable the block on the OTHER url()
+     * references in the same document (issue #193).
+     *
+     * The original rule asked two DOCUMENT-GLOBAL questions — "is there a
+     * data: anywhere?" and "is there an http(s)/`//` anywhere?" — instead of
+     * asking them of the offending match, so one data: URI earlier in the
+     * stylesheet accepted every non-http(s) scheme after it.
+     *
+     * @return void
+     */
+    public function testRejectsForeignSchemeAfterDataUri(): void
+    {
+        $schemes = [
+            'ftp://evil.test/x.png',
+            'chrome-extension://abcdefghijklmnop/x.png',
+            'file:///etc/passwd',
+            '//evil.test/x.png',
+            'https://evil.test/x.png',
+        ];
+
+        foreach ($schemes as $scheme) {
+            $css = '.a { background: url(data:image/gif;base64,R0lGODlhAQABAAAAACw=); }'."\n"
+                .'.b { background: url('.$scheme.'); }';
+
+            $errors = $this->validator->validate(css: $css);
+
+            $this->assertNotEmpty(
+                $errors,
+                $scheme.' must still be rejected when a data: URI appears earlier in the same document.'
+            );
+            $this->assertStringContainsStringIgnoringCase('url()', implode(' ', $errors));
+        }
+
+    }//end testRejectsForeignSchemeAfterDataUri()
+
+
+    /**
+     * The same bypass in the other order — the data: URI AFTER the offending
+     * reference — must not be accepted either.
+     *
+     * @return void
+     */
+    public function testRejectsForeignSchemeBeforeDataUri(): void
+    {
+        $css = '.b { background: url(ftp://evil.test/x.png); }'."\n"
+            .'.a { background: url(data:image/gif;base64,R0lGODlhAQABAAAAACw=); }';
+
+        $this->assertNotEmpty($this->validator->validate(css: $css));
+
+    }//end testRejectsForeignSchemeBeforeDataUri()
+
+
+    /**
+     * A non-http(s) scheme on its own stays rejected.
+     *
+     * @return void
+     */
+    public function testRejectsForeignSchemeWithoutDataUri(): void
+    {
+        $this->assertNotEmpty($this->validator->validate(css: '.x { background: url(ftp://evil.test/x.png); }'));
+
+    }//end testRejectsForeignSchemeWithoutDataUri()
+
+
+    /**
+     * The counter-control for the fix: legitimate documents that mix several
+     * data: URIs with relative references must STILL be accepted. A rule that
+     * rejects everything is not a fix.
+     *
+     * @return void
+     */
+    public function testAcceptsMultipleDataUrisAndRelativePaths(): void
+    {
+        $css = '.a { background: url(data:image/gif;base64,R0lGODlhAQABAAAAACw=); }'."\n"
+            .'.b { background: url("data:image/svg+xml;base64,PHN2Zy8+"); }'."\n"
+            .".c { background: url('../img/logo.svg'); }\n"
+            .'.d { background: url(/apps/nldesign/img/logo.svg); }';
+
+        $this->assertSame([], $this->validator->validate(css: $css));
+
+    }//end testAcceptsMultipleDataUrisAndRelativePaths()
+
+
+    /**
      * Legacy script-execution vectors are refused.
      *
      * @return void


### PR DESCRIPTION
Fixes #193.

## The defect

`lib/Service/CustomCssValidator.php:115-121` matched an offending `url()` occurrence into `$m` and then **threw it away**, running the follow-up decision against the *whole document*:

```php
if (preg_match('#url\(\s*[\'"]?\s*(?:[a-z][a-z0-9+.-]*:|//)#i', $css, $m) === 1) {
    if (preg_match('#url\(\s*[\'"]?\s*data:#i', $css) !== 1
        || preg_match('#url\(\s*[\'"]?\s*(?:https?:|//)#i', $css) === 1
    ) {
        $errors[] = 'External url() references are not allowed; …';
    }
}
```

Both inner tests are document-global. One legitimate `data:` URI anywhere in the stylesheet satisfies the first clause, and unless a *second*, `http(s)`/`//`-specific match also exists, no error is recorded — so `ftp://`, `chrome-extension://`, `file:///` and every other custom scheme are accepted for the rest of the document.

## The fix

A per-occurrence scan. `firstDisallowedUrlScheme()` runs `preg_match_all` over every `url(` target's scheme and permits only `data:` to carry one; relative and root-relative references carry no scheme at all, so they never match and stay usable. `validate()` reports the offending scheme in the error text.

The spec already required this (`Scenario: External url() rejected` — "…or any other absolute-scheme or protocol-relative URL"); the code just did not hold. No spec delta needed.

## Positive controls — both directions, executed

Same 20-case probe, same command, run against the **pre-fix** revision and the **fixed** revision (different `sha256` of the loaded class printed by each run).

<details><summary>PRE-FIX — 5 controls FAIL (the bypass)</summary>

```
LOADED FROM: /app/lib/Service/CustomCssValidator.php
sha256(file): 5ec78052415268900e95664109030e3e9e1195130b0418d50e72e6bdd52d1460

input                                  | expect | actual | verdict
------------------------------------------------------------------------------
ftp:// alone                           | BLOCK  | BLOCK  | PASS
http:// alone                          | BLOCK  | BLOCK  | PASS
https:// alone                         | BLOCK  | BLOCK  | PASS
//evil.com alone                       | BLOCK  | BLOCK  | PASS
chrome-extension:// alone              | BLOCK  | BLOCK  | PASS
THE BYPASS: data: then ftp://          | BLOCK  | ALLOW  | *** FAIL ***
THE BYPASS: data: then chrome-ext      | BLOCK  | ALLOW  | *** FAIL ***
THE BYPASS: data: then file://         | BLOCK  | ALLOW  | *** FAIL ***
THE BYPASS: data: then //evil.com      | BLOCK  | BLOCK  | PASS
THE BYPASS: data: then https://        | BLOCK  | BLOCK  | PASS
reverse order: ftp:// then data:       | BLOCK  | ALLOW  | *** FAIL ***
quoted: data: then "ftp://"            | BLOCK  | ALLOW  | *** FAIL ***
LEGIT: single data: URI                | ALLOW  | ALLOW  | PASS
LEGIT: two data: URIs                  | ALLOW  | ALLOW  | PASS
LEGIT: data: + relative path           | ALLOW  | ALLOW  | PASS
LEGIT: data: + root-relative path      | ALLOW  | ALLOW  | PASS
LEGIT: relative path only              | ALLOW  | ALLOW  | PASS
LEGIT: uppercase DATA: URI             | ALLOW  | ALLOW  | PASS
LEGIT: data: woff2 @font-face          | ALLOW  | ALLOW  | PASS
LEGIT: plain CSS, no url()             | ALLOW  | ALLOW  | PASS
------------------------------------------------------------------------------
5 CONTROL(S) FAILED
EXIT=1
```
</details>

<details><summary>POST-FIX — all 20 pass</summary>

```
LOADED FROM: /app/lib/Service/CustomCssValidator.php
sha256(file): 7e5444a7b9fe299958bf4c663944c6c572aa10de3ffc227902762e148d2a9fab

input                                  | expect | actual | verdict
------------------------------------------------------------------------------
ftp:// alone                           | BLOCK  | BLOCK  | PASS
http:// alone                          | BLOCK  | BLOCK  | PASS
https:// alone                         | BLOCK  | BLOCK  | PASS
//evil.com alone                       | BLOCK  | BLOCK  | PASS
chrome-extension:// alone              | BLOCK  | BLOCK  | PASS
THE BYPASS: data: then ftp://          | BLOCK  | BLOCK  | PASS
THE BYPASS: data: then chrome-ext      | BLOCK  | BLOCK  | PASS
THE BYPASS: data: then file://         | BLOCK  | BLOCK  | PASS
THE BYPASS: data: then //evil.com      | BLOCK  | BLOCK  | PASS
THE BYPASS: data: then https://        | BLOCK  | BLOCK  | PASS
reverse order: ftp:// then data:       | BLOCK  | BLOCK  | PASS
quoted: data: then "ftp://"            | BLOCK  | BLOCK  | PASS
LEGIT: single data: URI                | ALLOW  | ALLOW  | PASS
LEGIT: two data: URIs                  | ALLOW  | ALLOW  | PASS
LEGIT: data: + relative path           | ALLOW  | ALLOW  | PASS
LEGIT: data: + root-relative path      | ALLOW  | ALLOW  | PASS
LEGIT: relative path only              | ALLOW  | ALLOW  | PASS
LEGIT: uppercase DATA: URI             | ALLOW  | ALLOW  | PASS
LEGIT: data: woff2 @font-face          | ALLOW  | ALLOW  | PASS
LEGIT: plain CSS, no url()             | ALLOW  | ALLOW  | PASS
------------------------------------------------------------------------------
ALL 20 CONTROLS PASSED (both directions)
EXIT=0
```
</details>

The eight `LEGIT: …` rows are **byte-identical between the two runs** — that is the "a fix that blocks everything is not a fix" control. Only the five bypass rows moved.

## PHPUnit — new tests fail before, pass after

Four tests added to `tests/Unit/Service/CustomCssValidatorTest.php`: `testRejectsForeignSchemeAfterDataUri`, `testRejectsForeignSchemeBeforeDataUri`, `testRejectsForeignSchemeWithoutDataUri`, `testAcceptsMultipleDataUrisAndRelativePaths`.

Pre-fix source, new tests present:

```
........FF..........                                              20 / 20 (100%)

There were 2 failures:

1) …CustomCssValidatorTest::testRejectsForeignSchemeAfterDataUri
ftp://evil.test/x.png must still be rejected when a data: URI appears earlier in the same document.
Failed asserting that an array is not empty.

2) …CustomCssValidatorTest::testRejectsForeignSchemeBeforeDataUri
Failed asserting that an array is not empty.

FAILURES!
Tests: 20, Assertions: 35, Failures: 2.
```

After the fix: `OK (20 tests, 44 assertions)`.

Note that `testAcceptsMultipleDataUrisAndRelativePaths` passes on **both** revisions — the fix does not narrow what is accepted.

## Other gates

| gate | result |
| --- | --- |
| `phpunit tests/Unit/{BackgroundJob,Command,Controller,Listener,Service,Templates}` | **451 tests OK** |
| `phpunit tests/Unit/Mail` | cannot load (`OC\Mail\EMailTemplate` needs a full NC server) — **fails identically on `development`**, unrelated |
| `phpcs --standard=phpcs.xml lib/Service/CustomCssValidator.php` | exit 0 |
| `psalm --no-cache` | No errors found |
| `phpstan analyse` | No errors |
| `phpmd lib/Service/CustomCssValidator.php` | 6 findings → **2**; the four on `validate()` / `$m` (`CyclomaticComplexity`, `NPathComplexity`, `ShortVariable`, `UnusedLocalVariable`) are gone, exactly as #193 predicted. The 2 remaining are pre-existing, on the untouched `bracesAreBalanced()`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
