### PR TITLE
ci: bound the sync-tokens job runtime

### DIFF
--- a/.github/workflows/sync-tokens.yml
+++ b/.github/workflows/sync-tokens.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   sync-tokens:
     runs-on: ubuntu-latest
+    # Observed n=11 (2026): max 1.9 min, median 0.3 min. Bound loosely at 15.
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## What

Adds `timeout-minutes: 15` to the `sync-tokens` job in `.github/workflows/sync-tokens.yml` — the only job in this repo that runs on a runner and had no bound. Without it a hung clone or stalled step burns the 6h GitHub default.

**Measured, not guessed:** 11 runs in 2026, max 1.9 min, median 0.3 min. Bounded at 15 — deliberately loose, so ordinary runner contention can never convert a slow run into a phantom failure.

## Why only one job

The original sweep targeted 18 jobs across 16 workflow files. Those files exist only on `main`, which has not had its workflows touched since March 2026 and has run them 4 times total since June. On `development` (711/384 commits ahead) every workflow is a thin caller of a reusable workflow in `ConductionNL/.github`, and **all of those already carry `timeout-minutes`** — `branch-protection` 10, `sync-to-beta` 20, `documentation` 20, `quality` 20/30/45/60, `release-beta`/`release-stable` 45.

A caller job that uses `uses:` **cannot** declare `timeout-minutes` — it is a workflow syntax error, not an ignored key, so the workflow fails to start. Verified with actionlint 1.7.12:

```
when a reusable workflow is called with "uses", "timeout-minutes" is not available.
only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if", "permissions"
```

Adding the field to the 8 caller jobs would have taken CI from green to *invalid workflow file*.

## Verification

- `yaml.safe_load` parses the file; job set unchanged (`['sync-tokens']`); `timeout-minutes` = 15
- `actionlint` clean (exit 0)
- Diff is workflow files only, additions only (2 lines)