### PR TITLE
fix(ci): raise the php-checks bound to 30 — one bound covers six matrix legs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,12 +12,15 @@ jobs:
   php-checks:
     name: ${{ matrix.check.name }}
     runs-on: ubuntu-latest
-    # Matrix of 6 legs (PHP Lint, PHPCS, PHPMD, Psalm, PHPStan, PHPUnit). The
-    # equivalent shared PHP Quality legs were observed at max 4.0 min across
-    # 1497 executions, and the PHPUnit leg is the slow one (measured up to
-    # 18.9 min while succeeding elsewhere in the fleet). 20 min covers every
-    # leg with margin; the point is to catch a hang, not to enforce speed.
-    timeout-minutes: 20
+    # Matrix of 6 legs (PHP Lint, PHPCS, PHPMD, Psalm, PHPStan, PHPUnit). ONE
+    # job-level bound covers all six, so it has to clear the SLOWEST leg, not
+    # the average. Five of them are static analysis at max 4.0 min (shared PHP
+    # Quality, 1497 executions) — but the PHPUnit leg has been measured at
+    # 18.9 min WHILE SUCCEEDING elsewhere in the fleet, because a full PHPUnit
+    # run installs a Nextcloud server first. A 20-minute bound would leave that
+    # known-good duration only ~6% of headroom, which is exactly how a timeout
+    # turns a slow run into a phantom defect. 30 min instead.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Follow-up to ConductionNL/nldesign#202, which set `code-quality.yml` → `php-checks` to **20**. Raising it to **30**.

## Why

`php-checks` is a **6-leg matrix** (PHP Lint, PHPCS, PHPMD, Psalm, PHPStan, PHPUnit) and `timeout-minutes` is a **job-level** key — one value governs all six legs, so it has to clear the **slowest** leg, not the average.

Five legs are static analysis, observed at max 4.0 min across 1497 executions of the equivalent shared PHP Quality legs. But the **PHPUnit leg has been measured at 18.9 minutes while SUCCEEDING** (shillinq), because a real PHPUnit run installs a full Nextcloud server first.

A 20-minute bound leaves that known-good duration only **~6% of headroom**. That is precisely the failure mode this whole sweep is meant to avoid: **a timeout that fires under normal contention is worse than no timeout**, because it converts a slow run into a phantom defect. 30 min restores a sane margin.

This is a **loosening**, so it cannot newly fail anything that passes today.

Credit: the same reasoning was independently raised while bounding softwarecatalog's identical `main` matrix (ConductionNL/softwarecatalog#423, which used 30); this brings nldesign into line.

## Scope

One key changed, in one file, under `.github/workflows/`. Verified by re-parsing with `yaml.safe_load`: job set unchanged (`php-checks`, `css-quality`), matrix still 6 legs, `php-checks: 30`, `css-quality: 20`.

Branch is slash-free (`hotfix-raise-phpchecks-bound`) because the org gate admits `hotfix*` into `main`.

> Note: nldesign `main`'s PHP legs currently fail in ~0 min at `composer install` — a pre-existing, unrelated breakage documented in #202. This PR does not touch it.