### PR TITLE
fix(ci): regenerate docs/features.json so Features Check passes

### DIFF
--- a/docs/features.json
+++ b/docs/features.json
@@ -1,140 +1,137 @@
 [
   {
-    "slug": "admin-settings",
-    "title": "Admin Settings",
-    "summary": "Defines the admin settings panel for the NL Design app. The settings panel is located in Nextcloud's administration area under the Theming section. It provides controls for selecting the active token set, toggling the hide slogan feature, toggling show menu labels, and previewing the selected theme. The UI is built with vanilla PHP templates and vanilla JavaScript (no Vue or webpack). Additionally, the panel hosts the token editor for customizing individual Nextcloud CSS tokens, and triggers the theming sync dialog when a token set with theming metadata is selected.",
-    "docsUrl": "openspec/specs/admin-settings/spec.md"
-  },
-  {
-    "slug": "component-tokens",
-    "title": "Component Tokens",
-    "summary": "Introduces component-level NL Design System tokens using the `--nldesign-component-*` prefix, with a temporary bridge file that maps the current `--utrecht-*` component tokens to the nldesign namespace.",
-    "docsUrl": "openspec/specs/component-tokens/spec.md"
-  },
-  {
-    "slug": "css-architecture",
-    "title": "CSS Architecture",
-    "summary": "Defines the layered CSS architecture that transforms NL Design System tokens into Nextcloud-compatible theming.",
-    "docsUrl": "openspec/specs/css-architecture/spec.md"
-  },
-  {
-    "slug": "custom-css-overrides",
-    "title": "Custom CSS Overrides",
-    "summary": "Defines the CSS file persistence layer for user-defined token customizations.",
-    "docsUrl": "openspec/specs/custom-css-overrides/spec.md"
-  },
-  {
-    "slug": "custom-token-sets",
-    "title": "Custom Token Sets",
-    "summary": "Admins upload, validate, manage, and activate their own organization token sets (\"eigen huisstijl\"), in the app native `--nldesign-*` CSS format or the W3C Design Tokens JSON format. Backs GOVERNMENT-FEATURES F-04.",
-    "docsUrl": "openspec/specs/custom-token-sets/spec.md"
-  },
-  {
-    "slug": "docs-content",
-    "title": "docs-content",
-    "summary": "Documentation site content and structure specification.",
-    "docsUrl": "openspec/specs/docs-content/spec.md"
-  },
-  {
-    "slug": "extended-token-sets",
-    "title": "Extended Token Sets",
-    "summary": "Expands the nldesign app from 5 manually maintained token sets to all available NL Design System organization token sets (48+), using auto-generation from official upstream JSON token files.",
-    "docsUrl": "openspec/specs/extended-token-sets/spec.md"
-  },
-  {
-    "slug": "hide-slogan",
-    "title": "Hide Slogan",
-    "summary": "Defines the \"Hide Slogan\" feature that removes the Nextcloud slogan/payoff text from the login page.",
-    "docsUrl": "openspec/specs/hide-slogan/spec.md"
-  },
-  {
-    "slug": "icon-assets",
-    "title": "icon-assets",
-    "summary": "Bundles the Amsterdam Design System icon set (344 SVG icons) and organization logos (23) inside the nldesign app and exposes them to every other Nextcloud app through the standard `IURLGenerator::imagePath('nldesign', 'icons/{Name}.svg')` contract, with no nldesign-specific bootstrap required. Filenames are treated as a public API: an inventory in `img/ICONS.md` is kept in sync with the filesystem, renames are breaking changes, and the upstream MPL-2.0 license notice travels with the assets.",
-    "docsUrl": "openspec/specs/icon-assets/spec.md"
-  },
-  {
-    "slug": "menu-labels",
-    "title": "Show Menu Labels",
-    "summary": "Defines the \"Show Menu Labels\" feature that replaces app menu icons in the Nextcloud header with text labels.",
-    "docsUrl": "openspec/specs/menu-labels/spec.md"
-  },
-  {
-    "slug": "nextcloud-variable-mapping",
-    "title": "Nextcloud Variable Mapping",
-    "summary": "Provides a complete, audited mapping between all Nextcloud CSS custom properties and `--nldesign-*` design tokens, with comprehensive documentation and a defaults layer that ensures all tokens always have a value.",
-    "docsUrl": "openspec/specs/nextcloud-variable-mapping/spec.md"
-  },
-  {
-    "slug": "nl-design",
-    "title": "NL Design System Compliance — Delta Spec",
-    "summary": "Updates the existing nl-design shared spec to reflect expanded token set support and component-level tokens.",
-    "docsUrl": "openspec/specs/nl-design/spec.md"
-  },
-  {
-    "slug": "per-app-theming",
-    "title": "per-app-theming",
-    "summary": "Let an administrator exclude individual Nextcloud apps from NL Design theming. Requests rendering an excluded app's pages receive no nldesign CSS at all (stock Nextcloud styling, header included), while everything else — login, settings, and every non-excluded app — stays themed. Theming stays on by default (empty exclusion list reproduces global injection); admins opt specific apps out to roll a municipal huisstijl out incrementally or quarantine an app that breaks under theming. Backs GOVERNMENT-FEATURES F-15.",
-    "docsUrl": "openspec/specs/per-app-theming/spec.md"
-  },
-  {
-    "slug": "prometheus-metrics",
-    "title": "Prometheus Metrics Endpoint",
-    "summary": "Expose application metrics in Prometheus text exposition format at `GET /api/metrics` for monitoring, alerting, and operational dashboards.",
-    "docsUrl": "openspec/specs/prometheus-metrics/spec.md"
-  },
-  {
-    "slug": "theming-sync",
-    "title": "Theming Sync",
-    "summary": "Defines how the NL Design app synchronizes design token values with Nextcloud's built-in theming system.",
-    "docsUrl": "openspec/specs/theming-sync/spec.md"
-  },
-  {
-    "slug": "theming-sync-dialog",
-    "title": "Theming Sync Dialog",
-    "summary": "After an admin selects a different token set in nldesign, offer to automatically update Nextcloud's built-in theming values (primary color, background color, logo, background image) to match the selected token set, preventing a split-brain theming state where CSS tokens and Nextcloud theming are out of sync.",
-    "docsUrl": "openspec/specs/theming-sync-dialog/spec.md"
-  },
-  {
-    "slug": "token-editor-ui",
-    "title": "Token Editor UI",
-    "summary": "Provides a tabbed admin settings panel for browsing and editing all editable Nextcloud CSS custom properties (`--color-*`) with live preview and per-token reset controls. Changes are previewed in the browser before being committed to `custom-overrides.css`.",
-    "docsUrl": "openspec/specs/token-editor-ui/spec.md"
-  },
-  {
-    "slug": "token-import-export",
-    "title": "Token Import/Export",
-    "summary": "Allows admins to download the current `custom-overrides.css` as a portable file and upload a previously saved file to restore or share a token configuration. Only known, editable Nextcloud `--color-*` tokens are accepted on import — unknown variables are silently rejected and their count is reported.",
-    "docsUrl": "openspec/specs/token-import-export/spec.md"
+    "slug": "token-sets",
+    "title": "Dutch government token sets",
+    "summary": "Pick your organization and apply Rijkshuisstijl, VNG or 40+ gemeente house styles in one click.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/token-sets/spec.md",
+    "title_nl": "Token sets voor de Nederlandse overheid",
+    "summary_nl": "Kies je organisatie en pas de Rijkshuisstijl, VNG of 40+ gemeentehuisstijlen in een klik toe."
   },
   {
     "slug": "token-set-apply-dialog",
-    "title": "Token-Set Apply Dialog",
-    "summary": "Defines the modal dialog shown when an admin selects a new NL Design token set. The dialog shows which Nextcloud CSS variable values would change (resolved current value vs the value from the new token set), lets the admin check or uncheck individual changes, and writes only the checked values to `custom-overrides.css`. The NL Design token set CSS file itself is never applied directly.",
-    "docsUrl": "openspec/specs/token-set-apply-dialog/spec.md"
+    "title": "One-click instance theming",
+    "summary": "You re-brand your whole Nextcloud and its apps at once, login page, header and logo included.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/token-set-apply-dialog/spec.md",
+    "title_nl": "Eenmalig je hele instance huisstijlen",
+    "summary_nl": "Je geeft je hele Nextcloud en alle apps in een keer je huisstijl, inclusief loginpagina, header en logo."
   },
   {
-    "slug": "token-set-dropdown",
-    "title": "Token Set Dropdown",
-    "summary": "Replace the radio button list for token set selection with a searchable dropdown (`<select>`) that scales to 400+ entries, improving usability as the number of available token sets grows.",
-    "docsUrl": "openspec/specs/token-set-dropdown/spec.md"
+    "slug": "custom-token-sets",
+    "title": "Upload your own house style",
+    "summary": "You bring a custom brand as CSS or W3C Design Tokens JSON and the app validates it on upload.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/custom-token-sets/spec.md",
+    "title_nl": "Upload je eigen huisstijl",
+    "summary_nl": "Je brengt je eigen merk mee als CSS of W3C Design Tokens JSON en de app valideert het bij het uploaden."
   },
   {
-    "slug": "token-sets",
-    "title": "Token Sets",
-    "summary": "Defines how the NL Design app discovers, validates, stores, and serves design token sets.",
-    "docsUrl": "openspec/specs/token-sets/spec.md"
+    "slug": "token-editor-ui",
+    "title": "Token editor with live preview",
+    "summary": "You adjust a color in the browser, see it instantly and reset any token without touching the server.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/token-editor-ui/spec.md",
+    "title_nl": "Token-editor met live voorbeeld",
+    "summary_nl": "Je past een kleur aan in de browser, ziet het meteen en zet elk token terug zonder de server aan te raken."
+  },
+  {
+    "slug": "token-import-export",
+    "title": "Import and export your theme config",
+    "summary": "You download your settings, share them and restore them on another instance.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/token-import-export/spec.md",
+    "title_nl": "Importeer en exporteer je thema-instellingen",
+    "summary_nl": "Je downloadt je instellingen, deelt ze en zet ze terug op een andere instance."
+  },
+  {
+    "slug": "theming-sync",
+    "title": "Theming stays in sync",
+    "summary": "You keep token theming and Nextcloud's built-in theming from drifting apart for one coherent result.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/theming-sync/spec.md",
+    "title_nl": "Theming blijft in sync",
+    "summary_nl": "Je houdt token-theming en de ingebouwde theming van Nextcloud op een lijn, zodat het resultaat klopt."
+  },
+  {
+    "slug": "per-app-theming",
+    "title": "Per-app theming control",
+    "summary": "You roll a house style out app by app and leave any app stock while you test.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/per-app-theming/spec.md",
+    "title_nl": "Theming per app regelen",
+    "summary_nl": "Je rolt een huisstijl app voor app uit en laat elke app standaard terwijl je test."
+  },
+  {
+    "slug": "icon-assets",
+    "title": "Government icon and logo library",
+    "summary": "You reuse 344 icons and 23 logos by name in every app.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/icon-assets/spec.md",
+    "title_nl": "Bibliotheek met overheidsiconen en logo's",
+    "summary_nl": "Je hergebruikt 344 iconen en 23 logo's op naam in elke app."
+  },
+  {
+    "slug": "brand-typography",
+    "title": "Brand typography, self-hosted",
+    "summary": "Fira Sans ships inside the app, so you avoid a proprietary font and any external font fetch.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/brand-typography/spec.md",
+    "title_nl": "Merktypografie, zelf gehost",
+    "summary_nl": "Fira Sans zit in de app, dus je vermijdt een eigendomsfont en elke externe font-aanvraag."
   },
   {
     "slug": "token-sync-workflow",
-    "title": "Token Sync Workflow",
-    "summary": "Automates the synchronization of NL Design System token sets from the upstream `nl-design-system/themes` repository via a nightly GitHub Actions workflow that generates CSS token files and opens PRs when changes are detected.",
-    "docsUrl": "openspec/specs/token-sync-workflow/spec.md"
+    "title": "Stays up to date with NL Design System",
+    "summary": "A nightly sync pulls upstream token changes and proposes them to you as updates.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/token-sync-workflow/spec.md",
+    "title_nl": "Blijft up-to-date met het NL Design System",
+    "summary_nl": "Een nachtelijke sync haalt wijzigingen uit het NL Design System op en biedt ze als updates aan."
   },
   {
-    "slug": "vng-token-set",
-    "title": "VNG Token Set",
-    "summary": "Define requirements for adding VNG (Vereniging Nederlandse Gemeenten) as a selectable design token set in the nldesign Nextcloud app.",
-    "docsUrl": "openspec/specs/vng-token-set/spec.md"
+    "slug": "prometheus-metrics",
+    "title": "Health and metrics endpoints",
+    "summary": "Your hosting partner gets liveness and Prometheus metrics to monitor the deployment.",
+    "status": "stable",
+    "docsUrl": "openspec/specs/prometheus-metrics/spec.md",
+    "title_nl": "Health- en metrics-endpoints",
+    "summary_nl": "Je hostingpartner krijgt liveness en Prometheus-metrics om de installatie te monitoren."
+  },
+  {
+    "slug": "upload-contrast-check",
+    "title": "Upload-time contrast checking",
+    "summary": "The app checks color contrast when you upload a token set and warns you before you apply it.",
+    "status": "beta",
+    "docsUrl": "openspec/specs/custom-token-sets/spec.md",
+    "title_nl": "Contrastcontrole bij het uploaden",
+    "summary_nl": "De app controleert het kleurcontrast als je een token set uploadt en waarschuwt je voordat je toepast."
+  },
+  {
+    "slug": "accessibility-friendly-tokens",
+    "title": "Accessibility-friendly tokens",
+    "summary": "Token sets follow NL Design System guidance to support WCAG-aligned color and type.",
+    "status": "beta",
+    "docsUrl": "openspec/specs/nl-design/spec.md",
+    "title_nl": "Toegankelijke tokens",
+    "summary_nl": "Token sets volgen de richtlijnen van het NL Design System voor WCAG-gerichte kleur en typografie."
+  },
+  {
+    "slug": "component-tokens",
+    "title": "Component tokens",
+    "summary": "A bridge layer exposes component-level tokens today, with the native layer on the way.",
+    "status": "beta",
+    "docsUrl": "openspec/specs/component-tokens/spec.md",
+    "title_nl": "Component-tokens",
+    "summary_nl": "Een bridge-laag biedt vandaag component-tokens, de native laag komt eraan."
+  },
+  {
+    "slug": "high-contrast-mode",
+    "title": "High-contrast mode",
+    "summary": "A high-contrast token set arrives for users who need stronger color separation.",
+    "status": "soon",
+    "docsUrl": "openspec/specs/high-contrast-mode/spec.md",
+    "title_nl": "Hoog-contrastmodus",
+    "summary_nl": "Er komt een hoog-contrast token set voor gebruikers die sterkere kleurscheiding nodig hebben."
   }
 ]


### PR DESCRIPTION
## Problem

`quality / Features Check` has failed on every pull request since **2026-06-25**.

`docs/features.json` was last regenerated on 2026-06-18 (`e4f4f95a`), one week before `openspec/features.overlay.json` was added on 2026-06-25 (`2a699c8c`). The commercial overlay is the *authoritative* source for `scripts/extract-features.py`, so from that commit onward the generator has produced a different file than the one committed.

## Why it never self-healed

The push-side `Features Extract` job regenerates the file and tries to auto-commit it, but the push is rejected:

```
! [remote rejected] development -> development (push declined due to repository rule violations)
```

That failure is swallowed by `git push || echo "::warning::..."`, so the job still reports **success** while doing nothing. Tracked as ConductionNL/.github#61. Until that is fixed, `docs/features.json` must be regenerated and committed by hand whenever specs or the overlay change.

## The fix

Regenerated verbatim with `scripts/extract-features.py` from `ConductionNL/.github@main`. No generator changes, no gate disabled, no threshold relaxed.

## Verification

- Reproduced the exact CI error locally at the same SHA (`354af073`): `docs/features.json is out of date`, exit 1.
- After regeneration `--check` exits **0**.
- **Deterministic**: a second run produces a byte-identical file.
- **Positive control**: overwriting the regenerated file with `[]` makes `--check` exit 1 again, and restoring it returns exit 0 — proving the checker still reports.

Same root cause is fixed in parallel for deskdesk; nextcloud-app-template shows the identical error and is affected too.