### PR TITLE
chore(deps): upgrade @conduction/nextcloud-vue to 3.0.0-vue3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@fontsource/fira-sans": "^5.0.0"
 			},
 			"devDependencies": {
-				"@conduction/nextcloud-vue": "2.1.0-vue3.17",
+				"@conduction/nextcloud-vue": "3.0.0-vue3.4",
 				"@cyclonedx/cyclonedx-npm": "^4.2.1",
 				"@openfun/cunningham-tokens": "^3.0.0",
 				"@playwright/test": "^1.60.0",
@@ -485,9 +485,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.1.0-vue3.17",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.1.0-vue3.17.tgz",
-			"integrity": "sha512-EcKb/Gf1WEWlkjdt7HFTzjZYxNIMiOZqyGdYK69rJPYhFLIRWKdOK7b+OTEgxk37thznnDaRJRvH3Pb8fAXXpA==",
+			"version": "3.0.0-vue3.4",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.4.tgz",
+			"integrity": "sha512-+x6lUVhpoZsozAW5S20C9Y3KHhLo5+0MIqKi00lJlK+yOHuJxBoZlra7ijaY0Wk0TOs6iBdhmbGNYptJa1Pkwg==",
 			"dev": true,
 			"license": "EUPL-1.2",
 			"dependencies": {
@@ -5854,9 +5854,9 @@
 			"optional": true
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.12",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+			"integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
@@ -14719,9 +14719,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.21.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+			"version": "8.21.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+			"integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
 			"license": "MIT",
 			"optional": true,
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@gouvfr/dsfr": "^1.15.1"
 	},
 	"devDependencies": {
-		"@conduction/nextcloud-vue": "2.1.0-vue3.17",
+		"@conduction/nextcloud-vue": "3.0.0-vue3.4",
 		"@cyclonedx/cyclonedx-npm": "^4.2.1",
 		"@openfun/cunningham-tokens": "^3.0.0",
 		"@playwright/test": "^1.60.0",


### PR DESCRIPTION
## What

Pins the build-only devDependency `@conduction/nextcloud-vue` from **`2.1.0-vue3.17`** to **`3.0.0-vue3.4`** — exact pin, no caret, no tilde.

Base: `development` @ `2a27a6dbf40f35139e7a1ce391cdd4db614310a6`

## How nc-vue is consumed here (the no-op finding, with evidence)

nldesign is a **no-Vue app**. `@conduction/nextcloud-vue` never enters a runtime bundle.

**Evidence 1 — zero `.vue` files.** `find . -name '*.vue'` (excluding `node_modules`) returns **0**. Positive control: the identical command against `openregister/src` returns **206**, so the query can match. The `git ls-files` extension histogram has no `.vue` row at all (top extensions: 2635 `.svg`, 342 `.md`, 128 `.php`, 128 `.css`, 81 `.json`, 42 `.js`). `src/` contains exactly one file, `manifest.json`.

**Evidence 2 — the single consuming call site.** `scripts/build-icons.js:52-54` imports three data-URI catalogue modules and decodes them into standalone SVGs:

```js
{ kind: 'dataUri', specifier: '@conduction/nextcloud-vue/src/icons/rvo.js',           exportName: 'rvoIcons',           set: 'rvo',            ... },
{ kind: 'dataUri', specifier: '@conduction/nextcloud-vue/src/icons/openGemeenten.js', exportName: 'openGemeentenIcons', set: 'open-gemeenten', ... },
{ kind: 'dataUri', specifier: '@conduction/nextcloud-vue/src/icons/denHaag.js',       exportName: 'denHaagIcons',       set: 'den-haag',       ... },
```

Nothing under `js/` or `lib/` imports the package — a full-tree `grep -F '@conduction/nextcloud-vue'` over all tracked files returns only `package.json`, this build script, docs/specs/CHANGELOG prose, and two test files.

**Evidence 3 — the schema gate does not depend on the installed version.** `tests/validate-manifest.js:36-41` resolves the app-manifest schema with the vendored `tests/schemas/app-manifest-v2.schema.json` **ahead of** `node_modules/@conduction/nextcloud-vue/...`, so `check:manifest` is deliberately version-independent (schema v2.13.0, PASS, 0 errors).

**Evidence 4 — the committed build output is byte-identical.** This is the part that actually matters: `img/icons/` **is** checked in and **is** generated from these packs, so this bump is a build-input change, not an inert pin. Rebuilding against `3.0.0-vue3.4` reproduces the tree exactly:

| set | committed (built from 2.1.0-vue3.17) | rebuilt on 3.0.0-vue3.4 |
|---|---|---|
| rvo | 1163 | 1163 |
| open-gemeenten | 256 | 256 |
| den-haag | 69 | 69 |
| dsfr (`@gouvfr/dsfr`, unrelated to this bump) | 1038 | 1038 |

`diff -rq img/icons <rebuilt>` → **0 differing entries** across all 2526 SVGs + 77 legacy aliases. Positive control: appending `<!--canary-->` to one rebuilt SVG makes `diff -rq` report it; removing the canary restores identity — so the comparison can detect a difference.

`img/ICONS.md` regenerates with a single 40-line hunk, **entirely inside the `dsfr` sample list** (all 40 changed lines contain `dsfr`; 0 mention `rvo`, `open-gemeenten` or `den-haag`; the four `### <set> (N icons)` headings are unchanged). That hunk is an artefact of the verification harness, not of this bump: `@gouvfr/dsfr` cannot currently be npm-installed (documented upstream breakage), so the DSFR pack was staged flat from the committed `img/icons/dsfr/`, whereas the real source has category subdirectories — `listSvgFilesRecursive` therefore returns a different traversal order and the "first 20" sample differs. **No `img/` change is committed in this PR.**

## Lockfile verification (read from `package-lock.json`, not `npm ls`)

- `node_modules/@conduction/nextcloud-vue` → **`3.0.0-vue3.4`** exactly, one entry only, `dev: true`, resolved from `registry.npmjs.org/.../nextcloud-vue-3.0.0-vue3.4.tgz`.
- **`vue3-apexcharts` = `1.8.0`** — below the 1.9.0 proprietary boundary that forbids sublicensing in our EUPL-1.2 apps. `apexcharts` = 4.7.0. Both dev-only. **No override applied.**
- `overrides` is `null` — no `//` key, so no silent zero-resolution.
- 1066 packages, lockfileVersion 3, 481,890 bytes (baseline 481,893). Full diff is **10 insertions / 10 deletions**: the pin itself plus two incidental floating transitive bumps, `dompurify` 3.4.12 → 3.4.13 and `ws` 8.21.1 → 8.21.2.

Install cycle: `rm -rf package-lock.json node_modules` → `npm install` (npm 11.13.0 / node v22.22.0) → `npm install --package-lock-only` (npm 10.9.8 / node v20.20.2) → `npm ci` (npm 10.9.8).

## 3.0.0 breaking surface

The three components removed in 3.0.0 — `CnFlowCanvas`, `CnEditFlowsModal`, `CnFlowCanvasModal` — occur **0 times** across `src/ js/ lib/ templates/ css/ tests/ scripts/`.

Because this app produces no JS bundle, there is no built output to grep for nc-vue symbols. Positive control used instead: grepping the **installed** `node_modules/@conduction/nextcloud-vue` proves the symbol names are greppable and the replacement exists — `CnFlowEditModal` → **30 hits**, `CnEditFlowsModal` → 0, `CnFlowCanvasModal` → 0, `CnFlowCanvas` → 1 (a prose comment in `eslint/index.js`, not an export).

## Local gates

| gate | result |
|---|---|
| `USE_LOCAL_LIB=false npm run build` (fonts + marianne + icons) | ✅ exit 0 — 2526 icons, 4 sets, 77 aliases |
| `npm run test:unit` (vitest) | ✅ 7 files, **76/76 passed** |
| `npm run stylelint` | ✅ exit 0 |
| `npm run check:manifest` | ✅ Ajv PASS, 0 errors |
| `npm run lint` | ✅ exit 0 (script is a no-op echo — "No JavaScript to lint") |
| `npm test` | ✅ exit 0 (script is a no-op echo — "No tests yet") |
| `npm run test:l10n:completeness` | ✅ 208 keys, 36 locales, 0 missing |
| `npm run test:lasuite-tokens` / `test:lasuite-override` / `test:lasuite-bridge-coverage` | ✅ all exit 0 |
| `npm run test:l10n` | ❌ **fails — pre-existing, unrelated** (see below) |

### Pre-existing `test:l10n` failure

`test:l10n` reports one key used in source but missing from `l10n/en.json`: `"Saved. Reload to see the change."` at `js/admin.js:2829`.

Proof it pre-dates this branch:
- this branch changes **exactly two files**, `package.json` and `package-lock.json` (`git diff --name-only 2a27a6d`);
- the call site is already present at base: `git show 2a27a6d:js/admin.js | sed -n '2829p'` → `setFeedback(t('nldesign', 'Saved. Reload to see the change.'), false);`
- the key is already absent from base `l10n/en.json` (positive control: an unrelated key `"Colour picker for {label}"` is confirmed present in the same file).

Not fixed here deliberately: adding the key to `en.json` immediately breaks `test:l10n:completeness`, which requires every one of the 36 locale files to carry every `en.json` key. That is an i18n change needing 36 translations, not a drive-by fix inside a dependency pin.
