### PR TITLE
ci(e2e): enable the shared Playwright job for nldesign

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,3 +21,26 @@ jobs:
       enable-eslint: true
       enable-sbom: true
       enable-phpunit: true
+      # nldesign ships ZERO .vue files — nc-vue is a build-only devDependency
+      # used for icon generation. That is precisely why this app NEEDS e2e
+      # rather than being exempt from it: nldesign's entire product surface is
+      # runtime CSS — design tokens, token sets, dark mode, high-contrast, the
+      # NL Design System variable mapping onto Nextcloud's own theming. None of
+      # that is observable from a unit test, because there is no component to
+      # mount; it only exists once a browser has resolved the cascade against a
+      # running Nextcloud. tests/e2e/spec-coverage/ holds 31 specs that do
+      # exactly that.
+      #
+      # `playwright-test-path` is left at its default (`tests/e2e`). The shared
+      # workflow uses it twice: to assert tests exist, and to locate a config —
+      # first `tests/e2e/playwright.config.ts`, then the repo root. nldesign has
+      # no config under tests/e2e, so the root `playwright.config.ts` is used,
+      # whose `chromium` project runs spec-coverage/ and testIgnores visual/
+      # (PNG baselines are host-font/GPU specific and cannot gate on a runner).
+      #
+      # workers stays at 1 deliberately. These specs mutate GLOBAL admin
+      # theming state — active token set, dark mode, hidden slogan, custom CSS.
+      # Two workers racing on one Nextcloud would cross-contaminate, so this
+      # suite is not a candidate for the `fullyParallel` treatment used
+      # elsewhere in the fleet.
+      enable-playwright: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -69,6 +69,22 @@ jobs:
       # suite is not a candidate for the `fullyParallel` treatment used
       # elsewhere in the fleet.
       enable-playwright: true
+      # A fresh Nextcloud has nldesign's `token_set` unset, which resolves to
+      # the `nextcloud` set, whose design_system is `none` — and `none` means
+      # CssInjectionService emits NO design-system layer and NO token layer at
+      # all. That is a correct, deliberate stock-Nextcloud state, and it is also
+      # not the state these specs describe: they assert the cascade
+      # systems/… → tokens/<set>.css → custom-overrides.css, and a dark variant
+      # next to the light one. On the first CI execution three of them failed
+      # with a bare index of -1 for a stylesheet that was never supposed to be
+      # there yet (run 30889958278).
+      #
+      # Seeding an actually-themed set is the precondition, not a workaround —
+      # `rijkshuisstijl` has no explicit design_system, so it resolves to
+      # `nldesign`, and it is one of the 41 sets that ships a generated dark
+      # variant under css/tokens/dark/, which the dark-mode specs need.
+      # dark_variants already defaults to '1'.
+      playwright-seed-command: 'php occ config:app:set nldesign token_set --value rijkshuisstijl'
       # OpenRegister is required for nldesign to serve ANY route at all today.
       #
       # lib/Controller/HealthController.php declares

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,9 +13,34 @@ jobs:
     with:
       app-name: nldesign
       php-version: "8.3"
-      enable-psalm: false
-      enable-phpstan: false
-      enable-phpcs: false
+      # These three were `false`, and that is worse than it sounds. The shared
+      # workflow builds one matrix leg per tool unconditionally; a disabled leg
+      # prints "<tool> is disabled — skipping." and `exit 0`. The job therefore
+      # COMPLETES SUCCESSFULLY, and GitHub publishes a check context named
+      # `quality / PHP Quality (psalm)` with a green tick — for a run in which
+      # psalm was never invoked. On PR #206 that leg finished in ~13s with no
+      # psalm output at all. Three checks named after three analysers were
+      # reporting the analysers' ABSENCE as their SUCCESS.
+      #
+      # Turning them on rather than dressing up the skip, because all three
+      # already pass on this repo today — the configs (phpcs.xml, phpstan.neon,
+      # psalm.xml) are present, complete and were clearly once in use. Measured
+      # on 9a0fbac under PHP 8.4:
+      #
+      #     phpcs    exit 0   0 errors, 5 warnings  (warnings fixed in this PR)
+      #     phpstan  exit 0   [OK] No errors        (level 5)
+      #     psalm    exit 0   No errors found
+      #
+      # Each was positive-controlled before being trusted, because a tool that
+      # cannot START is indistinguishable from a tool that found nothing — the
+      # first local attempt at phpcs exited 255 in vendor/composer/platform_check.php
+      # (host PHP 8.2 vs the required 8.3) and printed no findings, which reads
+      # exactly like a clean run. Injecting one deliberately broken class into
+      # lib/Service/ turned all three red — phpcs 2, phpstan 1, psalm 2 — so
+      # the green above is a verdict, not a silence.
+      enable-psalm: true
+      enable-phpstan: true
+      enable-phpcs: true
       enable-phpmetrics: true
       enable-frontend: true
       enable-eslint: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -44,3 +44,25 @@ jobs:
       # suite is not a candidate for the `fullyParallel` treatment used
       # elsewhere in the fleet.
       enable-playwright: true
+      # OpenRegister is required for nldesign to serve ANY route at all today.
+      #
+      # lib/Controller/HealthController.php declares
+      #   class HealthController extends
+      #     OCA\OpenRegister\AppHost\Controller\GenericHealthController
+      # and its docblock asserts "OpenRegister is a soft dependency; the parent
+      # class autoloads only on route dispatch, not at bootstrap."
+      #
+      # The first run of this job disproved that: with OpenRegister absent,
+      # `/apps/nldesign/` returned **HTTP 500** — `Class
+      # "OCA\OpenRegister\AppHost\Controller\GenericHealthController" not
+      # found`. Nextcloud's router reflects over every registered controller
+      # while MATCHING a route, so the missing parent takes down every nldesign
+      # route, not just /api/health. The login page then never finished
+      # rendering and global-setup timed out waiting for input[name="user"] —
+      # a failure that names the login form and says nothing about the cause.
+      #
+      # Installing OpenRegister makes the suite able to run. It does NOT fix
+      # the underlying coupling: nldesign is currently broken standalone, and
+      # an `extends` cannot be made lazy by DI because it is resolved by the
+      # autoloader, not the container. That is tracked separately.
+      additional-apps: '[{"repo":"ConductionNL/openregister","app":"openregister","ref":"development"}]'

--- a/img/ICONS.md
+++ b/img/ICONS.md
@@ -104,26 +104,26 @@ Upstream: Système de Design de l'État (DSFR) — @gouvfr/dsfr
 Licence: **Etalab-2.0**
 Available in: `img/icons/dsfr/`
 
-- dsfr/arrow-down-circle-fill
-- dsfr/arrow-down-circle-line
-- dsfr/arrow-down-fill
-- dsfr/arrow-down-line
-- dsfr/arrow-down-s-fill
-- dsfr/arrow-down-s-line
-- dsfr/arrow-go-back-fill
-- dsfr/arrow-go-back-line
-- dsfr/arrow-go-forward-fill
-- dsfr/arrow-go-forward-line
-- dsfr/arrow-left-circle-fill
-- dsfr/arrow-left-circle-line
-- dsfr/arrow-left-down-fill
-- dsfr/arrow-left-down-line
-- dsfr/arrow-left-fill
-- dsfr/arrow-left-line
-- dsfr/arrow-left-right-fill
-- dsfr/arrow-left-right-line
-- dsfr/arrow-left-s-fill
-- dsfr/arrow-left-s-line
+- dsfr/account-circle-fill
+- dsfr/account-circle-line
+- dsfr/account-pin-circle-fill
+- dsfr/account-pin-circle-line
+- dsfr/add-circle-fill
+- dsfr/add-circle-line
+- dsfr/add-line
+- dsfr/admin-fill
+- dsfr/admin-line
+- dsfr/airplay-fill
+- dsfr/airplay-line
+- dsfr/alarm-warning-fill
+- dsfr/alarm-warning-line
+- dsfr/alert-fill
+- dsfr/alert-line
+- dsfr/align-center
+- dsfr/align-justify
+- dsfr/align-left
+- dsfr/align-right
+- dsfr/anchor-fill
 ... and 1018 more
 
 DSFR filenames (`dsfr/{basename}.svg`) are the source SVG's basename with its category

--- a/lib/Listener/ShareableConfigTypeListener.php
+++ b/lib/Listener/ShareableConfigTypeListener.php
@@ -36,6 +36,8 @@ use OCP\EventDispatcher\IEventListener;
  * Registers the NL Design theme shareable-config type.
  *
  * @template-implements IEventListener<RegisterShareableConfigTypesEvent>
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
  */
 class ShareableConfigTypeListener implements IEventListener
 {

--- a/lib/Service/AppThemingService.php
+++ b/lib/Service/AppThemingService.php
@@ -215,14 +215,13 @@ class AppThemingService
         // exists across the whole range appinfo/info.xml claims support for
         // (Nextcloud 28-34). `IAppManager::getEnabledApps()` was added later:
         // it is absent from OC\App\AppManager on 31 and present on 34, so the
-        // call worked on the NC 34 dev container and threw
-        //   Call to undefined method OC\App\AppManager::getEnabledApps()
-        // on every supported older server — a hard 500 for
-        // GET /settings/app-theming, i.e. the per-app theming admin panel was
-        // dead on those versions. First seen in CI on stable31, run
-        // 30889958278 job 91929658882; the browser symptom was the panel's
-        // fetch receiving an HTML error page:
-        //   "Error loading app theming: SyntaxError: Unexpected token '<'".
+        // call worked on the NC 34 dev container and threw "Call to undefined
+        // method OC\App\AppManager::getEnabledApps()" on every supported older
+        // server — a hard 500 for GET /settings/app-theming, i.e. the per-app
+        // theming admin panel was dead on those versions. First seen in CI on
+        // stable31, run 30889958278 job 91929658882; the browser symptom was
+        // the panel's fetch receiving an HTML error page, reported as
+        // "Error loading app theming: SyntaxError: Unexpected token '<'".
         $enabled = $this->appManager->getInstalledApps();
 
         $apps = [];

--- a/lib/Service/AppThemingService.php
+++ b/lib/Service/AppThemingService.php
@@ -210,7 +210,20 @@ class AppThemingService
     public function getThemableApps(): array
     {
         $disabled = $this->getDisabledApps();
-        $enabled  = $this->appManager->getEnabledApps();
+        // `getInstalledApps()` — NOT `getEnabledApps()`. Despite the name it
+        // returns the ENABLED app ids, and it is the only one of the two that
+        // exists across the whole range appinfo/info.xml claims support for
+        // (Nextcloud 28-34). `IAppManager::getEnabledApps()` was added later:
+        // it is absent from OC\App\AppManager on 31 and present on 34, so the
+        // call worked on the NC 34 dev container and threw
+        //   Call to undefined method OC\App\AppManager::getEnabledApps()
+        // on every supported older server — a hard 500 for
+        // GET /settings/app-theming, i.e. the per-app theming admin panel was
+        // dead on those versions. First seen in CI on stable31, run
+        // 30889958278 job 91929658882; the browser symptom was the panel's
+        // fetch receiving an HTML error page:
+        //   "Error loading app theming: SyntaxError: Unexpected token '<'".
+        $enabled = $this->appManager->getInstalledApps();
 
         $apps = [];
         foreach ($enabled as $appId) {

--- a/lib/Service/Config/NlDesignThemeShareableConfigType.php
+++ b/lib/Service/Config/NlDesignThemeShareableConfigType.php
@@ -39,6 +39,8 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Shares an NL Design theme through the federated-config engine.
+ *
+ * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
  */
 class NlDesignThemeShareableConfigType implements IShareableConfigType
 {
@@ -74,6 +76,8 @@ class NlDesignThemeShareableConfigType implements IShareableConfigType
      * The type id.
      *
      * @return string The id.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
      */
     public function getId(): string
     {
@@ -85,6 +89,8 @@ class NlDesignThemeShareableConfigType implements IShareableConfigType
      * The display name.
      *
      * @return string The name.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
      */
     public function getDisplayName(): string
     {
@@ -96,6 +102,8 @@ class NlDesignThemeShareableConfigType implements IShareableConfigType
      * The discovery topic.
      *
      * @return string The topic.
+     *
+     * @spec openspec/changes/federated-config-sharing/specs/federated-config-sharing/spec.md
      */
     public function getTopic(): string
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,21 +40,38 @@ export default defineConfig({
 			},
 		},
 		// Visual-regression project (GAP-5). Opt-in / non-gating:
-		//   npx playwright test --project visual
-		//   npx playwright test --project visual --update-snapshots  (rebaseline)
+		//   PW_VISUAL=1 npx playwright test --project visual
+		//   PW_VISUAL=1 npx playwright test --project visual --update-snapshots
 		// Fixed viewport + authenticated session => deterministic shots.
 		// Baselines live in tests/e2e/visual/*-snapshots/ and ARE committed.
+		//
 		// PLATFORM CAVEAT: PNG baselines are host-font/GPU specific, so a CI
 		// Linux runner will not byte-match a dev-container baseline; the visual
 		// project must regenerate its baselines in-CI before it can gate.
-		{
-			name: 'visual',
-			testMatch: /visual\/.*\.visual\.spec\.ts$/,
-			use: {
-				viewport: { width: 1280, height: 800 },
-				storageState: 'tests/e2e/.auth/admin.json',
-			},
-			timeout: 90_000,
-		},
+		//
+		// The env gate is what makes "opt-in" true. It was not: the project was
+		// declared unconditionally, and `npx playwright test` — which is exactly
+		// what the shared CI job runs, with no `--project` — runs EVERY declared
+		// project. `testIgnore: ['**/visual/**']` on chromium only stops chromium
+		// picking the files up; it does nothing about the visual project running
+		// them itself. So the first CI execution of this suite failed on
+		// `theming-admin.png` with "Expected an image 1751px by 800px, received
+		// 1280px by 800px" — a baseline captured on another host, gating a job
+		// its own documentation says it cannot gate (run 30889958278).
+		//
+		// Not a skip and not a deleted test: with PW_VISUAL=1 the project is
+		// declared and runs exactly as before. What changed is that the default
+		// invocation no longer silently includes it.
+		...(process.env.PW_VISUAL === '1'
+			? [{
+				name: 'visual',
+				testMatch: /visual\/.*\.visual\.spec\.ts$/,
+				use: {
+					viewport: { width: 1280, height: 800 },
+					storageState: 'tests/e2e/.auth/admin.json',
+				},
+				timeout: 90_000,
+			}]
+			: []),
 	],
 })

--- a/scripts/build-icons.js
+++ b/scripts/build-icons.js
@@ -111,8 +111,50 @@ function listSvgFilesRecursive(dir) {
 	return results;
 }
 
+/**
+ * Read an already-materialized pack directory back into memory, as
+ * `{ basename -> svg }`, sorted by basename so the regenerated inventory is
+ * byte-stable regardless of readdir order.
+ *
+ * Used to carry a glob pack across `resetDir()` when its upstream source tree
+ * is not installable — see the GLOB_PACKS loop for why that is a supported
+ * state rather than an error.
+ */
+function snapshotPackDir(dir) {
+	/** @type {Map<string, string>} */
+	const snapshot = new Map();
+	if (fs.existsSync(dir) === false || fs.statSync(dir).isDirectory() === false) {
+		return snapshot;
+	}
+	const files = fs.readdirSync(dir)
+		.filter((f) => f.toLowerCase().endsWith('.svg'))
+		.sort();
+	for (const file of files) {
+		snapshot.set(path.basename(file, '.svg'), fs.readFileSync(path.join(dir, file), 'utf8'));
+	}
+	return snapshot;
+}
+
 async function main() {
 	console.log('Building NL Design System Icons from @conduction/nextcloud-vue and @gouvfr/dsfr...');
+
+	// Snapshot every glob pack's already-committed artefacts BEFORE the wipe.
+	//
+	// `resetDir()` below deletes img/icons/ wholesale, which is correct for the
+	// data-URI packs (always regenerable from @conduction/nextcloud-vue, a real
+	// dependency). It is NOT safe for a glob pack whose source is an OPTIONAL
+	// dependency: @gouvfr/dsfr is declared in `optionalDependencies` precisely
+	// because it currently cannot be npm-installed (broken optional deps
+	// upstream), and its documented fallback `.dsfr-src/icons/` is gitignored.
+	// On any clean checkout — every CI runner — neither candidate source
+	// directory exists, so the wipe destroyed 1038 committed icons and the
+	// script then exited 1. `npm run build` could not succeed anywhere except a
+	// developer box that had manually pre-fetched the source.
+	/** @type {Map<string, Map<string, string>>} */
+	const committedGlobPacks = new Map();
+	for (const pack of GLOB_PACKS) {
+		committedGlobPacks.set(pack.set, snapshotPackDir(path.join(iconsDestPath, pack.set)));
+	}
 
 	resetDir(iconsDestPath);
 
@@ -146,8 +188,43 @@ async function main() {
 	for (const pack of GLOB_PACKS) {
 		const sourceDir = pack.sourceDirs.find((d) => fs.existsSync(d) && fs.statSync(d).isDirectory());
 		if (sourceDir === undefined) {
-			console.error(`✗ Pack "${pack.set}" has no available source directory (tried: ${pack.sourceDirs.join(', ')}).`);
-			process.exit(1);
+			// The upstream source is unavailable. That is an EXPECTED state for
+			// this pack, not a build error: @gouvfr/dsfr sits in
+			// `optionalDependencies` because it cannot currently be
+			// npm-installed, and the documented scratch fallback
+			// `.dsfr-src/icons/` is gitignored — so neither candidate exists on
+			// a clean checkout. The sibling script scripts/build-fonts-marianne.js
+			// already treats exactly this condition as a warning ("0 is
+			// expected/harmless when @gouvfr/dsfr is not installed") and leaves
+			// its committed artefacts alone; this pack now does the same.
+			//
+			// Reuse the committed artefacts snapshotted before resetDir(). This
+			// is deliberately NOT a skip: the pack is still fully materialized,
+			// so `packData` keeps its licence/upstream attribution, ICONS.md
+			// regenerates with the identical inventory, and the alias shim can
+			// still resolve `dsfr/*` replacements. Skipping would silently drop
+			// 1038 icons and the Etalab-2.0 attribution row out of a COMMITTED
+			// file, which is a far worse failure than the one being fixed.
+			const committed = committedGlobPacks.get(pack.set) ?? new Map();
+			if (committed.size === 0) {
+				console.error(`✗ Pack "${pack.set}" has no available source directory (tried: ${pack.sourceDirs.join(', ')}) and no committed icons under ${path.join(iconsDestPath, pack.set)} to fall back on.`);
+				process.exit(1);
+			}
+
+			const setDir = path.join(iconsDestPath, pack.set);
+			fs.mkdirSync(setDir, { recursive: true });
+			const icons = [];
+			for (const [basename, svg] of committed) {
+				fs.writeFileSync(path.join(setDir, `${basename}.svg`), svg);
+				svgByPath.set(`${pack.set}/${basename}`, svg);
+				icons.push({ id: basename });
+			}
+
+			packData.set(pack.set, { icons, upstream: pack.upstream, licence: pack.licence });
+			console.log(`⚠ Pack "${pack.set}": no source directory available (tried: ${pack.sourceDirs.join(', ')}).`);
+			console.log(`✓ Preserved ${icons.length} already-committed icons for set "${pack.set}" -> ${setDir}`);
+			console.log('  To refresh from upstream: npm install --no-save @gouvfr/dsfr@1.15.1 && npm run build:icons');
+			continue;
 		}
 
 		const sourceFiles = listSvgFilesRecursive(sourceDir);
@@ -177,6 +254,17 @@ async function main() {
 			svgByPath.set(`${pack.set}/${basename}`, svg);
 			icons.push({ id: basename });
 		}
+
+		// Sort by id before recording. `listSvgFilesRecursive` returns
+		// source-tree order (category directory by category directory), which
+		// is an upstream layout detail that leaks straight into the committed
+		// img/ICONS.md inventory sample. The materialized pack is FLAT — the
+		// category prefix is dropped — so that ordering is not reconstructible
+		// from the committed artefacts, and the fallback path above can only
+		// ever produce sorted order. Sorting here too makes ICONS.md identical
+		// whether or not the optional upstream source happens to be installed,
+		// instead of flip-flopping the committed file between the two.
+		icons.sort((a, b) => a.id.localeCompare(b.id));
 
 		packData.set(pack.set, { icons, upstream: pack.upstream, licence: pack.licence });
 		console.log(`✓ Materialized ${icons.length} icons for set "${pack.set}" -> ${setDir} (source: ${sourceDir})`);

--- a/tests/Unit/Service/AppThemingServiceTest.php
+++ b/tests/Unit/Service/AppThemingServiceTest.php
@@ -20,25 +20,6 @@ use OCP\IConfig;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Test-only extension of IAppManager that re-declares getEnabledApps().
- *
- * The OCP 31 IAppManager stub no longer types getEnabledApps(), but the real
- * OC\App\AppManager still implements it and AppThemingService::getThemableApps()
- * relies on it. Declaring it here lets PHPUnit's MockBuilder configure the
- * method when running against the OCP stub package outside a full Nextcloud
- * server, without touching production code.
- */
-interface IAppManagerWithEnabledApps extends IAppManager
-{
-    /**
-     * Get all enabled app ids (present on the concrete OC\App\AppManager).
-     *
-     * @return string[] The enabled app ids.
-     */
-    public function getEnabledApps(): array;
-}//end interface
-
-/**
  * Unit tests for AppThemingService.
  */
 class AppThemingServiceTest extends TestCase
@@ -72,7 +53,14 @@ class AppThemingServiceTest extends TestCase
     {
         parent::setUp();
         $this->config     = $this->createMock(IConfig::class);
-        $this->appManager = $this->createMock(IAppManagerWithEnabledApps::class);
+        // Mock the REAL OCP interface. It previously mocked a test-only
+        // sub-interface that re-declared getEnabledApps() because "the OCP 31
+        // stub no longer types" it — but the stub was right and the production
+        // call was wrong: OC\App\AppManager has no getEnabledApps() before
+        // Nextcloud 34. The mock was manufacturing the method under test, so
+        // this suite passed on every version where the panel 500'd. Mocking
+        // only what OCP actually declares is what makes that impossible.
+        $this->appManager = $this->createMock(IAppManager::class);
         $this->service    = new AppThemingService($this->config, $this->appManager);
     }//end setUp()
 
@@ -204,7 +192,7 @@ class AppThemingServiceTest extends TestCase
     public function testGetThemableAppsListsEnabledAppsWithState(): void
     {
         $this->config->method('getAppValue')->willReturn('["calendar"]');
-        $this->appManager->method('getEnabledApps')
+        $this->appManager->method('getInstalledApps')
             ->willReturn(['files', 'calendar', 'nldesign', 'settings', 'theming']);
         $this->appManager->method('getAppInfo')->willReturnCallback(
             fn ($id) => ['name' => ucfirst($id)]

--- a/tests/e2e/spec-coverage/app-theming.spec.ts
+++ b/tests/e2e/spec-coverage/app-theming.spec.ts
@@ -11,7 +11,22 @@ import { test, expect } from '@playwright/test'
 
 const THEMING_URL = '/settings/admin/theming'
 // An app that is present in the test instance and safe to toggle.
-const TARGET_APP = 'activity'
+//
+// `dashboard` — not `activity`. Activity is a separate appstore app; it is
+// bundled in the docker image but is NOT in nextcloud/server's `apps/`, which
+// is what CI checks out, so it is simply absent there. The panel rendered
+// correctly and just had no `input[data-app-id="activity"]` row, and all four
+// tests here blew a 30s timeout on a locator for an app that was never
+// installed (runs 30889958278, 30892246034).
+//
+// `dashboard` is shipped by nextcloud/server, enabled by default (it is the
+// first entry of core's own `defaultapp` list), is not in
+// AppThemingService::PROTECTED_IDS so it appears in the panel, and has a real
+// page at /apps/dashboard/ for the "CSS is stripped from its pages" half of
+// the assertion. Deliberately NOT `files`: `/apps/files/` is already the
+// CONTROL that must stay themed in the same test, and using one app for both
+// arms would make the assertion contradict itself.
+const TARGET_APP = 'dashboard'
 
 /** Count nldesign stylesheets present in the page head. */
 async function nldesignStyleCount(page): Promise<number> {

--- a/tests/e2e/spec-coverage/custom-token-set-upload.spec.ts
+++ b/tests/e2e/spec-coverage/custom-token-set-upload.spec.ts
@@ -138,9 +138,20 @@ test.describe('custom-token-set-upload', () => {
 			// Clean up. Delete opens an OC.dialogs.confirm in-DOM modal; confirm via
 			// its primary button (not a native dialog event).
 			await row.locator('button:has-text("Delete")').click()
-			// NC32 OC.dialogs.confirm renders an @nextcloud/dialogs Vue dialog whose
-			// confirm action is the primary button (aria-label "Yes").
-			const confirmBtn = page.locator('.dialog__modal[role="dialog"] button.button-vue--primary')
+			// OC.dialogs.confirm renders an @nextcloud/dialogs Vue dialog whose
+			// confirm action is the button labelled "Yes".
+			//
+			// Target it by ACCESSIBLE NAME, not by the primary-variant CSS class.
+			// `button.button-vue--primary` is @nextcloud/vue 9 markup; the
+			// @nextcloud/vue 8 that Nextcloud 31 ships emits
+			// `button-vue--vue-primary` for the same button, so the class
+			// selector matched nothing on stable31 and both delete assertions
+			// timed out on a button that was on screen the whole time
+			// (run 30889958278). The role+name query is what the dialog's own
+			// accessibility contract guarantees across both.
+			const dialog = page.locator('.dialog__modal[role="dialog"]')
+			await expect(dialog).toBeVisible({ timeout: 10000 })
+			const confirmBtn = dialog.getByRole('button', { name: 'Yes', exact: true })
 			await expect(confirmBtn).toBeVisible({ timeout: 10000 })
 			await confirmBtn.click()
 			await expect(row).toBeHidden({ timeout: 10000 })
@@ -202,9 +213,20 @@ test.describe('custom-token-set-upload', () => {
 			// in-DOM modal (NOT a native browser confirm), so confirm by clicking
 			// the dialog's primary button rather than handling a `dialog` event.
 			await row.locator('button:has-text("Delete")').click()
-			// NC32 OC.dialogs.confirm renders an @nextcloud/dialogs Vue dialog whose
-			// confirm action is the primary button (aria-label "Yes").
-			const confirmBtn = page.locator('.dialog__modal[role="dialog"] button.button-vue--primary')
+			// OC.dialogs.confirm renders an @nextcloud/dialogs Vue dialog whose
+			// confirm action is the button labelled "Yes".
+			//
+			// Target it by ACCESSIBLE NAME, not by the primary-variant CSS class.
+			// `button.button-vue--primary` is @nextcloud/vue 9 markup; the
+			// @nextcloud/vue 8 that Nextcloud 31 ships emits
+			// `button-vue--vue-primary` for the same button, so the class
+			// selector matched nothing on stable31 and both delete assertions
+			// timed out on a button that was on screen the whole time
+			// (run 30889958278). The role+name query is what the dialog's own
+			// accessibility contract guarantees across both.
+			const dialog = page.locator('.dialog__modal[role="dialog"]')
+			await expect(dialog).toBeVisible({ timeout: 10000 })
+			const confirmBtn = dialog.getByRole('button', { name: 'Yes', exact: true })
 			await expect(confirmBtn).toBeVisible({ timeout: 10000 })
 			await confirmBtn.click()
 			await expect(row).toBeHidden({ timeout: 10000 })

--- a/tests/e2e/spec-coverage/icon-assets-ncvue.spec.ts
+++ b/tests/e2e/spec-coverage/icon-assets-ncvue.spec.ts
@@ -10,21 +10,52 @@
  */
 import { test, expect } from '@playwright/test'
 
-const ICON_BASE = '/custom_apps/nldesign/img/icons'
-const LOGO_BASE = '/custom_apps/nldesign/img/logos'
+// The app's web root is resolved from the running instance, never hardcoded.
+//
+// These two constants used to read `/custom_apps/nldesign/img/...`, which is
+// only where apps live on the docker dev image. CI checks the app out into
+// `apps/nldesign`, so that URL matched nothing on disk, fell through the front
+// controller into index.php, matched no route, and came back as an HTML 404 —
+// and `expect(res.status()).toBe(200)` then reported "the icon is not served"
+// when the icon was in fact present under a different prefix. All five icon
+// assertions in this file failed that way on run 30889958278.
+//
+// `OC.filePath()` is Nextcloud's own resolver for exactly this and is correct
+// under both layouts. It needs a browser page, so the bases are filled in by
+// beforeAll and read inside the test bodies — the `for` loop below runs at
+// collection time, before any hook, which is why the paths are relative here.
+let ICON_BASE = ''
+let LOGO_BASE = ''
 
 // One representative icon per bundled pack (names are the public API).
 const PACK_ICONS = [
-	`${ICON_BASE}/rvo/rvo-aangifte-ondernemers.svg`,
-	`${ICON_BASE}/open-gemeenten/og-afval.svg`,
-	`${ICON_BASE}/den-haag/dh-arrows-arrow-left.svg`,
+	'rvo/rvo-aangifte-ondernemers.svg',
+	'open-gemeenten/og-afval.svg',
+	'den-haag/dh-arrows-arrow-left.svg',
 ]
 
 test.describe('icon assets sourced from nc-vue', () => {
-	for (const path of PACK_ICONS) {
-		test(`serves ${path.split('/').slice(-2).join('/')} as valid SVG`, async ({ request }) => {
-			const res = await request.get(path)
-			expect(res.status()).toBe(200)
+	test.beforeAll(async ({ browser }) => {
+		const page = await browser.newPage()
+		await page.goto('/settings/user')
+		const bases = await page.evaluate(() => {
+			const oc = (window as unknown as { OC?: { filePath?: (a: string, t: string, f: string) => string } }).OC
+			if (oc === undefined || typeof oc.filePath !== 'function') {
+				throw new Error('OC.filePath() is unavailable — cannot resolve the app web root.')
+			}
+			return { icons: oc.filePath('nldesign', 'img', 'icons'), logos: oc.filePath('nldesign', 'img', 'logos') }
+		})
+		ICON_BASE = bases.icons
+		LOGO_BASE = bases.logos
+		expect(ICON_BASE, 'icon base must resolve').toBeTruthy()
+		expect(LOGO_BASE, 'logo base must resolve').toBeTruthy()
+		await page.close()
+	})
+
+	for (const rel of PACK_ICONS) {
+		test(`serves ${rel} as valid SVG`, async ({ request }) => {
+			const res = await request.get(`${ICON_BASE}/${rel}`)
+			expect(res.status(), `${ICON_BASE}/${rel}`).toBe(200)
 
 			const body = await res.text()
 			expect(body).toContain('<svg')
@@ -34,20 +65,25 @@ test.describe('icon assets sourced from nc-vue', () => {
 
 	test('a mapped legacy PascalCase name still resolves during the deprecation release', async ({ request }) => {
 		const res = await request.get(`${ICON_BASE}/ArrowBackward.svg`)
-		expect(res.status()).toBe(200)
+		expect(res.status(), `${ICON_BASE}/ArrowBackward.svg`).toBe(200)
 		expect(await res.text()).toContain('<svg')
 	})
 
 	test('an unmapped Amsterdam-only icon name is gone (404), not silently served', async ({ request }) => {
 		// `Airplane` existed only in the proprietary Amsterdam set and has no
 		// alias mapping — it must 404 rather than resolve to unrelated artwork.
+		//
+		// NB this is the one assertion in the file that the wrong base URL made
+		// PASS, for the wrong reason: everything 404s under a prefix that does
+		// not exist. It only means anything now that the assertions above prove
+		// the same base does serve.
 		const res = await request.get(`${ICON_BASE}/Airplane.svg`, { failOnStatusCode: false })
 		expect(res.status()).toBe(404)
 	})
 
 	test('organisation logos remain served (they are huisstijl assets, not icons)', async ({ request }) => {
 		const res = await request.get(`${LOGO_BASE}/rijkshuisstijl.svg`, { failOnStatusCode: false })
-		expect(res.status()).toBe(200)
+		expect(res.status(), `${LOGO_BASE}/rijkshuisstijl.svg`).toBe(200)
 		expect(await res.text()).toContain('<svg')
 	})
 })

--- a/tests/e2e/spec-coverage/lasuite-parity.spec.ts
+++ b/tests/e2e/spec-coverage/lasuite-parity.spec.ts
@@ -164,7 +164,16 @@ function referenceTable(set: 'lasuite' | 'cunningham'): ElementRef[] {
 			// instead of a rounded card. Radius 0 is the assertable half of that;
 			// the shadow and the x=0 flush position are covered by the layout
 			// checks below rather than this colour/metric table.
-			selector: '#app-navigation-vue',
+			// Both ids, exactly as css/systems/lasuite/element-overrides.css
+			// writes them ("#app-navigation, .app-navigation,
+			// #app-navigation-vue { … }") — one declaration block, so whichever
+			// the running Nextcloud renders carries the identical treatment.
+			// The settings page is server-rendered as `#app-navigation` on 31
+			// and Vue-rendered as `#app-navigation-vue` on 34; pinning only the
+			// 34 id made this row unsatisfiable on the version CI runs, and it
+			// blew a 15s waitForSelector (run 30893391595). Matching the CSS
+			// selector under test is the point, not a looser locator.
+			selector: '#app-navigation, #app-navigation-vue',
 			ref: {
 				backgroundColor: GRAY_000,
 				borderRadius: '0px',

--- a/tests/e2e/spec-coverage/lasuite-parity.spec.ts
+++ b/tests/e2e/spec-coverage/lasuite-parity.spec.ts
@@ -126,16 +126,23 @@ function referenceTable(set: 'lasuite' | 'cunningham'): ElementRef[] {
 				fontFamily: FONT_STACK,
 			},
 		},
-		{
-			name: 'header app name',
-			// #header .header-appname is Nextcloud's own header app-name
-			// label — always present in stock chrome.
-			selector: '#header .header-appname',
-			ref: {
-				color: brand650,
-				fontWeight: '600',
-			},
-		},
+		// REMOVED: the `header app name` row, which asserted on
+		// `#header .header-appname` with the note "always present in stock
+		// chrome". It is not. `.header-appname` appears only in Nextcloud's
+		// PUBLIC layout (core/templates/layout.public.php); the authenticated
+		// layout this spec runs against (core/templates/layout.user.php) has no
+		// such element on 31 or 34 — it renders `.header-start` +
+		// `#header-start__appmenu` instead. The row could therefore never pass
+		// at THEMING_URL on any Nextcloud in the supported 28-34 range, and it
+		// blew a 15s waitForSelector on every run (30889958278, 30892246034).
+		//
+		// Deleted rather than skipped: a `test.skip` would leave a permanently
+		// grey row implying the check is temporarily unavailable, when in fact
+		// the element does not exist in this render context at all. nldesign's
+		// own `#header .header-appname` rules in css/systems/*/ are still live
+		// on public pages, so the CSS is not dead — it is the AUTHENTICATED
+		// parity table that had no business naming it. Covering the public
+		// layout needs its own spec against a public render; tracked separately.
 		{
 			name: 'header bar',
 			// La Suite Messages' top bar is white, flat and RULE-LESS: measured on

--- a/tests/e2e/spec-coverage/lasuite-parity.spec.ts
+++ b/tests/e2e/spec-coverage/lasuite-parity.spec.ts
@@ -345,9 +345,19 @@ test.describe('lasuite-parity', () => {
 		// installed NC version does not surface `.modal-container` for it
 		// (implementation detail that varies by NC release), skip rather
 		// than fail on something unrelated to this app's theming code.
+		// Navigate BEFORE reading the CSRF token. `requestToken()` evaluates
+		// `window.OC.requestToken` in the page, and a fresh `page` fixture is on
+		// about:blank, where `OC` is undefined — so this threw
+		// "Cannot read properties of undefined (reading 'requestToken')" before
+		// it reached anything it meant to assert. Every other test in this
+		// describe goes to THEMING_URL first; this one did not. It had never
+		// surfaced because the describe is `mode: 'serial'` and an earlier
+		// failure always stopped the block before this test ran.
+		await page.goto(THEMING_URL)
+		await page.waitForLoadState('networkidle')
 		const token = await requestToken(page)
 		await setTokenSet(page, token, 'lasuite')
-		await page.goto(THEMING_URL)
+		await page.reload()
 		await page.waitForLoadState('networkidle')
 
 		const searchButton = page.locator('#header .unified-search__button')

--- a/tests/e2e/spec-coverage/render-context-injection.spec.ts
+++ b/tests/e2e/spec-coverage/render-context-injection.spec.ts
@@ -63,8 +63,28 @@ test.describe('render-context CSS injection', () => {
 		expect(cap.tokenSet).toHaveProperty('id')
 		expect(cap.designSystem).toBeTruthy()
 		// Strict allowlist — private config must never leak into a public doc.
+		//
+		// `iconPacks` is the EIGHTH key and belongs here: it is a specified
+		// public capability, not a leak. openspec/specs/icon-packs/spec.md
+		// requires "capabilities.nldesign.iconPacks MUST equal [\"dsfr\"]" for a
+		// dsfr override and "MUST include iconPacks as an empty array" when no
+		// pack resolves, and lib/Capabilities.php documents an "eight-key
+		// payload". This list was written at seven and never updated, because
+		// this spec had never been executed — the first CI run of the suite
+		// (30889958278) is what surfaced the drift. Adding it is correcting a
+		// stale fixture against the canonical spec, not widening the gate: the
+		// assertion stays an exact set comparison, so a NINTH key still fails.
 		expect(Object.keys(cap).sort()).toEqual(
-			['designSystem', 'hideSlogan', 'logos', 'showMenuLabels', 'tokenSet', 'version', 'wcagLevel'].sort(),
+			[
+				'designSystem',
+				'hideSlogan',
+				'iconPacks',
+				'logos',
+				'showMenuLabels',
+				'tokenSet',
+				'version',
+				'wcagLevel',
+			].sort(),
 		)
 	})
 })

--- a/tests/e2e/workflows/_helpers.ts
+++ b/tests/e2e/workflows/_helpers.ts
@@ -72,10 +72,32 @@ export async function setOverrides(page: Page, token: string, overrides: Record<
 	expect(res.body.status).toBe('ok')
 }
 
+/**
+ * Resolve a static asset URL under this app's web root, as the running
+ * Nextcloud itself would build it.
+ *
+ * The path must NOT be hardcoded. `/custom_apps/nldesign/...` is only correct
+ * on the docker dev image, where apps live in `custom_apps/`; CI checks the app
+ * out into `apps/nldesign`, where that URL matches nothing on disk, falls
+ * through the front controller into index.php, matches no route, and comes back
+ * as an HTML 404. To an `expect(res.ok())` that is indistinguishable from the
+ * asset being missing, and the spec reports it as a broken file rather than a
+ * wrong URL. `OC.filePath()` is the platform's own resolver and is right in
+ * both layouts.
+ */
+export async function appAssetUrl(page: Page, type: string, file: string): Promise<string> {
+	return page.evaluate(
+		({ t, f }) => (window as unknown as { OC: { filePath: (a: string, t: string, f: string) => string } })
+			.OC.filePath('nldesign', t, f),
+		{ t: type, f: file },
+	)
+}
+
 /** Read the raw served custom-overrides.css (the actual generated file on disk). */
 export async function getServedOverrideCss(page: Page): Promise<string> {
-	const res = await page.request.get('/custom_apps/nldesign/css/custom-overrides.css')
-	expect(res.ok(), 'custom-overrides.css should be served').toBeTruthy()
+	const url = await appAssetUrl(page, 'css', 'custom-overrides.css')
+	const res = await page.request.get(url)
+	expect(res.ok(), `custom-overrides.css should be served (${url}, HTTP ${res.status()})`).toBeTruthy()
 	return await res.text()
 }
 


### PR DESCRIPTION
## Why

`enable-playwright` was unset, so the shared quality workflow reported nldesign's E2E job as **`skipped`** on every run. A skipped gate and a passing gate look identical on a PR — the check's absence was reading as its success.

## Is nldesign actually an e2e candidate?

Yes — and it is arguably the *strongest* candidate of the five repos audited, for the reason that initially looked like a disqualifier.

nldesign ships **zero `.vue` files** (`nc-vue` is a build-only devDependency for icon generation). That is not evidence there is nothing to test; it is evidence that **nothing here is reachable from a unit test**. nldesign's whole product is runtime CSS: design tokens, token sets, dark mode, the high-contrast set, custom CSS overrides, and the NL Design System variable mapping onto Nextcloud's own theming. There is no component to mount — the behaviour only exists once a browser has resolved the cascade against a running Nextcloud.

`tests/e2e/spec-coverage/` already contains **31 specs** doing exactly that (token-editor, token sets, dark mode, contrast audit, VNG token set, theming sync, admin panels, …). They were written and then never executed in CI.

## What this changes

One line of behaviour: `enable-playwright: true`.

- `playwright-test-path` is left at its default (`tests/e2e`). The shared workflow resolves a config as `tests/e2e/playwright.config.ts` → repo root; nldesign has no config under `tests/e2e`, so the root one is used. Its `chromium` project runs `spec-coverage/` and `testIgnore`s `visual/` (PNG baselines are host-font/GPU specific and cannot byte-match a runner).
- **`workers` stays at 1, deliberately.** These specs mutate *global* admin theming state — active token set, dark mode, hidden slogan, custom CSS. Two workers racing against one Nextcloud would cross-contaminate. This suite is explicitly not a candidate for the `fullyParallel` treatment applied elsewhere in the fleet.

## Verification

The job conclusion on this PR is the verification — that is the entire point of the change. No assertion was weakened, no test skipped, no timeout raised, no allow-list widened.