### PR TITLE
fix(apphost): stop one cross-app `extends` from 500ing every nldesign route

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -55,13 +55,19 @@ class Application extends App implements IBootstrap
      * Register services and providers.
      *
      * No bootstrap-time service registration is required for health: the
-     * `/api/health` endpoint is served by the thin `Controller\HealthController`
-     * subclass of the OpenRegister AppHost engine's GenericHealthController
-     * (ADR-040). The subclass is autoloaded only when the route is dispatched,
-     * never at bootstrap, so OpenRegister is a SOFT/optional dependency for
-     * health only — Nextcloud still boots and nldesign still themes when
-     * OpenRegister is absent (a request to /api/health would then degrade
-     * rather than fatal the app). The declarative checks live in
+     * `/api/health` endpoint is served by `Controller\HealthController`, which
+     * adopts the OpenRegister AppHost observability engine by COMPOSITION
+     * (ADR-040) — it resolves the engine out of the DI container by FQCN
+     * string at dispatch time and never names an OpenRegister class in a
+     * position the autoloader must resolve. OpenRegister is therefore a
+     * SOFT/optional dependency for health only: Nextcloud still boots,
+     * nldesign still themes, and every nldesign route still resolves when
+     * OpenRegister is absent — /api/health then degrades to
+     * `status: degraded` at HTTP 200 rather than 500ing the app. (It must NOT
+     * go back to `extends GenericHealthController`: NC's router
+     * ReflectionClass()es every file in lib/Controller/ while MATCHING any
+     * route, so an unresolvable parent 500s EVERY route — decidesk#377.)
+     * The declarative checks live in
      * `src/manifest.json` and use only the OR-independent primitives
      * (database, filesystem, appEnabled) — never orAvailable, and no OR-object
      * metrics. The `Capabilities` class IS registered here — it is the app's
@@ -93,8 +99,8 @@ class Application extends App implements IBootstrap
         // can be constructed by another app's dispatcher. Mirrors hermiq.
         include_once __DIR__.'/../../vendor/autoload.php';
 
-        // Health endpoint served by the thin Controller\HealthController
-        // subclass of the AppHost engine — no explicit registration needed.
+        // Health endpoint served by Controller\HealthController, which drives
+        // the AppHost engine by composition — no explicit registration needed.
         // Public huisstijl capability — see lib/Capabilities.php.
         $context->registerCapability(Capabilities::class);
 

--- a/lib/Controller/HealthController.php
+++ b/lib/Controller/HealthController.php
@@ -3,21 +3,27 @@
 /**
  * NL Design Health Controller.
  *
- * Thin subclass of the OpenRegister AppHost engine's GenericHealthController
- * (ADR-040). nldesign is a pure NL Design theme app with NO OpenRegister
- * dependency, so the engine is a SOFT/optional dependency wired here ONLY for
- * the health endpoint: this class is autoloaded solely when the `/api/health`
- * route is dispatched, never at Nextcloud bootstrap, so Nextcloud still boots
- * and nldesign still themes when OpenRegister is absent (a request to
- * /api/health would then surface a degraded 5xx instead of fatalling the app).
+ * AppHost adopter by COMPOSITION, not inheritance: the OpenRegister AppHost
+ * observability engine is resolved lazily out of the DI container by FQCN
+ * string, and its result is rendered as the ADR-006
+ * `{status, app, version, checks}` envelope. Health-check execution, the
+ * status-code policy and the CORS decision come from the engine (declared in
+ * the `observability.health` block of `src/manifest.json`); the envelope and
+ * the OpenRegister-absent fallback are owned here.
  *
- * All logic — executing the declarative `observability.health` checks from
- * src/manifest.json and rendering the ADR-006 {status, app, version, checks}
- * envelope — lives in the engine. The checks declared in the manifest use only
- * the OR-independent primitives (database, filesystem, appEnabled); this app
- * never declares orAvailable or OR-object metrics. The public auth posture
- * (#[PublicPage] + #[NoCSRFRequired]) and the response contract are owned by
- * the engine's index() method and cannot drift here.
+ * ⚠️ This class MUST NOT `extends` — nor name in any resolved position — a
+ * class from another app. Nextcloud's router `ReflectionClass()`es every file
+ * in `lib/Controller/` while MATCHING a route, so an unresolvable parent makes
+ * EVERY route in nldesign return HTTP 500, not just this one. `extends` is
+ * resolved by the autoloader, not the container, so no amount of lazy DI
+ * registration can rescue it. nldesign does not declare
+ * `<app>openregister</app>` in appinfo/info.xml, so the parent was
+ * unresolvable on any instance without OpenRegister. See decidesk#377 /
+ * decidesk#388.
+ *
+ * The checks declared in the manifest use only the OR-independent primitives
+ * (database, filesystem, appEnabled); this app never declares orAvailable or
+ * OR-object metrics.
  *
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
@@ -36,27 +42,77 @@ declare(strict_types=1);
 
 namespace OCA\NLDesign\Controller;
 
-use OCA\OpenRegister\AppHost\Controller\GenericHealthController;
+use OCA\NLDesign\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use Psr\Container\ContainerInterface;
 
 /**
- * NlDesign health endpoint — engine-owned, declarative.
+ * NlDesign health endpoint — engine-driven, declarative.
  *
- * @psalm-suppress UndefinedClass — OpenRegister is a soft dependency; the
- *   parent class autoloads only on route dispatch, not at bootstrap.
+ * The engine collaborators are pulled from the container by FQCN string at
+ * dispatch time, so nldesign never binds an OpenRegister class at
+ * class-declaration time.
  *
  * @spec openspec/changes/adopt-apphost-2026-06-16/tasks.md#task-3
  */
-class HealthController extends GenericHealthController
+class HealthController extends Controller
 {
+
+    /**
+     * FQCN of the AppHost observability manifest loader.
+     *
+     * Referenced as a string, never imported: the class only exists when
+     * openregister is installed.
+     *
+     * @var string
+     */
+    private const MANIFEST_LOADER = 'OCA\\OpenRegister\\AppHost\\Observability\\ManifestLoader';
+
+    /**
+     * FQCN of the AppHost declarative health-check executor.
+     *
+     * Referenced as a string, never imported: the class only exists when
+     * openregister is installed.
+     *
+     * @var string
+     */
+    private const HEALTH_EXECUTOR = 'OCA\\OpenRegister\\AppHost\\Observability\\HealthCheckExecutor';
+
+    /**
+     * Constructor.
+     *
+     * @param IRequest           $request   The request object.
+     * @param IConfig            $config    The Nextcloud config service (fallback version).
+     * @param ContainerInterface $container DI container — resolves the AppHost engine lazily.
+     *
+     * @return void
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly IConfig $config,
+        private readonly ContainerInterface $container
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+
+    }//end __construct()
+
     /**
      * GET /api/health — declarative health check (ADR-006).
      *
-     * Delegates entirely to the engine. The auth posture is re-declared here
-     * so it is statically visible at nldesign's route, but it matches and
-     * cannot widen the engine contract.
+     * Runs the manifest-declared checks through the AppHost engine and renders
+     * the `{status, app, version, checks}` envelope with the status code the
+     * engine's policy resolved. CORS headers are emitted only when the
+     * manifest opts in, exactly as the engine does.
+     *
+     * When the AppHost engine cannot be resolved — openregister absent or
+     * disabled — the endpoint still answers (the whole point of a health
+     * probe): `status: degraded`, `checks.openregister: unavailable`, HTTP 200.
      *
      * @return JSONResponse `{status, app, version, checks}`.
      *
@@ -66,6 +122,64 @@ class HealthController extends GenericHealthController
     #[NoCSRFRequired]
     public function index(): JSONResponse
     {
-        return parent::index();
+        $engine = $this->engineResult();
+        if ($engine === null) {
+            return new JSONResponse(
+                [
+                    'status'  => 'degraded',
+                    'app'     => $this->appName,
+                    'version' => $this->config->getAppValue(Application::APP_ID, 'installed_version', ''),
+                    'checks'  => ['openregister' => 'unavailable'],
+                ],
+                Http::STATUS_OK
+            );
+        }
+
+        $response = new JSONResponse(
+            [
+                'status'  => $engine['status'],
+                'app'     => $this->appName,
+                'version' => $engine['version'],
+                'checks'  => $engine['checks'],
+            ],
+            $engine['httpStatus']
+        );
+
+        if ($engine['cors'] === true) {
+            $response->addHeader('Access-Control-Allow-Origin', '*');
+            $response->addHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+        }
+
+        return $response;
+
     }//end index()
+
+    /**
+     * Run the AppHost observability engine for this app.
+     *
+     * @return array{status: string, version: string, checks: array<string, string>, httpStatus: int, cors: bool}|null
+     *         Null when the engine is unavailable (openregister absent/disabled).
+     */
+    private function engineResult(): ?array
+    {
+        try {
+            $manifestLoader = $this->container->get(self::MANIFEST_LOADER);
+            $executor       = $this->container->get(self::HEALTH_EXECUTOR);
+
+            $appId    = $this->appName;
+            $manifest = $manifestLoader->load(appId: $appId);
+            $result   = $executor->execute(manifest: $manifest);
+
+            return [
+                'status'     => (string) $result->status,
+                'version'    => (string) $manifestLoader->appVersion(appId: $appId),
+                'checks'     => (array) $result->checks,
+                'httpStatus' => (int) $result->httpStatusCode,
+                'cors'       => ($manifest->cors === true),
+            ];
+        } catch (\Throwable $e) {
+            return null;
+        }//end try
+
+    }//end engineResult()
 }//end class


### PR DESCRIPTION
## The defect

`lib/Controller/HealthController.php` did `extends OCA\OpenRegister\AppHost\Controller\GenericHealthController`.

Nextcloud's router `ReflectionClass()`es **every file in `lib/Controller/`** while *matching* a route (`Router::findMatchingRoute()` → `loadRoutes()` → `loadAttributeRoutes()` → `getAttributeRoutes()` → `new ReflectionClass()`). One unresolvable parent therefore makes **every nldesign route return HTTP 500** — not just `/api/health`.

nldesign does **not** declare `<app>openregister</app>` in `appinfo/info.xml`, so the parent is unresolvable on any instance without OpenRegister.

**Lazy DI cannot fix this.** `extends` is resolved by the **autoloader**, not the container.

Adding `<app>openregister</app>` is deliberately *not* the fix — decidesk#388 rejected it, because it makes `occ app:enable` fail instead of making the app work.

## The fix — composition, not inheritance

`HealthController` now `extends OCP\AppFramework\Controller` and pulls `ManifestLoader` / `HealthCheckExecutor` out of the DI container **by FQCN string** (`private const`) at dispatch time. No OpenRegister class is named in any position the autoloader must resolve.

Behaviour when openregister **is** installed is unchanged:

| Inherited from the generic | Now |
|---|---|
| `#[PublicPage]` | declared explicitly |
| `#[NoCSRFRequired]` | declared explicitly |
| body `{status, app, version, checks}` | reproduced field-for-field |
| HTTP code = `$result->httpStatusCode` | reproduced |
| `Access-Control-Allow-Origin: *` + `Allow-Methods: GET, OPTIONS` when `manifest.cors === true` | reproduced, same condition |

**Degrade, don't 500:** with the engine unresolvable the endpoint still answers — the whole point of a health probe — `status: degraded`, `checks: {openregister: unavailable}`, HTTP 200.

`lib/AppInfo/Application.php` docblock/comment corrected (they described the deleted subclass) and now carry the "do not simplify this back into a subclass" warning with the router/autoloader reason.

`MetricsController` is nldesign's own (already OCP-only) and is untouched.

## Evidence

A probe mirroring `Router::getAttributeRoutes()` exactly — scan `lib/Controller/*.php`, derive the FQCN, `new ReflectionClass()` each — run with **openregister absent**. The app's own `vendor/autoload.php` is deliberately *not* loaded (a `--no-dev` release build has no stub mappings).

| | scanned | reflected ok | **fail** | `appinfo/routes.php` |
|---|---|---|---|---|
| `origin/development` | 12 | 11 | **1** (`HealthController`) | OK, 48 routes |
| this branch | 12 | **12** | **0** | OK, 48 routes |

**Positive control (both runs):** `positive_control=OK` — a throwaway class extending the absent generic still fatals under the same probe, so it is not blind to the defect it tests for.
**Negative control (both runs):** `negative_control=OK` — an OCP-only controller reflects fine, so the probe is not failing everything for an unrelated reason.

Route count is unchanged (48), so no route was lost.

## Local gates (PHP 8.4 container, `composer check:strict` components)

`lint` ✅ 0 · `phpcs` ✅ 0 errors · `phpmd` ✅ 0 · `psalm` ✅ **No errors found!** · `phpstan` ✅ **No errors**

⚠️ **`phpunit` was NOT run locally** — nldesign's unit suite needs a full Nextcloud server tree (it touches `OC\Mail\EMailTemplate`), and `composer test:all` self-skips without `../../lib/base.php`. I would not boot `base.php` against the shared dev database from a throwaway container. CI runs it; I am relying on the CI job's own conclusion, not asserting a pass I did not observe. nldesign has no `HealthController` test, and nothing outside `lib/AppInfo/Application.php` referenced the old constructor signature.

## Same shape elsewhere in the fleet

Per decidesk#388: **docudesk** (Dashboard, Health, Metrics, Preferences) and **procest** (Dashboard) still carry the identical latent defect. **pipelinq** is fixed in the companion PR.