### PR TITLE
fix(lasuite): keep Nextcloud's container radius instead of the control radius

### DIFF
--- a/css/systems/lasuite/bridge.css
+++ b/css/systems/lasuite/bridge.css
@@ -305,3 +305,43 @@ body,
 	outline: 2px solid var(--nldesign-color-focus) !important;
 	outline-offset: 2px !important;
 }
+
+/* ===================================================================
+ * DARK MODE — the Nextcloud-facing text variables
+ *
+ * The mapping above pins --color-main-text to gray-850 with !important,
+ * unconditionally. In LIGHT mode that is correct and measured. In DARK mode it
+ * is actively harmful: Nextcloud darkens --color-main-background (a REQ-CSS-007
+ * reserved variable this file correctly never touches), and our dark text is
+ * then painted onto it. Observed on a dark render of the Files list: file and
+ * folder names rendered dark-on-dark and were invisible, while the shell around
+ * them was correct.
+ *
+ * Fixing this needs no reserved variable. Nextcloud owns the BACKGROUND; this
+ * file owns the FOREGROUND it maps. Flipping only the foreground restores the
+ * pairing, and the reserved variables keep deriving exactly as before.
+ *
+ * Scope selectors mirror css/tokens/dark/lasuite.css so this turns on and off
+ * with the rest of the dark layer. `!important` is carried for the same reason
+ * the light mapping carries it: Nextcloud assigns these at equal specificity
+ * from its own body[data-themes] rules (ADR-CSS-002 category 1).
+ * =================================================================== */
+
+@media (prefers-color-scheme: dark) {
+	body:not([data-theme-light]):not([data-theme-dark]):not([data-theme-light-highcontrast]):not([data-theme-dark-highcontrast]) {
+		--color-main-text: var(--lasuite-color-gray-050) !important;
+		--color-text-maxcontrast: var(--lasuite-color-gray-200) !important;
+		/* Inverted pair: on a dark ground the "light" text token is the dark one
+		   and vice versa, otherwise both collapse to the same end of the ramp. */
+		--color-text-light: var(--lasuite-color-gray-850) !important;
+		--color-text-lighter: var(--lasuite-color-gray-300) !important;
+	}
+}
+
+body[data-theme-dark],
+body[data-themes*="dark"] {
+	--color-main-text: var(--lasuite-color-gray-050) !important;
+	--color-text-maxcontrast: var(--lasuite-color-gray-200) !important;
+	--color-text-light: var(--lasuite-color-gray-850) !important;
+	--color-text-lighter: var(--lasuite-color-gray-300) !important;
+}

--- a/css/systems/lasuite/bridge.css
+++ b/css/systems/lasuite/bridge.css
@@ -254,9 +254,23 @@ body {
 	 * BORDER RADIUS
 	 * =================================================================== */
 
+	/* `--lasuite-border-radius` (4px) is the one literal in the token set, and
+	   it was observed on Cunningham's BUTTON and INPUT — a control radius (see
+	   defaults.css COMPATIBILITY ALIASES). It is mapped onto the control-scale
+	   NC tokens only.
+
+	   `--border-radius-large` is deliberately NOT mapped. It is Nextcloud's
+	   CONTAINER radius (cards, widget surfaces; NC default 8px), and there is
+	   no measured Cunningham container radius to map it to — the parity suite
+	   asserts 4px for a button, a text input and a modal, none of which is a
+	   container, and all three take their radius from the direct
+	   `border-radius` rules in element-overrides.css rather than from this
+	   token. Collapsing the container scale onto the control radius flattened
+	   NC's radius hierarchy and, on a 1px gray-100 hairline, shrank card corner
+	   arcs to roughly two antialiased pixels — the corners visibly went
+	   missing while the straight edges stayed crisp. */
 	--border-radius: var(--lasuite-border-radius) !important;
 	--border-radius-small: var(--lasuite-border-radius) !important;
-	--border-radius-large: var(--lasuite-border-radius) !important;
 	--border-radius-element: var(--lasuite-border-radius) !important;
 
 	/* ===================================================================

--- a/css/systems/lasuite/bridge.css
+++ b/css/systems/lasuite/bridge.css
@@ -186,7 +186,12 @@ body {
 	--color-text-maxcontrast: var(--lasuite-color-gray-600) !important;
 	/* --color-text-maxcontrast-default: unmapped — auto-calculated per theme by Nextcloud */
 	/* --color-text-maxcontrast-background-blur: unmapped — blur-adjusted maxcontrast, auto-calculated */
-	--color-text-light: var(--lasuite-color-gray-000) !important;
+	/* NOT gray-000. Nextcloud's --color-text-light means DE-EMPHASISED text, not
+	   WHITE text — NC 34 defines it as equal to --color-main-text. Mapping it to
+	   pure white made every component using it invisible on a white surface:
+	   observed on Hermiq's features-roadmap sidebar, where five paragraphs
+	   rendered white-on-white and could only be found by selecting them. */
+	--color-text-light: var(--lasuite-color-gray-850) !important;
 	--color-text-lighter: var(--lasuite-color-gray-500) !important;
 	--color-text-error: var(--lasuite-color-error-550) !important;
 	--color-text-success: var(--lasuite-color-success-550) !important;
@@ -333,7 +338,7 @@ body,
 		--color-text-maxcontrast: var(--lasuite-color-gray-200) !important;
 		/* Inverted pair: on a dark ground the "light" text token is the dark one
 		   and vice versa, otherwise both collapse to the same end of the ramp. */
-		--color-text-light: var(--lasuite-color-gray-850) !important;
+		--color-text-light: var(--lasuite-color-gray-050) !important;
 		--color-text-lighter: var(--lasuite-color-gray-300) !important;
 	}
 }
@@ -342,6 +347,6 @@ body[data-theme-dark],
 body[data-themes*="dark"] {
 	--color-main-text: var(--lasuite-color-gray-050) !important;
 	--color-text-maxcontrast: var(--lasuite-color-gray-200) !important;
-	--color-text-light: var(--lasuite-color-gray-850) !important;
+	--color-text-light: var(--lasuite-color-gray-050) !important;
 	--color-text-lighter: var(--lasuite-color-gray-300) !important;
 }

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -151,6 +151,28 @@ header#header {
 #header .app-menu__current-app-name,
 #header .app-menu__current-app .button-vue__text,
 #header .header-start .header-appname {
+	/* KNOWN DISCREPANCY — this renders brand-550, and lasuite-parity expects
+	   brand-650 (#4844ad).
+
+	   The size and weight here were measured against La Suite; the COLOUR was
+	   not, because Messages renders its wordmark as an image and offers no
+	   computed value to read. brand-550 was an estimate that happens to match
+	   what the browser actually paints.
+
+	   Setting brand-650 was tried and does NOT take effect: the declaration is
+	   present, `!important`, the selector matches the element, and the token
+	   resolves to #4844ad — yet the computed colour stays brand-550, while an
+	   inline `!important` on the same element does apply #4844ad. So some other
+	   rule outranks it, and it is not among the top-level rules of any loaded
+	   sheet; the likely home is inside an at-rule block. Writing brand-650 here
+	   would make this file claim a colour it does not produce, which is worse
+	   than an honest brand-550.
+
+	   Leaving the parity assertion failing on purpose, with the delta recorded,
+	   rather than editing the reference to match the code. Deciding between
+	   brand-550 and brand-650 is a design call, and it should be made against a
+	   measured La Suite value — Docs renders its wordmark as TEXT, so that
+	   value is obtainable. */
 	color: var(--lasuite-color-brand-550) !important;
 	font-size: 20px !important;
 	font-weight: 600 !important;

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -118,28 +118,110 @@ header#header {
 	-webkit-filter: none !important;
 }
 
-/* The Nextcloud logo is a background-IMAGE (core/img/logo/logo.svg) shipped in
-   white, so `color` cannot reach it and a filter is the only lever available.
-   It contains no avatar, so the subtree hazard described above does not apply
-   here. `brightness(0)` renders it as a dark wordmark, matching the gray-850
-   header text rather than the brand tint used for actionable icons. */
+/* The Nextcloud logo is a background-IMAGE (core/img/logo/logo.svg), so `color`
+   cannot reach it. An earlier revision used `filter: brightness(0)`, which
+   renders it PURE BLACK — the same complaint as the glyphs above, and nothing
+   in La Suite's header is black: its wordmark is brand violet.
+
+   A filter cannot tint an arbitrary image to an exact colour (the usual
+   hue-rotate chains are approximations that drift). Masking can: the SVG
+   becomes the alpha channel and the background paints the colour, so the result
+   is exactly brand-550 with no colour maths at all.
+
+   The URL is relative to THIS stylesheet
+   (css/systems/lasuite/ → five levels up is the server root), so it keeps
+   working on instances installed under a sub-path, where a root-relative
+   `/core/…` would break. */
 #header .logo,
 #header .logo-icon {
-	filter: brightness(0) !important;
-	-webkit-filter: brightness(0) !important;
+	background-color: var(--lasuite-color-brand-550) !important;
+	background-image: none !important;
+	filter: none !important;
+	-webkit-filter: none !important;
+	-webkit-mask: url('../../../../../core/img/logo/logo.svg') no-repeat center / contain !important;
+	mask: url('../../../../../core/img/logo/logo.svg') no-repeat center / contain !important;
 }
 
-/* App menu — dark on white, brand-650 active indicator (Cunningham accent). */
+/* CURRENT APP NAME — La Suite sets its product wordmark noticeably larger than
+   Nextcloud sets its app name (measured: the Messages wordmark reads ~20px
+   semibold violet, against Nextcloud's 15px regular gray-900). Matching the
+   visual weight is what makes the two headers read alike; the two strings are
+   not structurally the same thing (product name vs current app), so this is a
+   deliberate visual match rather than a like-for-like mapping. */
+#header .app-menu__current-app-name,
+#header .app-menu__current-app .button-vue__text,
+#header .header-start .header-appname {
+	color: var(--lasuite-color-brand-550) !important;
+	font-size: 20px !important;
+	font-weight: 600 !important;
+	letter-spacing: -0.01em !important;
+}
+
+/* UNIFIED SEARCH — Nextcloud styles this for a dark header, so on our white bar
+   the placeholder rendered WHITE-ON-WHITE and the control had no visible edge
+   at all. Measured on La Suite Messages:
+
+       container   background #f8f8f9 (gray-025), 1px solid #d3d4e0,
+                   border-radius 4px, height 34
+       input       transparent, colour gray-850, 14px / weight 500
+       placeholder rgb(117,117,117)
+
+   The border uses gray-100, the step this file already uses for every
+   structural hairline (see the sidebar rule), rather than the measured
+   #d3d4e0 — that value falls between two ramp steps and consistency with the
+   rest of the theme is worth more than matching one control exactly. */
+#header .unified-search-input,
+#header .unified-search-input__button,
+#header .unified-search__input {
+	background-color: var(--lasuite-color-gray-025) !important;
+	border: 1px solid var(--lasuite-color-gray-100) !important;
+	border-radius: var(--lasuite-border-radius) !important;
+	color: var(--lasuite-color-gray-850) !important;
+	box-shadow: none !important;
+	/* Nextcloud stretches the control to the full 50px header height; La Suite's
+	   is a 34px field centred in the bar. Height alone is not enough — the
+	   element is absolutely positioned, so it also has to be re-centred. */
+	block-size: 34px !important;
+	inset-block-start: 8px !important;
+	min-block-size: 0 !important;
+}
+
+#header .unified-search-input__label,
+#header .unified-search-input input::placeholder,
+#header .unified-search__input::placeholder {
+	color: var(--lasuite-color-gray-500) !important;
+	font-size: 14px !important;
+	font-weight: 500 !important;
+}
+
+#header .unified-search-input input,
+#header .unified-search-input__button .button-vue__text {
+	background-color: transparent !important;
+	border: 0 !important;
+	color: var(--lasuite-color-gray-850) !important;
+	font-size: 14px !important;
+	font-weight: 500 !important;
+}
+
+/* The magnifier inside the field is a neutral affordance in La Suite, not a
+   brand-tinted action, so it opts out of the brand colour set above. */
+#header .unified-search-input svg,
+#header .unified-search-input .button-vue__icon {
+	color: var(--lasuite-color-gray-500) !important;
+}
+
+/* App menu — dark on white, brand-650 active indicator (Cunningham accent).
+
+   The CURRENT app's name is deliberately NOT in this list. NC34 renders it
+   through `.app-menu__current-app-name`, and it used to be included here so it
+   would not sit white-on-white — but this block re-declares `color` and
+   `font-weight` with the same specificity LATER in the file than the wordmark
+   rule above, so it silently overrode it and the name stayed 15px gray-900 no
+   matter what that rule said. Sizing and colouring the current app name now
+   happens in exactly one place. */
 #header nav.app-menu a,
 #header nav.app-menu .app-menu-entry__link,
-#header nav.app-menu .app-menu-entry__label,
-/* NC34 renders the CURRENT app's name through these classes rather than
-   .app-menu-entry__label. They inherit Nextcloud's white header foreground, so
-   without them the app name ("Files") is present in the DOM but invisible on
-   our white bar — the top-left corner just looks empty. */
-#header .app-menu__current-app,
-#header .app-menu__current-app-name,
-#header .app-menu__current-app .button-vue__text {
+#header nav.app-menu .app-menu-entry__label {
 	color: var(--lasuite-color-gray-900) !important;
 	font-weight: 400 !important;
 }

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -861,21 +861,28 @@ body[data-themes*="dark"] {
 
    `color` cannot reach an <img>, and the masking trick used for the Nextcloud
    logo needs a known URL — this src differs per app and is not knowable from
-   CSS. Nextcloud's own answer to exactly this problem is
-   --background-invert-if-bright, which resolves to `invert(100%)` on a bright
-   header and to `no` on a dark one. REQ-CSS-007 reserves that variable against
-   being SET; reading it is what it exists for, and it keeps the icon correct in
-   both light and dark without this file having to know the theme.
+   CSS. An earlier revision therefore used --background-invert-if-bright, which
+   made the icon VISIBLE but BLACK, and black is not a colour that appears
+   anywhere in La Suite's chrome.
 
-   The result is a dark icon rather than a brand-violet one. Tinting an
-   arbitrary per-app image to an exact colour is not expressible in CSS without
-   its URL, and a visible icon in the platform's own idiom beats an invisible
-   one. */
+   A filter chain tints it instead. `brightness(0) saturate(100%)` first
+   collapses the white source to pure black — a known starting point regardless
+   of what the app shipped — and the remaining steps rotate that black toward
+   brand-550, so the icon reads as part of the same violet set as the logo,
+   waffle and wordmark beside it.
+
+   This is an APPROXIMATION, and deliberately so: filter chains cannot hit an
+   exact hex the way the logo's mask does. Exactness here would require knowing
+   each app's icon URL to mask against, which CSS cannot read from the element.
+   The approximation is within a couple of percent and, unlike black, belongs to
+   the palette. */
 #header .app-menu__current-app-icon,
 #header .app-menu-entry__icon img,
 #header .app-menu-icon img {
-	filter: var(--background-invert-if-bright, none) !important;
-	-webkit-filter: var(--background-invert-if-bright, none) !important;
+	filter: brightness(0) saturate(100%) invert(38%) sepia(69%) saturate(1907%)
+		hue-rotate(228deg) brightness(88%) contrast(88%) !important;
+	-webkit-filter: brightness(0) saturate(100%) invert(38%) sepia(69%) saturate(1907%)
+		hue-rotate(228deg) brightness(88%) contrast(88%) !important;
 	opacity: 1 !important;
 }
 

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -61,45 +61,72 @@ header#header {
 	opacity: 1 !important;
 }
 
-#header .header-end svg,
+/* Nextcloud ships every header glyph WHITE, because its own header is normally
+   a dark brand colour. On our white bar they render white-on-white and the bar
+   looks empty. Nextcloud's own mechanism for this is
+   --background-invert-if-bright, but that variable is reserved by REQ-CSS-007
+   (the dark-mode derivation depends on it), so the colour is set here directly.
+
+   These glyphs are Material SVGs whose `fill` resolves to `currentColor`, so
+   setting `color` recolours them exactly — and, unlike a filter, colour
+   INHERITS, which means a descendant can opt back out.
+
+   An earlier revision used `filter: invert(1) brightness(0) contrast(100)`
+   here. That was wrong twice over:
+
+     1. `brightness(0)` forces every glyph to PURE BLACK. Measured against La
+        Suite Messages, nothing in its header is #000: actionable icons are
+        brand violet rgb(94,92,208) and text is gray-850 rgb(37,37,47).
+
+     2. A filter on an ancestor rasterises its ENTIRE subtree, and no
+        descendant `filter: none` can undo that. `.button-vue__icon` wraps the
+        user-menu trigger, so the avatar inside it was flattened to a solid
+        black disc — the exclusion list below it could never have worked, no
+        matter which avatar selector it named. Colour inherits; filters do not
+        un-inherit. */
 #header .header-end .button-vue__icon,
-#header .header-end .icon-vue {
-	filter: invert(1) brightness(0) contrast(100) !important;
-	-webkit-filter: invert(1) brightness(0) contrast(100) !important;
-}
-
-/* Preserve avatar / user-status colour on the white bar. */
-#header .header-end .avatardiv img,
-#header .header-end .user-status-icon svg {
-	filter: none !important;
-	-webkit-filter: none !important;
-}
-
-/* LEFT of the bar — the Nextcloud logo, the app-menu waffle and the current
-   app's icon. Nextcloud ships all three WHITE because its own header is a dark
-   brand colour; on our white bar they render white-on-white and the top-left
-   corner looks empty. The same inversion the header-end icons already get is
-   applied here so the logo / menu / app icon are visible again.
-
-   Nextcloud's own mechanism for this is --background-invert-if-bright, but
-   that variable is reserved by REQ-CSS-007 (its dark-mode derivation depends
-   on it), so the filter is applied directly to the elements instead. */
-#header .logo,
-#header .header-start svg,
+#header .header-end .icon-vue,
+#header .header-end svg,
 #header .header-start .button-vue__icon,
 #header .header-start .icon-vue,
-#header nav.app-menu svg,
+#header .header-start svg,
+#header .app-menu__waffle,
 #header .app-menu__waffle svg {
-	filter: invert(1) brightness(0) contrast(100) !important;
-	-webkit-filter: invert(1) brightness(0) contrast(100) !important;
-}
-
-/* …but never invert the user's own avatar or a coloured app icon that already
-   reads correctly on white. */
-#header .header-start .avatardiv img,
-#header .header-start img[src*="avatar"] {
+	color: var(--lasuite-color-brand-550) !important;
 	filter: none !important;
 	-webkit-filter: none !important;
+}
+
+/* The avatar carries Nextcloud's per-user generated colour and the user's own
+   photo. It must inherit nothing from the tinting above — La Suite's own
+   avatar is a coloured disc with near-white initials, never a monochrome
+   glyph. `color` is scoped back to the initials so they stay legible on that
+   generated background. */
+#header .avatardiv,
+#header .avatardiv *,
+#header [class*="avatar" i],
+#header [class*="avatar" i] * {
+	filter: none !important;
+	-webkit-filter: none !important;
+	color: var(--lasuite-color-gray-000) !important;
+}
+
+/* User-status emoji/icon keeps its own colours. */
+#header .user-status-icon,
+#header .user-status-icon * {
+	filter: none !important;
+	-webkit-filter: none !important;
+}
+
+/* The Nextcloud logo is a background-IMAGE (core/img/logo/logo.svg) shipped in
+   white, so `color` cannot reach it and a filter is the only lever available.
+   It contains no avatar, so the subtree hazard described above does not apply
+   here. `brightness(0)` renders it as a dark wordmark, matching the gray-850
+   header text rather than the brand tint used for actionable icons. */
+#header .logo,
+#header .logo-icon {
+	filter: brightness(0) !important;
+	-webkit-filter: brightness(0) !important;
 }
 
 /* App menu — dark on white, brand-650 active indicator (Cunningham accent). */
@@ -170,6 +197,7 @@ header#header {
 }
 
 #app-navigation.app-navigation--close,
+#app-navigation-vue.app-navigation--close,
 .app-navigation.app-navigation--close {
 	margin-right: 0 !important;
 }
@@ -183,19 +211,119 @@ header#header {
 	background-color: var(--lasuite-color-gray-050) !important;
 }
 
+/* ACTIVE NAVIGATION ENTRY
+
+   La Suite marks the current item with a neutral 5% wash and nothing else.
+   Measured on La Suite Messages (.mailbox__item-row, active):
+
+       background   rgba(27, 27, 35, 0.05)
+       border-radius 4px
+       border-left  0 — none
+       font-weight  400   (identical to the inactive row)
+       color        rgb(37, 37, 47)  (identical to the inactive row)
+
+   Active and inactive differ by the wash ALONE. Nextcloud instead stacks three
+   separate signals: a 16%-alpha brand tint, a label bolded to 600, and a 3px
+   brand rail. Matching La Suite means removing two of the three.
+
+   The wash is deliberately a literal rgba rather than a token: it is a
+   translucent neutral, and the gray ramp only carries opaque steps
+   (gray-050 #f0f0f3 is the nearest, but opaque it reads heavier over the
+   white card and loses the tint of whatever sits beneath it).
+
+   SELECTOR / SPECIFICITY NOTE — why these rules look repetitive:
+
+   Nextcloud 34 renders the navigation into `#app-navigation-vue`. There is no
+   `#app-navigation` element at all, so every `#app-navigation …` rule written
+   against the older DOM matches nothing. That left only the bare
+   `.app-navigation-entry.active` selector (0,2,0) in play, and nc-vue injects a
+   SCOPED rule that outguns it:
+
+       .app-navigation-entry:not(…--legacy).active[data-v-…]  (0,4,0) !important
+           background-color: color-mix(in srgb, var(--color-primary-element) 16%, transparent)
+
+   Both carry `!important`, so specificity decides and nc-vue won — which is why
+   the row kept its brand tint no matter what this file said. The id-prefixed
+   selectors below reach (1,2,0) and win outright; the class-repeated fallback
+   reaches (0,5,0) for any navigation rendered without either id. */
+#app-navigation-vue .app-navigation-entry.active,
+#app-navigation-vue .app-navigation-entry--active,
 #app-navigation .app-navigation-entry.active,
 #app-navigation .app-navigation-entry--active,
-.app-navigation-entry.active,
-.app-navigation-entry--active {
-	background: var(--lasuite-color-brand-050) !important;
+.app-navigation-entry.app-navigation-entry.active.active.active,
+.app-navigation-entry.app-navigation-entry--active.app-navigation-entry--active {
+	background: rgba(27, 27, 35, 0.05) !important;
+	background-color: rgba(27, 27, 35, 0.05) !important;
 	border-radius: var(--lasuite-border-radius) !important;
 }
 
+/* The brand rail is a ::before pseudo-element (3px, absolutely positioned at
+   left: 0), NOT a border property — `border-left: none` does not touch it and
+   an earlier attempt to neutralise it that way silently did nothing. It has to
+   be removed as a pseudo-element. */
+#app-navigation-vue .app-navigation-entry.active::before,
+#app-navigation-vue .app-navigation-entry--active::before,
+#app-navigation .app-navigation-entry.active::before,
+#app-navigation .app-navigation-entry--active::before,
+.app-navigation-entry.app-navigation-entry.active.active.active::before,
+.app-navigation-entry.app-navigation-entry--active.app-navigation-entry--active::before {
+	content: none !important;
+	display: none !important;
+}
+
+/* Label keeps the ordinary text colour and weight in BOTH states — the wash is
+   the only affordance, exactly as La Suite does it. */
+#app-navigation-vue .app-navigation-entry.active a,
+#app-navigation-vue .app-navigation-entry.active .app-navigation-entry-link,
+#app-navigation-vue .app-navigation-entry.active .app-navigation-entry__name,
+#app-navigation-vue .app-navigation-entry--active a,
 #app-navigation .app-navigation-entry.active a,
-.app-navigation-entry.active a,
-.app-navigation-entry--active a {
-	color: var(--lasuite-color-brand-650) !important;
-	font-weight: 600 !important;
+#app-navigation .app-navigation-entry.active .app-navigation-entry-link,
+#app-navigation .app-navigation-entry.active .app-navigation-entry__name,
+.app-navigation-entry.app-navigation-entry.active.active a,
+.app-navigation-entry.app-navigation-entry.active.active .app-navigation-entry-link,
+.app-navigation-entry.app-navigation-entry.active.active .app-navigation-entry__name {
+	color: var(--lasuite-color-gray-850) !important;
+	font-weight: 400 !important;
+}
+
+/* Inactive entries: Nextcloud ships these at 500, La Suite at 400. Levelling
+   them is what makes the wash the only difference between the two states. */
+#app-navigation-vue .app-navigation-entry .app-navigation-entry-link,
+#app-navigation-vue .app-navigation-entry .app-navigation-entry__name,
+#app-navigation .app-navigation-entry .app-navigation-entry-link,
+#app-navigation .app-navigation-entry .app-navigation-entry__name,
+.app-navigation-entry.app-navigation-entry .app-navigation-entry-link,
+.app-navigation-entry.app-navigation-entry .app-navigation-entry__name {
+	font-weight: 400 !important;
+}
+
+/* SELECTED LIST ROW (NcListItem)
+
+   The same two divergences as the navigation entry, on a different component.
+   `.list-item` is the shared nc-vue row used by Contacts, Mail and every other
+   list-detail app, so it is the row the user actually spends the day looking
+   at. Selection is marked on the WRAPPER (`.list-item__wrapper--active`), and
+   nc-vue paints the child `.list-item` with `--color-primary-element-light`
+   (#eef1fa here) plus a 3px brand rail via ::before.
+
+   La Suite marks a selected row with the same neutral 5% wash it uses in the
+   sidebar, and no rail. Keeping the two components consistent matters more
+   than either one in isolation: with the sidebar fixed and this left alone,
+   one selected row would read grey and the other lavender on the same screen. */
+.list-item__wrapper--active .list-item,
+.list-item__wrapper.active .list-item,
+.list-item__wrapper--active .list-item:hover,
+.list-item__wrapper--active .list-item:focus-within {
+	background-color: rgba(27, 27, 35, 0.05) !important;
+}
+
+.list-item__wrapper--active .list-item::before,
+.list-item__wrapper.active .list-item::before,
+.list-item__wrapper--active::before,
+.list-item__wrapper.active::before {
+	content: none !important;
+	display: none !important;
 }
 
 /* App content — flat white card, no shadow (Cunningham surfaces are flat). */

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -508,11 +508,34 @@ header#header {
 	/* No top margin: the outer #content already clears the 50px header. Adding
 	   it here is what produced the band. */
 	margin: 0 !important;
+	/* …but see the body-child rule below: not every app HAS an outer #content. */
 	/* Nextcloud sizes this with a calc() that subtracts its own 8px side
 	   margins. Dropping the margins without resetting the width left a 16px
 	   strip of body colour showing down the right edge. */
 	width: 100% !important;
 }
+
+/* NOT EVERY APP HAS THE OUTER SHELL.
+
+   Contacts, Files and Settings render <div id="content"><div id="content-vue">.
+   Mail renders #content-vue as a DIRECT CHILD OF BODY, with no #content at all.
+   The rule above assumes the outer shell has already cleared the 50px header,
+   so on Mail nothing did: #content-vue sat at y=0 behind the header and, being
+   `calc(100vh - 50px)` tall, stopped 50px short of the bottom — a blue strip
+   along the foot of the window.
+
+   When #content-vue is a body child it has to clear the header itself. Scoped
+   by parentage rather than by app so it holds for any app built the same way. */
+body > #content-vue,
+#body-user > #content-vue {
+	/* Also pin the insets. As a body child this element is `position: fixed`
+	   with Nextcloud's own `inset: 0 8px 8px`, and there is no outer #content
+	   here to have neutralised them — so without this it sits 8px in from each
+	   side and 8px up from the foot, showing body colour down both edges. */
+	inset: 0 !important;
+	margin-block-start: var(--header-height, 50px) !important;
+}
+
 
 /* The single white card: the app's content area, inset from the grey.
    22px on every side — measured on the live La Suite app, whose <main> starts

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -958,3 +958,32 @@ body#body-public {
 	background-color: var(--lasuite--contextuals--background--surface--tertiary, var(--lasuite-color-gray-025)) !important;
 	background-image: none !important;
 }
+
+/* ============================================
+   GUEST / LOGIN SURFACES — flat, on the same ground
+
+   La Suite is flat. Measured on both its products: the Messages top bar carries
+   `box-shadow: none`, and its content cards are a 4px radius with no shadow at
+   all. Nextcloud's guest pages instead float the login box and its footer on a
+   `rgba(77,77,77,.5) 0 0 10px` drop shadow, which reads as a different design
+   language the moment you put the two side by side.
+
+   The logo banner is the second half of the same point: `.header-guest` paints
+   itself white across the full width, so the page showed a white strip on a
+   grey ground for no reason — La Suite would simply let the ground run behind
+   the mark.
+
+   NOT touched: the `box-shadow` on `.input-field__input`. Those are focus
+   RINGS, not decoration — removing them would take the visible focus indicator
+   with them and break keyboard navigation (WCAG 2.4.7). Only the decorative
+   shadows on the guest surfaces are cleared. */
+.guest-box,
+.guest-box.login-box,
+footer.guest-box {
+	box-shadow: none !important;
+}
+
+.header-guest {
+	background-color: transparent !important;
+	background-image: none !important;
+}

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -347,15 +347,65 @@ header#header {
    La Suite's arrangement — and it yields ONE card rather than one per child.
    (Carding `#app-content-vue > *` was tried and rejected: Nextcloud emits
    several siblings there — `.hidden-visually`, `.files-list__header`,
-   `.files-list` — so it produced four disconnected cards.) */
-#content-vue.content,
+   `.files-list` — so it produced four disconnected cards.)
+
+   TWO NESTED SHELLS, NOT ONE — and only one of them carries `.content`.
+
+   Nextcloud 34 renders:
+
+       <div id="content" class="app-contacts">          <-- OUTER, no `content` class
+         <div id="content-vue" class="content app-…">   <-- INNER, has it
+
+   An earlier revision selected `#content.content`, which matches NOTHING: the
+   outer shell kept Nextcloud's stock `margin: 50px 8px 8px` and
+   `border-radius: 16px`, so the body colour showed through as an 8px frame down
+   the left and along the bottom. Meanwhile the inner shell DID match and was
+   given `margin-top: 50px` — on top of the 50px the outer shell already has to
+   clear the absolutely-positioned header — so the content started at y=100
+   instead of y=50 and a 50px band of body colour opened up beneath the header.
+
+   Both artefacts were previously mis-attributed to `--color-background-plain`
+   being reserved by REQ-CSS-007. That was wrong. The reserved variable is only
+   ever VISIBLE here because these two shells left it exposed; no other
+   Nextcloud app shows a band under the header. Nothing about dark-mode
+   derivation prevents closing it — the shells simply have to be sized right.
+
+   So: the OUTER shell clears the header and nothing else; the INNER shell adds
+   no offset of its own and paints the grey canvas. */
+#content,
 #content.content {
+	border-radius: 0 !important;
+	/* `position: fixed` with `inset: 0 0 8px` — the 8px is a bottom OFFSET, not
+	   a height, so zeroing the margin alone still left an 8px strip of body
+	   colour along the bottom edge. Zeroing only the bottom inset then
+	   bottom-ANCHORED the box (its height stayed pinned), pushing the top edge
+	   down by the same 8px. Pinning all four insets and letting the height
+	   resolve from them is what actually fills the frame: top 0 + the 50px
+	   margin clears the header, bottom 0 reaches the viewport floor. */
+	height: auto !important;
+	inset: 0 !important;
+	margin: 50px 0 0 !important;
+	width: 100% !important;
+}
+
+#content-vue,
+#content-vue.content {
 	background-color: var(--lasuite-color-gray-025) !important;
 	border-radius: 0 !important;
-	margin: 50px 0 0 !important;
+	/* Fill the outer shell exactly. Nextcloud sizes this 8px short (it expects
+	   the outer shell's 8px bottom inset), which left a strip of body colour
+	   along the bottom edge once the shell itself was made full-bleed.
+	   `height: 100%` is NOT usable here: the outer shell is `position: fixed`,
+	   so the percentage resolves against the initial containing block (the full
+	   viewport) rather than the shell, overflowing 50px past the fold. The
+	   header height is the only offset in play, so subtract it explicitly. */
+	height: calc(100vh - var(--header-height, 50px)) !important;
+	/* No top margin: the outer #content already clears the 50px header. Adding
+	   it here is what produced the band. */
+	margin: 0 !important;
 	/* Nextcloud sizes this with a calc() that subtracts its own 8px side
 	   margins. Dropping the margins without resetting the width left a 16px
-	   strip of --color-background-plain showing down the right edge. */
+	   strip of body colour showing down the right edge. */
 	width: 100% !important;
 }
 

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -612,18 +612,32 @@ button.secondary {
    instead of an action.
 
    SCOPED DELIBERATELY to text-bearing tertiary buttons OUTSIDE the header:
-   NC's header uses --vue-tertiary-no-background for icon buttons that sit on
-   the coloured header band and must stay white for contrast, and icon-only row
-   actions (the "…" menus) stay neutral — colouring every icon violet is not
-   what La Suite does and would be visually noisy.
-   ============================================ */
+   NC's header uses tertiary-no-background for icon buttons that sit on the
+   header band, and icon-only row actions (the "…" menus) stay neutral —
+   colouring every icon violet is not what La Suite does and would be visually
+   noisy.
 
+   TWO NAMING SCHEMES. Nextcloud 34 emits BOTH `button-vue--tertiary` and
+   `button-vue--vue-tertiary`, depending on the vintage of the component doing
+   the rendering. Measured on one page: 60 elements carry the plain form and
+   exactly 1 carries the `--vue-` form. This block previously listed only the
+   `--vue-` form, so it styled 1 button and missed 60 — which is why tertiary
+   buttons still read as plain body text almost everywhere.
+
+   Both forms are matched below. The same applies to primary and secondary, but
+   those blocks already catch either spelling through their
+   `button[class*="primary"]` / `button[class*="secondary"]` fallbacks. */
+
+:not(#header) > .button-vue--tertiary.button-vue--text-only,
+:not(#header) .button-vue--tertiary.button-vue--icon-and-text,
 :not(#header) > .button-vue--vue-tertiary.button-vue--text-only,
 :not(#header) .button-vue--vue-tertiary.button-vue--icon-and-text {
 	color: var(--lasuite--contextuals--content--semantic--brand--tertiary) !important;
 	background-color: transparent !important;
 }
 
+:not(#header) > .button-vue--tertiary.button-vue--text-only span,
+:not(#header) .button-vue--tertiary.button-vue--icon-and-text span,
 :not(#header) > .button-vue--vue-tertiary.button-vue--text-only span,
 :not(#header) .button-vue--vue-tertiary.button-vue--icon-and-text span {
 	color: inherit !important;

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -878,3 +878,41 @@ body[data-themes*="dark"] {
 	-webkit-filter: var(--background-invert-if-bright, none) !important;
 	opacity: 1 !important;
 }
+
+/* ============================================
+   SETTINGS-DIALOG NAVIGATION — the same rail, a third component
+
+   The active-row work covered `.app-navigation-entry` (app sidebar) and
+   `.list-item` (NcListItem rows). The settings dialog uses a THIRD component
+   with its own markup, and still drew the brand tint plus a 3px rail that La
+   Suite does not use — reported from a screenshot of an app's User settings
+   modal.
+
+   Reached via: app nav → Settings (expands) → Personal settings. Measured on
+   the open dialog rather than guessed — an earlier attempt targeted
+   `.app-settings-navigation .app-settings-button`, which does not exist in this
+   Nextcloud, and was removed before commit rather than shipped. The real
+   structure is:
+
+       nav.dialog__navigation.app-settings__navigation
+         └ ul.navigation-list
+             └ li > a.navigation-list__link.navigation-list__link--active
+                    background rgb(238,241,250)   (brand-050 tint)
+                    ::before   rgb(94,92,208), 3px, left 0   (the rail)
+
+   Both the BEM `--active` and the plain `.active` spelling are covered: this
+   file has now been bitten four separate times by naming only one of two live
+   spellings. */
+.navigation-list__link--active,
+.navigation-list__link.active {
+	background: var(--lasuite-active-row-wash, rgba(27, 27, 35, 0.05)) !important;
+	border-radius: var(--lasuite-border-radius) !important;
+	color: var(--lasuite-content-primary, var(--lasuite-color-gray-850)) !important;
+	font-weight: 400 !important;
+}
+
+.navigation-list__link--active::before,
+.navigation-list__link.active::before {
+	content: none !important;
+	display: none !important;
+}

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -940,13 +940,21 @@ body[data-themes*="dark"] {
    text colours be flipped for dark mode without touching the reserved
    background.
 
-   The theming background IMAGE is deliberately left alone: it paints over this
-   colour where Nextcloud intends a wallpaper (login, guest pages), so admins
-   keep that feature and only the ground beneath it changes. */
+   The theming background IMAGE goes too. An earlier revision kept it, reasoning
+   that admins might want their wallpaper — but on the login and guest pages the
+   image is the whole visible surface, so keeping it meant those pages still
+   showed Nextcloud's blue spheres while every other La Suite cue (violet
+   button, violet logo, violet links) was already applied. La Suite has no
+   wallpaper concept anywhere in its products: its ground is a flat neutral.
+   Fixing the colour but not the image fixed the part nobody could see.
+
+   This is scoped to the lasuite system only, so the other design systems in
+   this app keep Nextcloud's wallpaper behaviour untouched. */
 html,
 body,
 body#body-user,
 body#body-login,
 body#body-public {
 	background-color: var(--lasuite--contextuals--background--surface--tertiary, var(--lasuite-color-gray-025)) !important;
+	background-image: none !important;
 }

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -30,9 +30,9 @@
 
 #header,
 header#header {
-	background-color: var(--lasuite-color-gray-000) !important;
+	background-color: var(--lasuite--contextuals--background--surface--primary, var(--lasuite-color-gray-000)) !important;
 	background-image: none !important;
-	background: var(--lasuite-color-gray-000) !important;
+	background: var(--lasuite--contextuals--background--surface--primary, var(--lasuite-color-gray-000)) !important;
 	border-bottom: 1px solid transparent !important;
 	box-shadow: none !important;
 	padding-inline: 18px !important;
@@ -48,7 +48,7 @@ header#header {
 /* Header foreground — dark text/icons on the white bar. */
 #header .header-appname,
 #header .header-left a {
-	color: var(--lasuite-color-brand-650) !important;
+	color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
 	font-weight: 600 !important;
 }
 
@@ -56,7 +56,7 @@ header#header {
 #header .header-right button,
 #header .menutoggle,
 #header .unified-search__button {
-	color: var(--lasuite-color-gray-900) !important;
+	color: var(--lasuite-content-primary, var(--lasuite-color-gray-900)) !important;
 	filter: none !important;
 	opacity: 1 !important;
 }
@@ -92,7 +92,7 @@ header#header {
 #header .header-start svg,
 #header .app-menu__waffle,
 #header .app-menu__waffle svg {
-	color: var(--lasuite-color-brand-550) !important;
+	color: var(--lasuite-content-brand-icon, var(--lasuite-color-brand-550)) !important;
 	filter: none !important;
 	-webkit-filter: none !important;
 }
@@ -134,7 +134,7 @@ header#header {
    `/core/…` would break. */
 #header .logo,
 #header .logo-icon {
-	background-color: var(--lasuite-color-brand-550) !important;
+	background-color: var(--lasuite-content-brand-icon, var(--lasuite-color-brand-550)) !important;
 	background-image: none !important;
 	filter: none !important;
 	-webkit-filter: none !important;
@@ -151,31 +151,22 @@ header#header {
 #header .app-menu__current-app-name,
 #header .app-menu__current-app .button-vue__text,
 #header .header-start .header-appname {
-	/* KNOWN DISCREPANCY — this renders brand-550, and lasuite-parity expects
-	   brand-650 (#4844ad).
+	/* MEASURED, not estimated. La Suite Docs renders its wordmark as TEXT (unlike
+	   Messages, which ships an image and offers no computed value), so these are
+	   read straight off the live app at localhost:3000:
 
-	   The size and weight here were measured against La Suite; the COLOUR was
-	   not, because Messages renders its wordmark as an image and offers no
-	   computed value to read. brand-550 was an estimate that happens to match
-	   what the browser actually paints.
+	       color        rgb(72, 68, 173)  = #4844ad = brand-650
+	       font-size    22px
+	       font-weight  700
 
-	   Setting brand-650 was tried and does NOT take effect: the declaration is
-	   present, `!important`, the selector matches the element, and the token
-	   resolves to #4844ad — yet the computed colour stays brand-550, while an
-	   inline `!important` on the same element does apply #4844ad. So some other
-	   rule outranks it, and it is not among the top-level rules of any loaded
-	   sheet; the likely home is inside an at-rule block. Writing brand-650 here
-	   would make this file claim a colour it does not produce, which is worse
-	   than an honest brand-550.
-
-	   Leaving the parity assertion failing on purpose, with the delta recorded,
-	   rather than editing the reference to match the code. Deciding between
-	   brand-550 and brand-650 is a design call, and it should be made against a
-	   measured La Suite value — Docs renders its wordmark as TEXT, so that
-	   value is obtainable. */
-	color: var(--lasuite-color-brand-550) !important;
-	font-size: 20px !important;
-	font-weight: 600 !important;
+	   An earlier revision guessed brand-550 / 20px / 600 from the Messages image
+	   and was wrong on all three. It also appeared immovable: setting brand-650
+	   seemed to do nothing, because the tertiary block below was leaking into the
+	   header and forcing `color: inherit` onto this element's children. That leak
+	   is fixed at its own site; see the note there. */
+	color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
+	font-size: 22px !important;
+	font-weight: 700 !important;
 	letter-spacing: -0.01em !important;
 }
 
@@ -195,10 +186,10 @@ header#header {
 #header .unified-search-input,
 #header .unified-search-input__button,
 #header .unified-search__input {
-	background-color: var(--lasuite-color-gray-025) !important;
-	border: 1px solid var(--lasuite-color-gray-100) !important;
+	background-color: var(--lasuite--contextuals--background--surface--tertiary, var(--lasuite-color-gray-025)) !important;
+	border: 1px solid var(--lasuite--contextuals--border--surface--primary, var(--lasuite-color-gray-100)) !important;
 	border-radius: var(--lasuite-border-radius) !important;
-	color: var(--lasuite-color-gray-850) !important;
+	color: var(--lasuite-content-primary, var(--lasuite-color-gray-850)) !important;
 	box-shadow: none !important;
 	/* Nextcloud stretches the control to the full 50px header height; La Suite's
 	   is a 34px field centred in the bar. Height alone is not enough — the
@@ -221,7 +212,7 @@ header#header {
  * and label rules happened to be correct; the rest was inert. Caught by
  * tests/e2e/spec-coverage/selector-liveness.spec.ts. */
 #header .unified-search-input__label {
-	color: var(--lasuite-color-gray-500) !important;
+	color: var(--lasuite-content-muted, var(--lasuite-color-gray-500)) !important;
 	font-size: 14px !important;
 	font-weight: 500 !important;
 }
@@ -230,7 +221,7 @@ header#header {
    so it opts out of the brand colour applied to header glyphs above. */
 #header .unified-search-input__icon,
 #header .unified-search-input svg {
-	color: var(--lasuite-color-gray-500) !important;
+	color: var(--lasuite-content-muted, var(--lasuite-color-gray-500)) !important;
 }
 
 /* App menu — dark on white, brand-650 active indicator (Cunningham accent).
@@ -245,14 +236,14 @@ header#header {
 #header nav.app-menu a,
 #header nav.app-menu .app-menu-entry__link,
 #header nav.app-menu .app-menu-entry__label {
-	color: var(--lasuite-color-gray-900) !important;
+	color: var(--lasuite-content-primary, var(--lasuite-color-gray-900)) !important;
 	font-weight: 400 !important;
 }
 
 #header nav.app-menu .app-menu-entry--active a,
 #header nav.app-menu .app-menu-entry--active .app-menu-entry__link,
 #header nav.app-menu .app-menu-entry--active .app-menu-entry__label {
-	color: var(--lasuite-color-brand-650) !important;
+	color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
 	font-weight: 600 !important;
 }
 
@@ -271,7 +262,7 @@ header#header {
 #header nav.app-menu a:hover,
 #header nav.app-menu .app-menu-entry__link:hover {
 	background-color: var(--lasuite-color-gray-050) !important;
-	color: var(--lasuite-color-brand-650) !important;
+	color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
 }
 
 #header nav.app-menu .app-menu-icon img,
@@ -289,7 +280,7 @@ header#header {
 #app-navigation,
 .app-navigation,
 #app-navigation-vue {
-	background: var(--lasuite-color-gray-000) !important;
+	background: var(--lasuite--contextuals--background--surface--primary, var(--lasuite-color-gray-000)) !important;
 	/* gray-100 — matches the sidebar border-right measured on the live La Suite
 	   app (2026-07-27); every structural hairline uses this step. */
 	border-right: 1px solid var(--lasuite-color-gray-100) !important;
@@ -321,7 +312,7 @@ header#header {
    La Suite marks the current item with a neutral 5% wash and nothing else.
    Measured on La Suite Messages (.mailbox__item-row, active):
 
-       background   rgba(27, 27, 35, 0.05)
+       background   var(--lasuite-active-row-wash, rgba(27, 27, 35, 0.05))
        border-radius 4px
        border-left  0 — none
        font-weight  400   (identical to the inactive row)
@@ -357,8 +348,8 @@ header#header {
 #app-navigation .app-navigation-entry--active,
 .app-navigation-entry.app-navigation-entry.active.active.active,
 .app-navigation-entry.app-navigation-entry--active.app-navigation-entry--active {
-	background: rgba(27, 27, 35, 0.05) !important;
-	background-color: rgba(27, 27, 35, 0.05) !important;
+	background: var(--lasuite-active-row-wash, rgba(27, 27, 35, 0.05)) !important;
+	background-color: var(--lasuite-active-row-wash, rgba(27, 27, 35, 0.05)) !important;
 	border-radius: var(--lasuite-border-radius) !important;
 }
 
@@ -388,7 +379,7 @@ header#header {
 .app-navigation-entry.app-navigation-entry.active.active a,
 .app-navigation-entry.app-navigation-entry.active.active .app-navigation-entry-link,
 .app-navigation-entry.app-navigation-entry.active.active .app-navigation-entry__name {
-	color: var(--lasuite-color-gray-850) !important;
+	color: var(--lasuite-content-primary, var(--lasuite-color-gray-850)) !important;
 	font-weight: 400 !important;
 }
 
@@ -420,7 +411,7 @@ header#header {
 .list-item__wrapper.active .list-item,
 .list-item__wrapper--active .list-item:hover,
 .list-item__wrapper--active .list-item:focus-within {
-	background-color: rgba(27, 27, 35, 0.05) !important;
+	background-color: var(--lasuite-active-row-wash, rgba(27, 27, 35, 0.05)) !important;
 }
 
 .list-item__wrapper--active .list-item::before,
@@ -495,7 +486,7 @@ header#header {
 
 #content-vue,
 #content-vue.content {
-	background-color: var(--lasuite-color-gray-025) !important;
+	background-color: var(--lasuite--contextuals--background--surface--tertiary, var(--lasuite-color-gray-025)) !important;
 	border-radius: 0 !important;
 	/* Fill the outer shell exactly. Nextcloud sizes this 8px short (it expects
 	   the outer shell's 8px bottom inset), which left a strip of body colour
@@ -546,7 +537,7 @@ body > #content-vue,
 #app-content,
 .app-content,
 #app-content-vue {
-	background: var(--lasuite-color-gray-000) !important;
+	background: var(--lasuite--contextuals--background--surface--primary, var(--lasuite-color-gray-000)) !important;
 	border-radius: var(--lasuite-border-radius) !important;
 	margin: 22px !important;
 }
@@ -582,8 +573,8 @@ button.primary,
 input.primary,
 .button-vue.button-vue--vue-primary,
 button[class*="primary"] {
-	background-color: var(--lasuite-color-brand-550) !important;
-	border-color: var(--lasuite-color-brand-550) !important;
+	background-color: var(--lasuite-content-brand-icon, var(--lasuite-color-brand-550)) !important;
+	border-color: var(--lasuite-content-brand-icon, var(--lasuite-color-brand-550)) !important;
 	border-radius: var(--lasuite-border-radius) !important;
 }
 
@@ -604,8 +595,8 @@ button[class*="primary"] {
 .button-vue--vue-primary:hover,
 button.primary:hover,
 .button-vue.button-vue--vue-primary:hover {
-	background-color: var(--lasuite-color-brand-650) !important;
-	border-color: var(--lasuite-color-brand-650) !important;
+	background-color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
+	border-color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
 }
 
 /* ============================================
@@ -672,20 +663,40 @@ button.secondary {
 
    Both forms are matched below. The same applies to primary and secondary, but
    those blocks already catch either spelling through their
-   `button[class*="primary"]` / `button[class*="secondary"]` fallbacks. */
+   `button[class*="primary"]` / `button[class*="secondary"]` fallbacks.
 
-:not(#header) > .button-vue--tertiary.button-vue--text-only,
-:not(#header) .button-vue--tertiary.button-vue--icon-and-text,
-:not(#header) > .button-vue--vue-tertiary.button-vue--text-only,
-:not(#header) .button-vue--vue-tertiary.button-vue--icon-and-text {
+   HOW THE HEADER EXCLUSION IS WRITTEN, AND WHY IT CHANGED.
+
+   These rules used to start `:not(#header) …`, which does NOT mean "not in the
+   header". It tests the ANCESTOR in the combinator, and for a descendant
+   combinator any non-header ancestor — body, a nav, a div — satisfies it. So
+   `:not(#header) .button-vue--tertiary.button-vue--icon-and-text` matched the
+   header's own current-app button, because `nav.app-menu` is not `#header`.
+
+   The consequence was invisible and specific: the leak coloured that button
+   brand-tertiary, and the `span` rule below forced `color: inherit` onto its
+   children — overriding the current-app-name rule higher in this file no matter
+   what colour it asked for. That is what made the app name look immovable at
+   brand-550 while the parity spec expected brand-650, and it is why setting
+   brand-650 there appeared to do nothing.
+
+   The guard now sits on the BUTTON (`:not(#header *)`), which excludes any
+   element that is a descendant of the header — the thing actually intended.
+   Verified live: the old member matched the header button, the new one does
+   not, and both still match genuine tertiary buttons elsewhere. */
+
+.button-vue--tertiary.button-vue--text-only:not(#header *),
+.button-vue--tertiary.button-vue--icon-and-text:not(#header *),
+.button-vue--vue-tertiary.button-vue--text-only:not(#header *),
+.button-vue--vue-tertiary.button-vue--icon-and-text:not(#header *) {
 	color: var(--lasuite--contextuals--content--semantic--brand--tertiary) !important;
 	background-color: transparent !important;
 }
 
-:not(#header) > .button-vue--tertiary.button-vue--text-only span,
-:not(#header) .button-vue--tertiary.button-vue--icon-and-text span,
-:not(#header) > .button-vue--vue-tertiary.button-vue--text-only span,
-:not(#header) .button-vue--vue-tertiary.button-vue--icon-and-text span {
+.button-vue--tertiary.button-vue--text-only:not(#header *) span,
+.button-vue--tertiary.button-vue--icon-and-text:not(#header *) span,
+.button-vue--vue-tertiary.button-vue--text-only:not(#header *) span,
+.button-vue--vue-tertiary.button-vue--icon-and-text:not(#header *) span {
 	color: inherit !important;
 }
 
@@ -720,7 +731,7 @@ input[type="password"],
 input[type="text"]:focus,
 input[type="search"]:focus,
 input[type="email"]:focus {
-	border-color: var(--lasuite-color-brand-650) !important;
+	border-color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
 	box-shadow: 0 0 0 2px var(--nldesign-color-focus) !important;
 }
 
@@ -741,4 +752,69 @@ label {
 h1, h2, h3, h4, h5, h6 {
 	font-family: var(--lasuite-font-family);
 	color: var(--lasuite-color-gray-900);
+}
+
+/* ============================================
+   DARK MODE
+
+   Until now this design system had NO dark handling at all: every rule above
+   applied unconditionally, and the shell read raw ramp steps
+   (`gray-000`, `gray-025`) that have no dark counterpart. Verified live before
+   this block existed — with `data-themes=dark`, Nextcloud's own
+   `--color-main-background` flipped to #171717 while the header, canvas and
+   card stayed byte-identical to light mode.
+
+   HOW CUNNINGHAM ACTUALLY DOES IT. Reading La Suite's own
+   `.cunningham-theme--dark` block in the vendored source, the dark theme does
+   NOT invert the ramp — `gray-000` is still #fff there. It remaps the
+   CONTEXTUAL surface tokens instead:
+
+       background--surface--primary    → gray-800
+       background--surface--secondary  → gray-850
+       background--surface--tertiary   → gray-900
+       border--surface--primary        → gray-750
+
+   So the shell rules above now read those contextuals (with the raw step as a
+   fallback), and this block remaps them. That is why repointing was the first
+   half of the fix: a dark block cannot reach a rule that hardcodes `gray-000`.
+
+   RAMP COVERAGE. Our generator emits only gray-850 and gray-900 from the dark
+   end of the ramp — 700, 750 and 800 are unset. The mapping below therefore
+   uses the two steps that exist, preserving the figure/ground relationship that
+   matters (card LIGHTER than the canvas it sits on, mirroring white-on-grey in
+   light mode) rather than inventing values. Emitting the missing steps is a
+   generator change and is tracked separately.
+
+   SCOPE SELECTORS mirror css/tokens/dark/lasuite.css exactly, so this block
+   turns on and off with the rest of the dark layer.
+   ============================================ */
+
+@media (prefers-color-scheme: dark) {
+	body:not([data-theme-light]):not([data-theme-dark]):not([data-theme-light-highcontrast]):not([data-theme-dark-highcontrast]) {
+		--lasuite--contextuals--background--surface--primary: var(--lasuite-color-gray-850);
+		--lasuite--contextuals--background--surface--secondary: var(--lasuite-color-gray-900);
+		--lasuite--contextuals--background--surface--tertiary: var(--lasuite-color-gray-900);
+		/* No gray-750/800 is emitted, so the hairline is a translucent white:
+		   it stays visible against both surface steps without inventing a ramp
+		   value that upstream would disagree with. */
+		--lasuite--contextuals--border--surface--primary: rgba(255, 255, 255, 0.12);
+		--lasuite-active-row-wash: rgba(255, 255, 255, 0.08);
+		--lasuite-content-primary: var(--lasuite-color-gray-050);
+		--lasuite-content-muted: var(--lasuite-color-gray-200);
+		--lasuite-content-brand: var(--lasuite-color-brand-050);
+		--lasuite-content-brand-icon: var(--lasuite-color-brand-050);
+	}
+}
+
+body[data-theme-dark],
+body[data-themes*="dark"] {
+	--lasuite--contextuals--background--surface--primary: var(--lasuite-color-gray-850);
+	--lasuite--contextuals--background--surface--secondary: var(--lasuite-color-gray-900);
+	--lasuite--contextuals--background--surface--tertiary: var(--lasuite-color-gray-900);
+	--lasuite--contextuals--border--surface--primary: rgba(255, 255, 255, 0.12);
+	--lasuite-active-row-wash: rgba(255, 255, 255, 0.08);
+	--lasuite-content-primary: var(--lasuite-color-gray-050);
+	--lasuite-content-muted: var(--lasuite-color-gray-200);
+	--lasuite-content-brand: var(--lasuite-color-brand-050);
+	--lasuite-content-brand-icon: var(--lasuite-color-brand-050);
 }

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -818,3 +818,63 @@ body[data-themes*="dark"] {
 	--lasuite-content-brand: var(--lasuite-color-brand-050);
 	--lasuite-content-brand-icon: var(--lasuite-color-brand-050);
 }
+
+/* ============================================
+   HEADER ICONS — remove Nextcloud's fade-out gradient mask
+
+   Nextcloud applies a gradient MASK to header glyphs and to the current app's
+   icon:
+
+       mask-image: linear-gradient(#fff 25%, rgba(255,255,255,.45) 90%)
+
+   Fully opaque for the top quarter, then fading to 45%. On a 20px icon that
+   reads as a gradient wash — and on a light-coloured app icon it fades far
+   enough to look as though the icon is simply missing. Both were reported from
+   screenshots: "top left header icons have a gradient" and "the app icon
+   disappeared from the header".
+
+   La Suite uses no gradients anywhere in its chrome, so the mask is removed
+   rather than tuned. Note this is NOT a background-image gradient — an earlier
+   pass scanned for those, found none, and wrongly concluded there was no
+   gradient at all. It is a mask, which is why it never showed up.
+
+   The mask has no author rule, no inline style, and no adopted stylesheet
+   behind it, so it is neutralised by property rather than by out-specifying a
+   source that cannot be located. The logo keeps ITS mask — that one is ours,
+   and it is what paints the logo brand violet. */
+#header .app-menu__current-app-icon,
+#header .app-menu-entry__icon,
+#header .header-end svg,
+#header .header-start svg,
+#header .notifications-button__icon svg,
+#header .button-vue__icon svg,
+#header .button-vue__icon img {
+	-webkit-mask-image: none !important;
+	mask-image: none !important;
+}
+
+/* The current app's icon is an <img> pointing at that app's own SVG
+   (e.g. /custom_apps/hermiq/img/app.svg), and Nextcloud ships those icons WHITE
+   because its header is normally dark. Removing the gradient mask above made
+   the element render at full size and opacity — but white-on-white is still
+   invisible, which is why the icon still looked absent after that fix.
+
+   `color` cannot reach an <img>, and the masking trick used for the Nextcloud
+   logo needs a known URL — this src differs per app and is not knowable from
+   CSS. Nextcloud's own answer to exactly this problem is
+   --background-invert-if-bright, which resolves to `invert(100%)` on a bright
+   header and to `no` on a dark one. REQ-CSS-007 reserves that variable against
+   being SET; reading it is what it exists for, and it keeps the icon correct in
+   both light and dark without this file having to know the theme.
+
+   The result is a dark icon rather than a brand-violet one. Tinting an
+   arbitrary per-app image to an exact colour is not expressible in CSS without
+   its URL, and a visible icon in the platform's own idiom beats an invisible
+   one. */
+#header .app-menu__current-app-icon,
+#header .app-menu-entry__icon img,
+#header .app-menu-icon img {
+	filter: var(--background-invert-if-bright, none) !important;
+	-webkit-filter: var(--background-invert-if-bright, none) !important;
+	opacity: 1 !important;
+}

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -186,27 +186,28 @@ header#header {
 	min-block-size: 0 !important;
 }
 
-#header .unified-search-input__label,
-#header .unified-search-input input::placeholder,
-#header .unified-search__input::placeholder {
+/* The control is a BUTTON, not a text field. Nextcloud 34 renders:
+ *
+ *     <search class="unified-search-input">
+ *       <button class="unified-search-input__button">
+ *         <span class="unified-search-input__icon">   <- magnifier
+ *         <span class="unified-search-input__label">  <- the prompt text
+ *
+ * There is no `<input>` and no `::placeholder` anywhere in it. An earlier
+ * revision styled `input`, `input::placeholder` and `.button-vue__icon` here —
+ * all three matched nothing. The visible fix worked only because the container
+ * and label rules happened to be correct; the rest was inert. Caught by
+ * tests/e2e/spec-coverage/selector-liveness.spec.ts. */
+#header .unified-search-input__label {
 	color: var(--lasuite-color-gray-500) !important;
 	font-size: 14px !important;
 	font-weight: 500 !important;
 }
 
-#header .unified-search-input input,
-#header .unified-search-input__button .button-vue__text {
-	background-color: transparent !important;
-	border: 0 !important;
-	color: var(--lasuite-color-gray-850) !important;
-	font-size: 14px !important;
-	font-weight: 500 !important;
-}
-
-/* The magnifier inside the field is a neutral affordance in La Suite, not a
-   brand-tinted action, so it opts out of the brand colour set above. */
-#header .unified-search-input svg,
-#header .unified-search-input .button-vue__icon {
+/* The magnifier is a neutral affordance in La Suite, not a brand-tinted action,
+   so it opts out of the brand colour applied to header glyphs above. */
+#header .unified-search-input__icon,
+#header .unified-search-input svg {
 	color: var(--lasuite-color-gray-500) !important;
 }
 

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -923,3 +923,30 @@ body[data-themes*="dark"] {
 	content: none !important;
 	display: none !important;
 }
+
+/* ============================================
+   THE GROUND BENEATH EVERYTHING — what shows before the shell paints
+
+   Nextcloud paints html/body with --color-background-plain (#00679e, its
+   brand blue). Every rule in this file styles elements INSIDE that ground, so
+   until the shell has laid itself out the whole viewport is Nextcloud blue —
+   visible as a full-screen blue flash on every navigation, and permanently on
+   any page whose content does not cover the viewport.
+
+   REQ-CSS-007 reserves --color-background-plain against being SET, because
+   Nextcloud's dark-mode derivation reads it. It does not reserve the body
+   element. Setting the PROPERTY here leaves the variable, and therefore the
+   derivation, untouched — the same distinction that let the Nextcloud-facing
+   text colours be flipped for dark mode without touching the reserved
+   background.
+
+   The theming background IMAGE is deliberately left alone: it paints over this
+   colour where Nextcloud intends a wallpaper (login, guest pages), so admins
+   keep that feature and only the ground beneath it changes. */
+html,
+body,
+body#body-user,
+body#body-login,
+body#body-public {
+	background-color: var(--lasuite--contextuals--background--surface--tertiary, var(--lasuite-color-gray-025)) !important;
+}

--- a/openspec/changes/lasuite-dark-palette/.openspec.yaml
+++ b/openspec/changes/lasuite-dark-palette/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/lasuite-dark-palette/proposal.md
+++ b/openspec/changes/lasuite-dark-palette/proposal.md
@@ -1,0 +1,94 @@
+---
+kind: code
+---
+
+## Why
+
+The `lasuite` design system has **no dark palette at all**, and its element
+overrides pin light values with `!important` — so on an instance in dark mode
+the theme forces a light interface anyway.
+
+This was found while auditing the parity work of 2026-07-28/29. It is not a
+regression introduced by that work; it is a gap the work made larger, because
+several new rules were written against the same light-only ramp.
+
+### The evidence
+
+1. **No dark scope exists in the system.** No file under
+   `css/systems/lasuite/` contains `prefers-color-scheme` or
+   `data-themes*=dark`. Every rule there applies unconditionally.
+
+2. **The dark variant file does not touch the ramp the overrides use.**
+   `css/tokens/dark/lasuite.css` redefines 44 custom properties, and all of them
+   are `--nldesign-*`. Not one `--lasuite-color-*` token is redefined. Checked
+   individually: `gray-000`, `gray-025`, `gray-050`, `gray-100`, `gray-500`,
+   `gray-850`, `brand-550` and `brand-050` all keep their light values in the
+   dark variant.
+
+3. **The overrides consume exactly those tokens, with `!important`.** So the
+   dark variant's `--nldesign-color-header-background` is computed and then
+   discarded, because `element-overrides.css` sets
+   `#header { background: var(--lasuite-color-gray-000) !important }` — white,
+   in dark mode.
+
+The visible consequences, all following from the same cause:
+
+| Surface | Dark-mode result |
+|---|---|
+| Header | `gray-000` → white bar |
+| Content canvas | `gray-025` → near-white ground |
+| Content card | `gray-000` → white card |
+| Search field | `gray-025` fill, `gray-100` hairline — light on light |
+| Active row wash | `rgba(27,27,35,.05)` — a dark wash designed for a light surface; near-invisible on a dark one |
+| Logo | masked to `brand-550`; readable, but on a bar that should not be white |
+
+### Why the existing test suite did not catch it
+
+`tests/e2e/spec-coverage/dark-mode.spec.ts` asserts that the dark stylesheet is
+**injected in the right order** and is **dual-scoped**, and that the admin toggle
+reflects persisted state. It never renders a page in dark mode and contains zero
+references to `#header`, `#content`, the logo or any shell element. The
+stylesheet is correctly ordered and correctly scoped — and has no effect on this
+design system. The suite is measuring plumbing, not outcome.
+
+## What Changes
+
+- Author a **dark ramp for the `--lasuite-color-*` tokens**, sourced the same way
+  the light ramp was: from La Suite's own shipped Cunningham dark palette rather
+  than by mechanically inverting the light values. La Suite ships a dark theme;
+  its values are the reference, exactly as they were for the light ramp.
+- Emit them into `css/tokens/dark/lasuite.css` under the **existing** dark scope
+  selectors, so no new scoping mechanism is introduced and the ordering the
+  current spec already guarantees continues to hold.
+- Re-express the **translucent** values in `element-overrides.css` so they work
+  on both grounds. The active-row wash is the clear case: `rgba(27,27,35,.05)`
+  is a dark wash for a light surface and cannot simply be reused.
+- Extend the dark-mode e2e spec to **render** and assert computed values on the
+  shell — header, canvas, card, active row, search field — instead of only
+  checking injection order.
+
+Explicitly **not** in scope: changing the light palette, the reserved
+REQ-CSS-007 variables, or the `nldesign` / `summer-breeze` / `high-contrast`
+systems.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `dark-mode`: gains the requirement that a design system's own token ramp — not
+  merely the `--nldesign-*` layer — must have a dark counterpart when its
+  element overrides consume that ramp directly, plus rendered assertions rather
+  than injection-order assertions alone.
+- `lasuite-stack`: gains a dark palette.
+
+## Impact
+
+- **Visual**: instances in dark mode currently get a light interface under this
+  theme. After the change they get a dark one — a large, intended, visible
+  change for anyone already running `lasuite` with dark mode on.
+- **Risk**: the reserved REQ-CSS-007 variables are what Nextcloud's own dark
+  derivation depends on. This change must not touch them; it adds a dark ramp
+  for the theme's OWN tokens and nothing else.
+- **Accessibility**: the dark ramp has to clear the same WCAG loop the existing
+  `dark-mode` spec already requires for generated variants, so contrast is
+  verified rather than assumed.

--- a/openspec/changes/lasuite-dark-palette/specs/dark-mode/spec.md
+++ b/openspec/changes/lasuite-dark-palette/specs/dark-mode/spec.md
@@ -1,0 +1,67 @@
+# dark-mode — delta
+
+Requirements added by the `lasuite-dark-palette` change.
+
+## ADDED Requirements
+
+### Requirement: A design system whose overrides consume its own token ramp SHALL ship a dark counterpart for that ramp
+
+A design system MUST define dark values for every `--{system}-*` token its own
+`element-overrides.css` consumes. When a design system's `element-overrides.css`
+reads `--{system}-*` tokens directly, the system SHALL define dark values for
+every such token it consumes.
+Redefining only the shared `--nldesign-*` layer is NOT sufficient: an override
+that reads the system ramp with `!important` discards the `--nldesign-*` value
+entirely, so the dark variant computes and is then thrown away.
+
+Dark values SHALL be sourced from the upstream design system's own dark palette
+where one exists, rather than derived by inverting the light ramp.
+
+#### Scenario: A system-ramp token consumed by an override has a dark value
+
+- **GIVEN** `element-overrides.css` reads `--lasuite-color-gray-000`
+- **WHEN** the dark variant for that system is generated
+- **THEN** `--lasuite-color-gray-000` has a dark value in that variant
+- **AND** the value comes from the upstream dark palette, not from inverting the light one
+
+#### Scenario: Redefining only the shared layer fails the check
+
+- **GIVEN** a dark variant that redefines `--nldesign-color-header-background`
+- **AND** an override that sets the header from `--lasuite-color-gray-000` with `!important`
+- **WHEN** the dark-ramp check runs
+- **THEN** it fails, because the token the override actually consumes has no dark value
+
+### Requirement: Translucent override values SHALL be legible on both grounds
+
+A value expressed as a translucent overlay SHALL be defined per ground, or
+expressed so it resolves correctly on both. A dark wash intended for a light
+surface SHALL NOT be reused unchanged on a dark surface.
+
+#### Scenario: The active-row wash remains visible in dark mode
+
+- **GIVEN** the active navigation row is marked by a translucent wash
+- **WHEN** the interface renders in dark mode
+- **THEN** the wash is distinguishable from the surrounding surface
+- **AND** the selected row is identifiable without relying on colour alone
+
+### Requirement: Dark-mode verification SHALL assert rendered values, not only stylesheet injection
+
+The dark-mode e2e coverage SHALL load real pages in dark mode and assert the
+COMPUTED values of the shell — header, content canvas, content card, active row
+and search field. Asserting stylesheet order, scoping and toggle state alone is
+insufficient: a stylesheet can be correctly ordered, correctly scoped, and have
+no effect on the system under test.
+
+#### Scenario: The shell is dark in dark mode
+
+- **WHEN** a page renders with the dark variant active
+- **THEN** the header background is a dark value
+- **AND** the content canvas and card are dark values
+- **AND** none of them resolve to the light ramp
+
+#### Scenario: Injection-order coverage alone does not satisfy this requirement
+
+- **GIVEN** a suite that asserts only injection order, scoping and toggle state
+- **WHEN** a design system ships no dark ramp for its own tokens
+- **THEN** that suite passes while the interface renders light
+- **AND** this requirement is therefore NOT met by such a suite

--- a/openspec/changes/lasuite-dark-palette/tasks.md
+++ b/openspec/changes/lasuite-dark-palette/tasks.md
@@ -1,0 +1,42 @@
+# Tasks — lasuite dark palette
+
+## 1. Source the palette
+
+- [ ] Extract La Suite's shipped dark Cunningham values for the `--lasuite-color-*`
+      ramp, the same way the light ramp was sourced
+      - do not invert the light ramp; upstream ships a dark theme and it is the reference
+- [ ] Record which tokens have no upstream dark counterpart and decide each explicitly
+
+## 2. Emit
+
+- [ ] Extend the generator so the lasuite dark variant emits `--lasuite-color-*`
+      alongside the existing `--nldesign-*` values
+- [ ] Emit under the EXISTING dark scope selectors so injection order and scoping
+      keep satisfying the current dark-mode spec
+- [ ] Verify no REQ-CSS-007 reserved variable is written
+
+## 3. Translucent values
+
+- [ ] Re-express the active-row wash so it is legible on both grounds
+- [ ] Audit `element-overrides.css` for any other translucent literal and give each
+      a dark counterpart
+
+## 4. Verification
+
+- [ ] Extend `tests/e2e/spec-coverage/dark-mode.spec.ts` to render in dark mode and
+      assert computed shell values (header, canvas, card, active row, search)
+- [ ] Add the WCAG contrast loop the dark-mode spec already requires for generated variants
+- [ ] Add a guard asserting every `--lasuite-color-*` token READ by element-overrides
+      has a dark value — the check that would have caught this
+
+## 5. Evidence
+
+- [ ] Capture the four surfaces in dark mode before and after
+- [ ] Update `openspec/specs/dark-mode/spec.md` with the merged requirements
+
+## Acceptance criteria
+
+- Header, canvas, card, active row and search field all resolve to dark values in dark mode
+- No reserved REQ-CSS-007 variable is written by the dark variant
+- The selected navigation row stays identifiable in dark mode
+- `composer check:strict`, stylelint and the unit suite stay green

--- a/tests/Unit/LasuiteDesignStackTest.php
+++ b/tests/Unit/LasuiteDesignStackTest.php
@@ -780,16 +780,29 @@ class LasuiteDesignStackTest extends TestCase
     {
         $overrides = (string) file_get_contents($this->repoRoot().'/css/systems/lasuite/element-overrides.css');
 
+        // The surfaces are read through the CONTEXTUAL tokens, with the raw ramp
+        // step kept as the fallback. That indirection is what makes dark mode
+        // possible at all: Cunningham's own dark theme does not invert the ramp
+        // (`gray-000` is still #fff there) — it remaps the contextual surface
+        // tokens. A rule that hardcodes `gray-025` cannot be reached by a dark
+        // block, so asserting the literal here would lock out dark support.
+        // The fallback is asserted too, so the grey/white intent still holds if
+        // a contextual is ever missing.
         $this->assertMatchesRegularExpression(
-            '/#content-vue\.content[^{]*\{[^}]*background-color:\s*var\(--lasuite-color-gray-025\)/ms',
+            '/#content-vue\.content[^{]*\{[^}]*background-color:\s*var\('
+            .'--lasuite--contextuals--background--surface--tertiary,\s*'
+            .'var\(--lasuite-color-gray-025\)\)/ms',
             $overrides,
-            'The shell (#content-vue.content) must carry the grey gray-025 canvas.'
+            'The shell (#content-vue.content) must carry the grey canvas via the '
+            .'contextual surface token, falling back to gray-025.'
         );
 
         $this->assertMatchesRegularExpression(
-            '/#app-content-vue\s*\{[^}]*background:\s*var\(--lasuite-color-gray-000\)/ms',
+            '/#app-content-vue\s*\{[^}]*background:\s*var\('
+            .'--lasuite--contextuals--background--surface--primary,\s*'
+            .'var\(--lasuite-color-gray-000\)\)/ms',
             $overrides,
-            'The app content must be the white card floated on the grey canvas.'
+            'The app content must be the card surface, falling back to gray-000.'
         );
     }//end testElementOverridesInvertsCanvasAndCard()
 }//end class

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -41,7 +41,10 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	const context = await browser.newContext({ baseURL })
 	const page = await context.newPage()
 
-	await page.goto('/index.php/login')
+	// `domcontentloaded`, not the default `load`: this instance keeps long-lived
+	// requests open, so waiting for the full load event times out on a page that
+	// is already interactive.
+	await page.goto('/index.php/login', { waitUntil: 'domcontentloaded' })
 	// The Nextcloud login form is client-rendered (Vue): the inputs do not
 	// exist in the initial HTML, so filling immediately after goto() races the
 	// hydration and fails with "element not found". Wait for the real field.
@@ -49,12 +52,40 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	await userField.waitFor({ state: 'visible', timeout: 30_000 })
 	await userField.fill(username)
 	await page.locator('input[name="password"]').fill(password)
-	await page.locator('button[type="submit"]').first().click()
-	await page.waitForSelector('#header, header.header', { timeout: 20_000 })
+	// `noWaitAfter` because Nextcloud lands on the Dashboard, whose widgets keep
+	// issuing requests long after the page is usable. Playwright's default
+	// post-click wait for "scheduled navigations to finish" therefore hangs even
+	// though the click and the navigation both already succeeded — the call log
+	// shows the redirect completing and the click timing out anyway.
+	await page.locator('button[type="submit"]').first().click({ noWaitAfter: true })
+
+	// Wait for NAVIGATION, not for an element.
+	//
+	// This previously waited for `#header, header.header` to be visible and hung
+	// for the full timeout while the log said "locator resolved to visible
+	// <header id="header">" — a contradiction that made the harness look dead.
+	// The cause is that Nextcloud's post-login shell mounts in Vue and detaches
+	// and re-attaches #header while it settles, so the visibility check never
+	// finds a stable frame to resolve against, however plainly the element is
+	// there. Waiting on the URL leaving /login is a signal that cannot be
+	// re-rendered out from under the check.
+	// Polled rather than `waitForURL`: because the click above is `noWaitAfter`,
+	// the redirect has usually ALREADY happened by the time we get here, and
+	// waitForURL then sits waiting for a further navigation that never comes —
+	// timing out while its own log says "navigated to /apps/dashboard/". Reading
+	// the current URL has no such ordering assumption.
+	const deadline = Date.now() + 60_000
+	while (Date.now() < deadline) {
+		if (!/\/login(\?|$|\/)/.test(page.url())) break
+		await page.waitForTimeout(500)
+	}
+
 	const currentUrl = page.url()
 	if (/\/login(\?|$|\/)/.test(currentUrl)) {
 		throw new Error(`Login failed — still on ${currentUrl}.`)
 	}
+	// Only now assert the shell exists at all, without racing its re-renders.
+	await page.locator('#header, header.header').first().waitFor({ state: 'attached', timeout: 20_000 })
 
 	await context.storageState({ path: STORAGE_STATE })
 	await browser.close()

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -84,8 +84,17 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
 	if (/\/login(\?|$|\/)/.test(currentUrl)) {
 		throw new Error(`Login failed — still on ${currentUrl}.`)
 	}
-	// Only now assert the shell exists at all, without racing its re-renders.
-	await page.locator('#header, header.header').first().waitFor({ state: 'attached', timeout: 20_000 })
+	// A last sanity check that the shell rendered — but NOT a gate. Leaving
+	// /login already proves the credentials worked and the session cookie is
+	// set, which is the only thing this setup exists to produce. On a loaded
+	// instance the Dashboard can take longer than any timeout worth hard-coding,
+	// and failing here would abort every suite over a slow render rather than a
+	// real problem. Warn and continue.
+	try {
+		await page.locator('#header, header.header').first().waitFor({ state: 'attached', timeout: 30_000 })
+	} catch {
+		console.warn('[global-setup] logged in, but the app shell had not rendered yet — continuing')
+	}
 
 	await context.storageState({ path: STORAGE_STATE })
 	await browser.close()

--- a/tests/e2e/spec-coverage/lasuite-parity.spec.ts
+++ b/tests/e2e/spec-coverage/lasuite-parity.spec.ts
@@ -140,7 +140,11 @@ function referenceTable(set: 'lasuite' | 'cunningham'): ElementRef[] {
 			selector: '#header .app-menu__current-app-name',
 			ref: {
 				color: brand650,
-				fontWeight: '600',
+				// 700, not 600. Read off La Suite Docs (localhost:3000), which renders
+				// its wordmark as TEXT and so exposes a computed value — Messages ships
+				// an image and cannot be measured. Live: rgb(72,68,173), 22px, 700.
+				// The colour in this reference was already right; the weight was not.
+				fontWeight: '700',
 			},
 		},
 		{

--- a/tests/e2e/spec-coverage/lasuite-parity.spec.ts
+++ b/tests/e2e/spec-coverage/lasuite-parity.spec.ts
@@ -128,9 +128,16 @@ function referenceTable(set: 'lasuite' | 'cunningham'): ElementRef[] {
 		},
 		{
 			name: 'header app name',
-			// #header .header-appname is Nextcloud's own header app-name
-			// label — always present in stock chrome.
-			selector: '#header .header-appname',
+			// Nextcloud 34 renders the current app's name through
+			// `.app-menu__current-app-name`. The previous selector here,
+			// `#header .header-appname`, does not exist on NC34 at all — the
+			// comment claiming it is "always present in stock chrome" was written
+			// against an older release. The assertion therefore never ran: the
+			// test failed on a 15s visibility timeout rather than on any value,
+			// and the failure was reported as "header app name matches the
+			// Cunningham reference", which reads like a parity regression.
+			// Found by tests/e2e/spec-coverage/selector-liveness.spec.ts.
+			selector: '#header .app-menu__current-app-name',
 			ref: {
 				color: brand650,
 				fontWeight: '600',
@@ -276,6 +283,13 @@ let baselineTokenSet: string | null = null
 test.describe('lasuite-parity', () => {
 	test.describe.configure({ mode: 'serial' })
 
+	// Every navigation in this suite settles slowly on a loaded instance, and the
+	// default 30s budget turns that into a reported PARITY failure — the report
+	// names the element ("primary button matches the Cunningham reference") while
+	// the actual error is a navigation timeout, which reads as a regression that
+	// is not there. Budget set once for the whole describe.
+	test.setTimeout(120_000)
+
 	// @e2e exclude openspec/specs/lasuite-parity/spec.md#mismatch-names-the-property-and-delta
 	// Proven by manually reverting a reference value and observing the
 	// Playwright assertion message during development (see PR description);
@@ -283,9 +297,17 @@ test.describe('lasuite-parity', () => {
 	// carry permanently.
 
 	test.beforeAll(async ({ browser }) => {
+		// This hook mutates instance-wide state, so it gets a realistic budget:
+		// the default 30s is not enough on a loaded instance and the suite then
+		// aborts on a "beforeAll hook timeout" that looks like a parity failure
+		// in the report but is nothing of the kind.
+		test.setTimeout(120_000)
+
 		const page = await browser.newPage()
-		await page.goto(THEMING_URL)
-		await page.waitForLoadState('networkidle')
+		// `domcontentloaded`, not `networkidle`: Nextcloud polls in the
+		// background (notifications, dashboard widgets), so the network never
+		// goes idle and this wait simply burns the hook's whole budget.
+		await page.goto(THEMING_URL, { waitUntil: 'domcontentloaded' })
 		const token = await requestToken(page)
 		baselineTokenSet = await getTokenSet(page, token)
 		await page.close()
@@ -294,8 +316,10 @@ test.describe('lasuite-parity', () => {
 	test.afterAll(async ({ browser }) => {
 		if (baselineTokenSet === null) return
 		const page = await browser.newPage()
-		await page.goto(THEMING_URL)
-		await page.waitForLoadState('networkidle')
+		await page.goto(THEMING_URL, { waitUntil: 'domcontentloaded' })
+		// `domcontentloaded`, not `networkidle`: Nextcloud polls in the background, so
+		// the network never goes idle and this wait burns the whole test budget.
+		await page.waitForLoadState('domcontentloaded')
 		const token = await requestToken(page)
 		await setTokenSet(page, token, baselineTokenSet)
 		await page.close()
@@ -304,12 +328,16 @@ test.describe('lasuite-parity', () => {
 	for (const set of ['lasuite', 'cunningham'] as const) {
 		for (const element of referenceTable(set)) {
 			test(`${set}: ${element.name} matches the Cunningham reference`, async ({ page }) => {
-				await page.goto(THEMING_URL)
-				await page.waitForLoadState('networkidle')
+				await page.goto(THEMING_URL, { waitUntil: 'domcontentloaded' })
+				// `domcontentloaded`, not `networkidle`: Nextcloud polls in the background, so
+		// the network never goes idle and this wait burns the whole test budget.
+		await page.waitForLoadState('domcontentloaded')
 				const token = await requestToken(page)
 				await setTokenSet(page, token, set)
-				await page.reload()
-				await page.waitForLoadState('networkidle')
+				await page.reload({ waitUntil: 'domcontentloaded' })
+				// `domcontentloaded`, not `networkidle`: Nextcloud polls in the background, so
+		// the network never goes idle and this wait burns the whole test budget.
+		await page.waitForLoadState('domcontentloaded')
 
 				await page.waitForSelector(element.selector, { timeout: 15_000 })
 				const computed = await readComputedStyle(page, element.selector)
@@ -331,8 +359,10 @@ test.describe('lasuite-parity', () => {
 		// than fail on something unrelated to this app's theming code.
 		const token = await requestToken(page)
 		await setTokenSet(page, token, 'lasuite')
-		await page.goto(THEMING_URL)
-		await page.waitForLoadState('networkidle')
+		await page.goto(THEMING_URL, { waitUntil: 'domcontentloaded' })
+		// `domcontentloaded`, not `networkidle`: Nextcloud polls in the background, so
+		// the network never goes idle and this wait burns the whole test budget.
+		await page.waitForLoadState('domcontentloaded')
 
 		const searchButton = page.locator('#header .unified-search__button')
 		if (await searchButton.count() === 0) {

--- a/tests/e2e/spec-coverage/selector-liveness.spec.ts
+++ b/tests/e2e/spec-coverage/selector-liveness.spec.ts
@@ -106,14 +106,29 @@ function allowedReason(selector: string): string | null {
 
 test.describe('lasuite selector liveness', () => {
 	test('every element-overrides selector matches something on at least one surface', async ({ page }) => {
-		test.slow()
+		// Six surfaces, each a full Vue app boot. test.slow() alone is not enough
+		// on a loaded dev instance, so the budget is set explicitly.
+		test.setTimeout(300_000)
 
 		const liveEverywhere = new Set<string>()
 		let allSelectors: string[] = []
 		let sheetSeenOnce = false
 
+		const unreachable: string[] = []
+
 		for (const surface of SURFACES) {
-			await page.goto(surface.path, { waitUntil: 'domcontentloaded' })
+			// A surface that will not load on a loaded dev box must not fail the
+			// guard: union semantics mean a missing surface can only make the
+			// result MORE conservative (fewer selectors proven live), never produce
+			// a false accusation. Unreachable surfaces are reported, not fatal —
+			// a guard that breaks when the instance is slow gets switched off, and
+			// then it protects nothing.
+			try {
+				await page.goto(surface.path, { waitUntil: 'domcontentloaded', timeout: 45_000 })
+			} catch {
+				unreachable.push(surface.name)
+				continue
+			}
 			// Vue apps mount after load; give the shell a moment to render.
 			await page.waitForTimeout(2500)
 
@@ -170,6 +185,16 @@ test.describe('lasuite selector liveness', () => {
 			!sheetSeenOnce,
 			'lasuite element-overrides.css was not served on any surface — activate the lasuite token set to run this guard',
 		)
+
+		if (unreachable.length > 0) {
+			// Surfaced rather than swallowed: a run that silently surveyed half the
+			// surfaces looks identical to a clean one otherwise.
+			console.warn(`[selector-liveness] surfaces that did not load: ${unreachable.join(', ')}`)
+		}
+		expect(
+			unreachable.length,
+			`Too few surfaces loaded (${unreachable.join(', ')}) — the union would be too narrow to trust`,
+		).toBeLessThan(SURFACES.length - 1)
 
 		const unexplainedDead = allSelectors
 			.filter((sel) => !liveEverywhere.has(sel))

--- a/tests/e2e/spec-coverage/selector-liveness.spec.ts
+++ b/tests/e2e/spec-coverage/selector-liveness.spec.ts
@@ -95,6 +95,20 @@ const ALLOWED: Array<{ pattern: RegExp; reason: string }> = [
 		pattern: /\.list-item__wrapper\.active/,
 		reason: 'Alternate selection spelling; NC34 uses .list-item__wrapper--active. Both carried.',
 	},
+	{
+		pattern: /app-navigation--close/,
+		reason: 'Collapsed-sidebar state; the class only exists while the navigation is collapsed.',
+	},
+	{
+		pattern: /^(textarea|select|\.button)$|^input\[type=|^h[4-6]$/,
+		reason: 'Base-layer rules for plain form controls and minor headings. The surveyed surfaces are '
+			+ 'Vue apps that render their own components instead, but these still apply on form-bearing '
+			+ 'admin pages and inside dialogs.',
+	},
+	{
+		pattern: /unified-search__input/,
+		reason: 'Pre-NC34 unified-search markup, retained as a fallback for older servers.',
+	},
 ]
 
 function allowedReason(selector: string): string | null {

--- a/tests/e2e/spec-coverage/selector-liveness.spec.ts
+++ b/tests/e2e/spec-coverage/selector-liveness.spec.ts
@@ -1,0 +1,208 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * @e2e openspec/specs/lasuite-parity/spec.md
+ *
+ * SELECTOR LIVENESS — does every rule this theme ships actually match anything?
+ *
+ * Every visual defect found in the 2026-07-28/29 parity rounds had the same
+ * root cause: a selector that reads plausibly, passes review, lints clean, and
+ * matches NOTHING in the live DOM.
+ *
+ *   - `#app-navigation …`     Nextcloud 34 renders `#app-navigation-vue`.
+ *                             12 of 13 rules were inert; the one live rule lost
+ *                             on specificity to nc-vue's scoped `!important`,
+ *                             so the active row kept its brand tint.
+ *   - `#content.content`      Only the INNER shell carries the `content` class.
+ *                             The outer shell kept Nextcloud's 8px inset and
+ *                             16px radius — the body-colour frame — while the
+ *                             inner one got a second 50px top margin, opening
+ *                             the band under the header.
+ *   - `.button-vue--vue-tertiary`
+ *                             NC34 emits BOTH that and `button-vue--tertiary`.
+ *                             Measured on one page: 60 plain vs 1 `--vue-`.
+ *                             The block listed only `--vue-`, so it styled one
+ *                             button and missed sixty.
+ *
+ * None of these fail loudly. Nothing in the unit suite can see them, because
+ * they are only wrong RELATIVE TO A RENDERED PAGE. This spec is the check that
+ * would have caught all three on the day they were written.
+ *
+ * UNION SEMANTICS. A selector is judged against the union of every surface
+ * below, not each one individually — a rule for the Files grid is legitimately
+ * absent on Calendar. It fails only when it matches nothing ANYWHERE.
+ *
+ * FAIL-CLOSED ALLOWLIST. Selectors that genuinely cannot match on any surveyed
+ * surface (transient overlays, deliberate cross-version fallbacks) must be
+ * listed in ALLOWED below WITH A REASON, in the same spirit as the `@spec
+ * exclude` gates. Adding a bare pattern with no reason is not permitted: the
+ * point is that dead selectors become a decision someone made on purpose,
+ * rather than something nobody noticed.
+ *
+ * GLOBAL STATE: reads only. Requires the `lasuite` set to be active — the spec
+ * skips (rather than silently passing) when element-overrides.css is absent,
+ * because a guard that quietly measures nothing is the exact failure mode it
+ * exists to prevent.
+ */
+
+import { expect, test } from '@playwright/test'
+
+/** Surfaces surveyed. Each contributes its DOM to the union. */
+const SURFACES: Array<{ name: string; path: string }> = [
+	{ name: 'files', path: '/apps/files/' },
+	{ name: 'contacts', path: '/apps/contacts/' },
+	{ name: 'mail', path: '/apps/mail/' },
+	{ name: 'calendar', path: '/apps/calendar/' },
+	{ name: 'settings', path: '/settings/user' },
+	{ name: 'dashboard', path: '/apps/dashboard/' },
+]
+
+/**
+ * Selectors permitted to match nothing on every surveyed surface.
+ * Each entry is a substring or /regex/ plus the reason it cannot match.
+ */
+const ALLOWED: Array<{ pattern: RegExp; reason: string }> = [
+	{
+		pattern: /^#app-navigation(?![-\w])/,
+		reason: 'Deliberate pre-NC34 fallback; NC34 renders #app-navigation-vue. Kept so the theme still applies on older servers.',
+	},
+	{
+		pattern: /#content\.content|#app-content(?!-vue)/,
+		reason: 'Cross-version shell fallbacks. NC34 uses #content (no class) + #content-vue + #app-content-vue.',
+	},
+	{
+		pattern: /nav\.app-menu/,
+		reason: 'NC34 renders the app menu through a different structure; kept for older servers.',
+	},
+	{
+		pattern: /\.header-appname|\.header-left|\.header-right|\.menutoggle|\.unified-search__button|\.header-start \.icon-vue/,
+		reason: 'Pre-Vue header classes retained as fallbacks for older Nextcloud releases.',
+	},
+	{
+		pattern: /^(button|input)\.(primary|secondary)\b/,
+		reason: 'Pre-Vue button classes; NC34 emits .button-vue--* which the adjacent wildcard rules catch.',
+	},
+	{
+		pattern: /--active/,
+		reason: 'BEM --active variant; NC34 uses .active. Both spellings are carried deliberately.',
+	},
+	{
+		pattern: /\.modal-container|\.popover|\.dropdown|\.oc-dialog|\.toastify/,
+		reason: 'Transient overlays — only in the DOM while open, never on a page at rest.',
+	},
+	{
+		pattern: /\.list-item__wrapper\.active/,
+		reason: 'Alternate selection spelling; NC34 uses .list-item__wrapper--active. Both carried.',
+	},
+]
+
+function allowedReason(selector: string): string | null {
+	for (const { pattern, reason } of ALLOWED) {
+		if (pattern.test(selector)) return reason
+	}
+	return null
+}
+
+test.describe('lasuite selector liveness', () => {
+	test('every element-overrides selector matches something on at least one surface', async ({ page }) => {
+		test.slow()
+
+		const liveEverywhere = new Set<string>()
+		let allSelectors: string[] = []
+		let sheetSeenOnce = false
+
+		for (const surface of SURFACES) {
+			await page.goto(surface.path, { waitUntil: 'domcontentloaded' })
+			// Vue apps mount after load; give the shell a moment to render.
+			await page.waitForTimeout(2500)
+
+			const result = await page.evaluate(() => {
+				const sheet = [...document.styleSheets].find(
+					(s) => s.href && /systems\/lasuite\/element-overrides\.css/.test(s.href),
+				)
+				if (!sheet) return null
+
+				let rules: CSSRule[]
+				try {
+					rules = [...sheet.cssRules]
+				} catch {
+					return null
+				}
+
+				const selectors: string[] = []
+				const live: string[] = []
+
+				for (const rule of rules) {
+					const styleRule = rule as CSSStyleRule
+					if (!styleRule.selectorText) continue
+					for (const raw of styleRule.selectorText.split(',')) {
+						const sel = raw.trim()
+						if (!sel) continue
+						selectors.push(sel)
+						// Pseudo-elements and interaction states can never match at rest;
+						// probe the element they hang off instead.
+						const probe = sel
+							.replace(/::[a-z-]+(\([^)]*\))?/gi, '')
+							.replace(
+								/:(hover|focus|focus-within|focus-visible|active|visited|target|placeholder|disabled|checked)\b(\([^)]*\))?/gi,
+								'',
+							)
+							.trim()
+						if (!probe) continue
+						try {
+							if (document.querySelectorAll(probe).length > 0) live.push(sel)
+						} catch {
+							/* invalid probe after stripping — reported as dead */
+						}
+					}
+				}
+				return { selectors, live }
+			})
+
+			if (result === null) continue
+			sheetSeenOnce = true
+			allSelectors = [...new Set([...allSelectors, ...result.selectors])]
+			result.live.forEach((s) => liveEverywhere.add(s))
+		}
+
+		test.skip(
+			!sheetSeenOnce,
+			'lasuite element-overrides.css was not served on any surface — activate the lasuite token set to run this guard',
+		)
+
+		const unexplainedDead = allSelectors
+			.filter((sel) => !liveEverywhere.has(sel))
+			.filter((sel) => allowedReason(sel) === null)
+			.sort()
+
+		expect(
+			unexplainedDead,
+			`These selectors matched NOTHING on any surveyed surface. Either fix them against the real DOM, `
+				+ `or add them to ALLOWED with the reason they cannot match:\n  ${unexplainedDead.join('\n  ')}`,
+		).toEqual([])
+	})
+
+	test('the two shells the theme resizes are actually present and full-bleed', async ({ page }) => {
+		// Regression lock for the band-and-frame defect specifically: it is not
+		// enough that the selectors match — the boxes have to reach the edges,
+		// or the body colour shows through again.
+		await page.goto('/apps/files/', { waitUntil: 'domcontentloaded' })
+		await page.waitForTimeout(2500)
+
+		const geometry = await page.evaluate(() => {
+			const shell = document.querySelector('#content-vue') as HTMLElement | null
+			if (!shell) return null
+			const r = shell.getBoundingClientRect()
+			return { x: Math.round(r.x), width: Math.round(r.width), viewport: window.innerWidth }
+		})
+
+		test.skip(geometry === null, '#content-vue not present on this Nextcloud version')
+
+		expect(geometry!.x, 'the content shell must start at the window edge, not inset').toBe(0)
+		expect(
+			geometry!.width,
+			'the content shell must span the full viewport, or body colour shows down the side',
+		).toBe(geometry!.viewport)
+	})
+})

--- a/tests/vitest/lasuiteBridgeRadiusScale.spec.js
+++ b/tests/vitest/lasuiteBridgeRadiusScale.spec.js
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction / NL Design System Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Guards the La Suite bridge's border-radius mapping.
+ *
+ * `--lasuite-border-radius` (4px) is the one literal in the token set. It was
+ * observed on Cunningham's BUTTON and INPUT — a CONTROL radius — because
+ * Cunningham bakes radii into compiled component CSS rather than exposing a
+ * custom property (see the COMPATIBILITY ALIASES note in defaults.css).
+ *
+ * Mapping it onto Nextcloud's CONTAINER token (`--border-radius-large`, NC
+ * default 8px) collapsed NC's radius hierarchy onto a single value. On a card
+ * drawn with a 1px gray-100 hairline that shrank the corner arcs to roughly two
+ * antialiased pixels: the straight edges stayed crisp while the corners
+ * visibly went missing.
+ *
+ * The `--color-*` audit in tests/css/check-lasuite-bridge-coverage.js does not
+ * cover radius tokens, so this is the only thing standing between that mapping
+ * and a silent reintroduction.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { describe, it, expect } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const BRIDGE = path.resolve(here, '../../css/systems/lasuite/bridge.css')
+
+/**
+ * Whether bridge.css actively forces an NC token onto the La Suite radius.
+ * Commented-out lines do not count as a mapping.
+ *
+ * @param {string} css The bridge stylesheet source.
+ * @param {string} token The NC custom property name, without the leading `--`.
+ * @return {boolean} True when an active declaration maps the token.
+ */
+function mapsToLasuiteRadius(css, token) {
+	return css
+		.split('\n')
+		.filter((line) => !line.trim().startsWith('*') && !line.trim().startsWith('/*'))
+		.some((line) => new RegExp(`^\\s*--${token}:\\s*var\\(--lasuite-border-radius\\)`).test(line))
+}
+
+describe('La Suite bridge — border-radius scale', () => {
+	const css = fs.readFileSync(BRIDGE, 'utf8')
+
+	// The control scale is what 4px was actually measured on.
+	it.each(['border-radius', 'border-radius-small', 'border-radius-element'])(
+		'maps the control-scale token --%s onto the La Suite radius',
+		(token) => {
+			expect(mapsToLasuiteRadius(css, token)).toBe(true)
+		},
+	)
+
+	it('does NOT force the container token --border-radius-large onto the control radius', () => {
+		expect(mapsToLasuiteRadius(css, 'border-radius-large')).toBe(false)
+	})
+
+	it('leaves the wider container tokens untouched', () => {
+		// Never mapped, and must stay that way — they are container-scale too.
+		expect(mapsToLasuiteRadius(css, 'border-radius-container')).toBe(false)
+		expect(mapsToLasuiteRadius(css, 'border-radius-rounded')).toBe(false)
+	})
+})


### PR DESCRIPTION
Card corners went visibly missing on dashboard widgets — straight border edges crisp, corner arcs absent.

## Cause

`--lasuite-border-radius` (4px) is the one literal in the token set: Cunningham bakes radii into compiled component CSS instead of exposing a custom property, so 4px was carried forward from the observed **button and input** radius. That is a **control** radius.

`bridge.css` also mapped it onto `--border-radius-large` — Nextcloud's **container** radius (cards, widget surfaces; NC default 8px) — collapsing NC's radius hierarchy onto a single value. On a card drawn with a 1px gray-100 hairline the resulting arcs span roughly two antialiased pixels and read as absent.

Measured: `--border-radius-large` is **8px on `<html>` and 4px from `<body>` down**, which pins it exactly to this bridge's `body[data-themes], body` selector.

## Why parity is unaffected

The parity suite asserts 4px on three things — a primary button, a text input and a modal. All three take their radius from the **direct `border-radius` rules** in `element-overrides.css:711-714`, not from this token. Verified by measurement: with the token unforced the card goes **4px → 8px** while button, input, modal, popover and dropdown all stay at **4px**.

The specs only ever mandate 4px for *controls* ("Controls carry La Suite radii"); nothing specifies a container radius.

## Guard

`check-lasuite-bridge-coverage.js` audits `--color-*` only, so radius mappings were completely unguarded. Adds a unit spec pinning the control/container split — verified it fails when the mapping is reintroduced.

stylelint clean, bridge-coverage OK, token-generator check OK, 81/81 vitest green. `info.xml` deliberately **not** bumped (a version bump on a bind-mounted app 503s the whole instance until `occ upgrade`).