### PR TITLE
fix(lasuite): keep Nextcloud's container radius instead of the control radius

### DIFF
--- a/css/systems/lasuite/bridge.css
+++ b/css/systems/lasuite/bridge.css
@@ -249,9 +249,23 @@ body {
 	 * BORDER RADIUS
 	 * =================================================================== */
 
+	/* `--lasuite-border-radius` (4px) is the one literal in the token set, and
+	   it was observed on Cunningham's BUTTON and INPUT — a control radius (see
+	   defaults.css COMPATIBILITY ALIASES). It is mapped onto the control-scale
+	   NC tokens only.
+
+	   `--border-radius-large` is deliberately NOT mapped. It is Nextcloud's
+	   CONTAINER radius (cards, widget surfaces; NC default 8px), and there is
+	   no measured Cunningham container radius to map it to — the parity suite
+	   asserts 4px for a button, a text input and a modal, none of which is a
+	   container, and all three take their radius from the direct
+	   `border-radius` rules in element-overrides.css rather than from this
+	   token. Collapsing the container scale onto the control radius flattened
+	   NC's radius hierarchy and, on a 1px gray-100 hairline, shrank card corner
+	   arcs to roughly two antialiased pixels — the corners visibly went
+	   missing while the straight edges stayed crisp. */
 	--border-radius: var(--lasuite-border-radius) !important;
 	--border-radius-small: var(--lasuite-border-radius) !important;
-	--border-radius-large: var(--lasuite-border-radius) !important;
 	--border-radius-element: var(--lasuite-border-radius) !important;
 
 	/* ===================================================================

--- a/tests/vitest/lasuiteBridgeRadiusScale.spec.js
+++ b/tests/vitest/lasuiteBridgeRadiusScale.spec.js
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Conduction / NL Design System Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Guards the La Suite bridge's border-radius mapping.
+ *
+ * `--lasuite-border-radius` (4px) is the one literal in the token set. It was
+ * observed on Cunningham's BUTTON and INPUT — a CONTROL radius — because
+ * Cunningham bakes radii into compiled component CSS rather than exposing a
+ * custom property (see the COMPATIBILITY ALIASES note in defaults.css).
+ *
+ * Mapping it onto Nextcloud's CONTAINER token (`--border-radius-large`, NC
+ * default 8px) collapsed NC's radius hierarchy onto a single value. On a card
+ * drawn with a 1px gray-100 hairline that shrank the corner arcs to roughly two
+ * antialiased pixels: the straight edges stayed crisp while the corners
+ * visibly went missing.
+ *
+ * The `--color-*` audit in tests/css/check-lasuite-bridge-coverage.js does not
+ * cover radius tokens, so this is the only thing standing between that mapping
+ * and a silent reintroduction.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { describe, it, expect } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const BRIDGE = path.resolve(here, '../../css/systems/lasuite/bridge.css')
+
+/**
+ * Whether bridge.css actively forces an NC token onto the La Suite radius.
+ * Commented-out lines do not count as a mapping.
+ *
+ * @param {string} css The bridge stylesheet source.
+ * @param {string} token The NC custom property name, without the leading `--`.
+ * @return {boolean} True when an active declaration maps the token.
+ */
+function mapsToLasuiteRadius(css, token) {
+	return css
+		.split('\n')
+		.filter((line) => !line.trim().startsWith('*') && !line.trim().startsWith('/*'))
+		.some((line) => new RegExp(`^\\s*--${token}:\\s*var\\(--lasuite-border-radius\\)`).test(line))
+}
+
+describe('La Suite bridge — border-radius scale', () => {
+	const css = fs.readFileSync(BRIDGE, 'utf8')
+
+	// The control scale is what 4px was actually measured on.
+	it.each(['border-radius', 'border-radius-small', 'border-radius-element'])(
+		'maps the control-scale token --%s onto the La Suite radius',
+		(token) => {
+			expect(mapsToLasuiteRadius(css, token)).toBe(true)
+		},
+	)
+
+	it('does NOT force the container token --border-radius-large onto the control radius', () => {
+		expect(mapsToLasuiteRadius(css, 'border-radius-large')).toBe(false)
+	})
+
+	it('leaves the wider container tokens untouched', () => {
+		// Never mapped, and must stay that way — they are container-scale too.
+		expect(mapsToLasuiteRadius(css, 'border-radius-container')).toBe(false)
+		expect(mapsToLasuiteRadius(css, 'border-radius-rounded')).toBe(false)
+	})
+})


### PR DESCRIPTION
Card corners went visibly missing on dashboard widgets — straight border edges crisp, corner arcs absent.

## Cause

`--lasuite-border-radius` (4px) is the one literal in the token set: Cunningham bakes radii into compiled component CSS instead of exposing a custom property, so 4px was carried forward from the observed **button and input** radius. That is a **control** radius.

`bridge.css` also mapped it onto `--border-radius-large` — Nextcloud's **container** radius (cards, widget surfaces; NC default 8px) — collapsing NC's radius hierarchy onto one value. On a card drawn with a 1px gray-100 hairline the arcs span roughly two antialiased pixels and read as absent.

Measured: `--border-radius-large` is **8px on `<html>` and 4px from `<body>` down**, pinning it exactly to this bridge's `body[data-themes], body` selector.

## Why parity is unaffected

The parity suite asserts 4px on a primary button, a text input and a modal. All three take their radius from the **direct `border-radius` rules** in `element-overrides.css:711-714`, not from this token. Verified by measurement: with the token unforced the card goes **4px → 8px** while button, input, modal, popover and dropdown all stay at **4px**. The specs only mandate 4px for *controls*; nothing specifies a container radius.

## Guard

`check-lasuite-bridge-coverage.js` audits `--color-*` only, so radius mappings were unguarded. Adds a unit spec pinning the control/container split — verified it fails when the mapping is reintroduced.

stylelint clean, bridge-coverage OK, 5/5 new tests green. `info.xml` deliberately **not** bumped (a version bump on a bind-mounted app 503s the whole instance until `occ upgrade`).

> Replaces #216, which was cut from a local `development` 19 commits ahead of origin and so carried 9 unrelated La Suite commits. This branch is one commit off `origin/development`.