### PR TITLE
chore(deps): repin @conduction/nextcloud-vue to 2.2.0-vue3.3 (3.0.0-vue3.6 was unpublished)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@fontsource/fira-sans": "^5.0.0"
 			},
 			"devDependencies": {
-				"@conduction/nextcloud-vue": "3.0.0-vue3.6",
+				"@conduction/nextcloud-vue": "2.2.0-vue3.3",
 				"@cyclonedx/cyclonedx-npm": "^4.2.1",
 				"@openfun/cunningham-tokens": "^3.0.0",
 				"@playwright/test": "^1.60.0",
@@ -485,9 +485,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "3.0.0-vue3.6",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.6.tgz",
-			"integrity": "sha512-6x8VapVLF22eCQB+CdoC1OkB3oLiIM31OceexDrvu/L++8Z5HYV2X3Xcgl8ZGy29jcqbtrjDNaZ5WbaDrzm8fA==",
+			"version": "2.2.0-vue3.3",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.3.tgz",
+			"integrity": "sha512-kO6qtFPnQx1gNFZO/l5YVaSnpnsJspaqazWn5pWiwpma1DbTO9Oa6Jfk5svzFOfR85QB37HKqDqL0JnHpKiXJw==",
 			"dev": true,
 			"license": "EUPL-1.2",
 			"dependencies": {
@@ -1566,14 +1566,6 @@
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
-		},
-		"node_modules/@gouvfr/dsfr-token": {
-			"optional": true,
-			"peer": true
-		},
-		"node_modules/@gouvfr/dsfr-weave": {
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/@img/colour": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@gouvfr/dsfr": "^1.15.1"
 	},
 	"devDependencies": {
-		"@conduction/nextcloud-vue": "3.0.0-vue3.6",
+		"@conduction/nextcloud-vue": "2.2.0-vue3.3",
 		"@cyclonedx/cyclonedx-npm": "^4.2.1",
 		"@openfun/cunningham-tokens": "^3.0.0",
 		"@playwright/test": "^1.60.0",


### PR DESCRIPTION
## Why

`@conduction/nextcloud-vue@3.0.0-vue3.6` — the pin on `development` — was **unpublished from npm**.

```
$ npm view @conduction/nextcloud-vue@3.0.0-vue3.6 version
npm error code E404
npm error 404 No match found for version 3.0.0-vue3.6
```

npm never permits reuse of an unpublished version number, so this pin is **permanently dead**: `npm ci` cannot succeed on `development` at all. This is fleet-blocking.

## What

Repin to `@conduction/nextcloud-vue@2.2.0-vue3.3` — verified live, and the current `vue3` dist-tag. Pinned exactly (no caret), per fleet convention.

Only `package.json` + `package-lock.json` changed.

## nldesign is a special case — and it is the one repo where rendered output could actually move

Unlike the other apps in this repin wave, nldesign has **no Vue components and no webpack**. `@conduction/nextcloud-vue` is a **devDependency consumed by exactly one thing**: `scripts/build-icons.js`, which deep-imports three icon packs and materialises them as **tracked SVG assets** under `img/icons/`:

| Deep import | Export | Icons |
|---|---|---|
| `@conduction/nextcloud-vue/src/icons/rvo.js` | `rvoIcons` | 1163 |
| `@conduction/nextcloud-vue/src/icons/openGemeenten.js` | `openGemeentenIcons` | 256 |
| `@conduction/nextcloud-vue/src/icons/denHaag.js` | `denHaagIcons` | 69 |

All three files exist in the new package, and all three export names resolve — verified by importing them and counting keys, not by assuming.

Because those SVGs are **committed**, the files already in git are a perfect baseline generated by the *old* pin. So the decisive test is: rebuild and diff.

```
$ npm run build      # exit 0
✅ Icon build complete! 2526 icons across 4 sets + 77 legacy aliases + 23 logos

$ git status --porcelain
 M package-lock.json
 M package.json
```

**Zero generated-asset drift.** The rebuild reproduced all 2526 icons byte-for-byte. Re-run a second time after a cold `npm ci` — still zero. **This repin does not change any rendered UI in nldesign.**

The build log's `Pack "dsfr": no source directory available … Preserved 1038 already-committed icons` line is the script's documented fallback — `@gouvfr/dsfr` is an `optionalDependency` that is intentionally not installed by default (the script itself prints `To refresh from upstream: npm install --no-save @gouvfr/dsfr@1.15.1`). Pre-existing, unrelated to this change.

## Verification

| Check | Result |
|---|---|
| Old pin `3.0.0-vue3.6` live on npm? | **No — E404** |
| New pin `2.2.0-vue3.3` live on npm? | Yes (current `vue3` dist-tag) |
| `3.0.0-vue3` refs in `package-lock.json` | 3 → **0** |
| `2.2.0-vue3.3` refs in `package-lock.json` | **3** |
| Cold `npm ci` (empty cache, npm 10.8.2) | **exit 0**, 785 packages |
| `npm run build` (fonts + icons) | **exit 0** |
| Generated-asset drift | **none — 0 files changed** |
| `vitest run` | **8/8 files, 81/81 tests passed** |
| Icon-pack surface check | **PASS — 3/3 deep imports + export names resolve** |

### Lockfile regenerated with npm 10.8.2, deliberately

CI runs node 20 / npm 10; this workstation is node 22 / npm 11. npm 11 prunes optional lockfile entries that do not apply to the local platform, producing a lockfile that makes CI's `npm ci` fail with `Missing: … from lock file` — and which a **local** `npm ci` does *not* reproduce, because npm 11 accepts the lockfile it just wrote. All install/ci steps here were run via `npx npm@10.8.2` to match CI.

### About the two removed lockfile lines

The lockfile diff also drops two entries:

```
-		"node_modules/@gouvfr/dsfr-token": { "optional": true, "peer": true },
-		"node_modules/@gouvfr/dsfr-weave":  { "optional": true, "peer": true },
```

I checked these rather than waving them through, since dropped optional entries are exactly the shape of the npm-version lockfile trap above. They are **placeholder markers for optional *peer* dependencies that are not installed** — they carry no `version`, no `resolved` and no `integrity`, so they install nothing. Every *real* `@gouvfr/*` entry (37 of them, including `@gouvfr/dsfr@1.15.1` itself) is retained with its tarball URL and integrity hash intact. They are unrelated to `@conduction/nextcloud-vue`; npm 10.8.2 simply does not re-emit these markers. The cold `npm ci` above is the proof that the resulting lockfile is complete and installable under CI's npm major.

## Notes

- **A "before" test run is impossible.** `npm ci` cannot install the dead pin, so there is no baseline test count to compare against — the pre-change state does not install at all. The numbers above are the post-change state only.
- A Playwright e2e suite exists (`playwright.config.ts`) but needs a live Nextcloud instance; not run here.
