### PR TITLE
fix(l10n): register the missing "Saved. Reload to see the change." key

### DIFF
--- a/l10n/be.json
+++ b/l10n/be.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/bg.json
+++ b/l10n/bg.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/bs.json
+++ b/l10n/bs.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/ca.json
+++ b/l10n/ca.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/da.json
+++ b/l10n/da.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/el.json
+++ b/l10n/el.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/et.json
+++ b/l10n/et.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/fi.json
+++ b/l10n/fi.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/ga.json
+++ b/l10n/ga.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/hr.json
+++ b/l10n/hr.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/hu.json
+++ b/l10n/hu.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/is.json
+++ b/l10n/is.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/lb.json
+++ b/l10n/lb.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/lt.json
+++ b/l10n/lt.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/lv.json
+++ b/l10n/lv.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/mk.json
+++ b/l10n/mk.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/mt.json
+++ b/l10n/mt.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/nb.json
+++ b/l10n/nb.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Standaard Nextcloud-iconen (geen aangepaste set)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Bron: beheerdersoverschrijving (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Bron: het actieve designsysteem",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "Dit wijzigt alleen de iconenassets die nldesign zelf levert via imagePath. Het vervangt niet de ingebouwde kern-iconen van Nextcloud, afgezien van wat de CSS van het actieve thema al herstylet."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "Dit wijzigt alleen de iconenassets die nldesign zelf levert via imagePath. Het vervangt niet de ingebouwde kern-iconen van Nextcloud, afgezien van wat de CSS van het actieve thema al herstylet.",
+        "Saved. Reload to see the change.": "Opgeslagen. Herlaad de pagina om de wijziging te zien."
     },
     "plurals": {}
 }

--- a/l10n/pl.json
+++ b/l10n/pl.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/pt.json
+++ b/l10n/pt.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/rm.json
+++ b/l10n/rm.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/ro.json
+++ b/l10n/ro.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/sk.json
+++ b/l10n/sk.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/sl.json
+++ b/l10n/sl.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/sq.json
+++ b/l10n/sq.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/sr.json
+++ b/l10n/sr.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/sv.json
+++ b/l10n/sv.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/tr.json
+++ b/l10n/tr.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }

--- a/l10n/uk.json
+++ b/l10n/uk.json
@@ -207,7 +207,8 @@
         "Nextcloud stock icons (no custom pack)": "Nextcloud stock icons (no custom pack)",
         "Source: admin override (occ config:app:set nldesign icon_pack)": "Source: admin override (occ config:app:set nldesign icon_pack)",
         "Source: the active design system": "Source: the active design system",
-        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles."
+        "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.": "This only switches the icon assets nldesign itself serves through imagePath. It does not replace Nextcloud's built-in core icons beyond what the active theme's CSS already restyles.",
+        "Saved. Reload to see the change.": "Saved. Reload to see the change."
     },
     "plurals": {}
 }


### PR DESCRIPTION
## What

`quality / Frontend Check (test:l10n)` is **red on `development`** and has been for a while. This fixes it.

`js/admin.js:2829` calls

```js
setFeedback(t('nldesign', 'Saved. Reload to see the change.'), false)
```

in the custom-CSS save handler, but that key was never added to `l10n/en.json`. So the l10n gate fails, and — more importantly — the string ships **untranslated in every locale**, including Dutch, on a Dutch-government theming app.

## Verified pre-existing, not caused by anything in flight

Run against a pristine `origin/development` tree (`git archive origin/development`), the check fails identically:

```
l10n-check: FAIL — 1 translation key(s) used in source but MISSING from l10n/en.json:
  • "Saved. Reload to see the change."
      js/admin.js:2829
```

This branch touches neither `js/admin.js` nor anything else outside `l10n/`.

## Changes

- `l10n/en.json` — added the key (key === English source), as the check instructs.
- 36 locale files — backfilled with the repo's own `node tests/l10n/check-l10n-completeness.js --write`. This is required: `test:l10n:completeness` passes today only because no locale is missing anything, so adding a key to `en.json` alone would turn a green check red. Both checks are green together only with the backfill.
- `l10n/nl.json` — translated properly rather than left as an English placeholder: *"Opgeslagen. Herlaad de pagina om de wijziging te zien."*, matching the phrasing of the neighbouring `Herlaad de pagina om …` strings (`Token set uploaded.`, `Font uploaded.`). The other 35 locales keep the English placeholder the tool writes, which is the documented convention.

## Verification

| check | before | after |
|---|---|---|
| `npm run test:l10n` | **FAIL** — 1 key missing | **OK** — 209 keys |
| `npm run test:l10n:completeness` | OK — 208 keys, 36 locales | **OK** — 209 keys, 36 locales, 0 missing |
| `npx vitest run` | 81 passed | 81 passed |
| `npm run check:manifest` | PASS | PASS |

Split out of the EUPL licence-normalisation PR (#224) so that one stays a pure licence diff.