### PR TITLE
chore(license): the docs homepage still advertised AGPL-3.0

### DIFF
--- a/docs/src/components/HomepageFeatures/index.js
+++ b/docs/src/components/HomepageFeatures/index.js
@@ -47,7 +47,7 @@ const FeatureList = [
     title: 'Open Source',
     description: (
       <>
-        Built on the NL Design System community. Token sets sourced from official government design repositories. AGPL-3.0 licensed.
+        Built on the NL Design System community. Token sets sourced from official government design repositories. EUPL-1.2 licensed.
       </>
     ),
   },


### PR DESCRIPTION
Follow-up to #224.

The documentation site's **"Open Source" feature card** — on the docs landing page — told every visitor:

> Built on the NL Design System community. Token sets sourced from official government design repositories. **AGPL-3.0 licensed.**

Meanwhile `composer.json`, `package.json`, `appinfo/info.xml`, the bundled `LICENSE` and every source header say **EUPL-1.2**.

This is arguably the most *public* licence claim the app makes, and #224 missed it: that sweep grepped for `SPDX-License-Identifier:` and `@license` tags, not for prose. Reporting the miss rather than quietly folding it in.

One string in `docs/src/components/HomepageFeatures/index.js`. No behaviour change.

### Deliberately not changed in the same sweep
- `README.md:345` — "Copyleft (EUPL-compatible): LGPL…, GPL…, **AGPL-3.0**, EUPL-1.1/1.2, MPL-2.0". That is a list of licences the EUPL is compatible with, and AGPL-3.0 genuinely belongs in it.
- `CHANGELOG.md:442` — a historical entry recording the earlier `agpl` → `eupl` correction in `appinfo/info.xml`. Rewriting history entries would make the changelog lie.
- `tests/Unit/ClaimAccuracyTest.php` — the `AGPL` strings there are the assertions that *guard* against this class of regression.