### PR TITLE
ci(quality): unpin the hydra-gates package, which is now failing the job outright

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -190,38 +190,41 @@ jobs:
       # ── Hydra mechanical gates ───────────────────────────────────────────
       # `enable-hydra-gates` defaults to FALSE, so this tier has never executed
       # here — the job reported `skipped`, which the Quality Report renders
-      # identically to a pass. Pinned to v1.0.1 so a change to the gate package
-      # cannot move this repo's verdict without a commit here.
+      # identically to a pass.
       # `enable-axe` deliberately NOT set: a vanilla Nextcloud 34 already carries
       # serious/critical violations from core's own UI.
       #
-      # v1.0.1 -> v1.3.0 (ConductionNL/.github#159). Two defects, one bump.
+      # NO `hydra-gates-ref` ON PURPOSE — it defaults to `main`.
       #
-      # 1. STALE. v1.0.1 is `f4d9756` (2026-08-03) and predates three gate
-      #    fixes, so every Hydra Gates run this repo has ever made executed a
-      #    script in which 16 gates reported PASS when their helper never ran
-      #    (#147), gate-33 had no axe report to read and never said so (#148),
-      #    and gates 6 and 7 reported PASS on an EMPTY scope (#149). A gate
-      #    that reports PASS without running emits a tick identical to a real
-      #    one, which is why nothing in this repo's history shows it.
+      # This repo pinned the package for two releases (v1.0.1, then v1.3.0 via
+      # ConductionNL/.github#159) on the theory that a pin stops a gate change
+      # from moving this repo's verdict without a commit here. That theory cost
+      # more than it bought, twice, and both failures are the same shape:
       #
-      # 2. RED. quality.yml is referenced `@main` while this package is
-      #    PINNED, so the two can desync — and on 2026-08-05 they did. #164
-      #    flipped `hydra-gates-require-full-coverage` to default TRUE, but
-      #    the accounting that makes that flag survivable (NOT APPLICABLE, as
-      #    distinct from a structural or a wiring gap) ships in the PACKAGE.
-      #    So every pin older than `f7eaf2a` now fails the coverage assertion
-      #    for gates it has no subject matter for. Measured on this repo's own
-      #    blocked PHPMD PR branch (#220), diff-scoped exactly as CI scopes it:
-      #      v1.0.1  exit 98  FAIL — "GATES THAT DID NOT RUN: 24 33",
-      #                              byte-identical to that PR's real CI log
-      #      v1.3.0  exit 0   PASS — 6 7 24 33 named NOT APPLICABLE
-      #    The old pin was not merely stale, it was failing this repo's CI for
-      #    a reason that had nothing to do with this repo — and it is what is
-      #    currently blocking #220 and #217.
+      #   quality.yml is consumed `@main` while the PACKAGE was pinned, so the
+      #   two move independently and a change on one side reaches an old runner
+      #   on the other.
       #
-      # v1.3.0 is `f7eaf2a` = .github@main, tagged so the ref stays
-      # reproducible and a later gate change cannot move this repo's verdict
-      # without a commit here.
+      # 1. #164 flipped `hydra-gates-require-full-coverage` to default TRUE, but
+      #    the accounting that makes the flag survivable ships in the PACKAGE.
+      #    Every older pin then failed a coverage assertion for gates it has no
+      #    subject matter for — red for a reason that had nothing to do with
+      #    this repo, and it blocked #220 and #217 here.
+      # 2. #177 added a step that verifies the pinned package contains every
+      #    path the workflow executes by name. v1.3.0 ships none of
+      #    check_spec_anchors.py, check_form_labels.py or check_license_triangle.py,
+      #    so the job now fails before a single gate runs. Verified by listing
+      #    those paths at each tag: only v1.5.0 and `main` carry all nine.
+      #
+      # A pin is a silent expiry date on every upstream fix, and it made each
+      # fix a 23-PR treadmill. Tracking `main` is the fleet contract as of
+      # ConductionNL/.github#177, which also added the guard that made this
+      # safe: `main` cannot serve an unresolvable workflow silently any more —
+      # quality-resolve-probe.yml counts the jobs a caller materialises and
+      # asserts `> 0`, because an unresolvable reusable workflow produces no
+      # red check at all, just zero jobs.
+      #
+      # ROLLBACK, if a gate change ever does break this repo: set
+      # `hydra-gates-ref:` here explicitly. Still supported and still honoured
+      # — an escape hatch, not a resting state.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.5.0


### PR DESCRIPTION
`quality / Hydra Gates` is **red on `development`**, and not for anything in this repo.

ConductionNL/.github#177 added a step that verifies the pinned package contains every path the workflow executes *by name*. Our pin, `v1.3.0`, ships none of `check_spec_anchors.py`, `check_form_labels.py` or `check_license_triangle.py`, so the job fails **before a single gate runs**. Listing all nine required paths at each tag:

| ref | missing |
|---|---|
| v1.3.0 | axe-run.cjs, check_spec_anchors.py, check_form_labels.py, check_license_triangle.py |
| v1.4.0 | check_spec_anchors.py, check_form_labels.py, check_license_triangle.py |
| **v1.5.0 / main** | **none** |

## Second time, same shape

`quality.yml` is consumed `@main` while the package was **pinned**, so the two move independently and a change on one side reaches an old runner on the other. #164 was the first instance: it flipped `hydra-gates-require-full-coverage` to default TRUE while the accounting that makes that flag survivable ships *in the package*, and every older pin went red on gates it has no subject matter for.

## Why remove the input rather than bump to v1.5.0

That is the fleet contract as of ConductionNL/.github#177 — the PO's ask was *"stop pinning the package per repo"*. A pin is a silent expiry date on every upstream fix, and it turned each fix into a 23-PR treadmill.

The guard that makes tracking `main` safe landed in the same PR. An unresolvable reusable workflow is **not a red check** — GitHub produces a run with *no jobs*, so every dashboard stays green while every caller quietly stops being checked. `quality-resolve-probe.yml` counts the jobs a caller materialises and asserts `> 0`.

**Rollback for this repo alone stays available**: set `hydra-gates-ref:` explicitly. An escape hatch, not a resting state.

Blocks #228. Same fix is needed in 16 other repos — sweeping them once this one is verified green.