### PR TITLE
fix(tests): resolve Newman fixture paths and honour the CI base_url variable

### DIFF
--- a/tests/integration/README-newman.md
+++ b/tests/integration/README-newman.md
@@ -21,6 +21,32 @@ BASE_URL=http://localhost:8080 ADMIN_USER=admin ADMIN_PASS=admin ./run-newman.sh
 `run-newman.sh` uses a globally-installed `newman` if present, otherwise
 `npx newman`. Runs are serialised under `flock /tmp/uiaudit-nldesign.lock`.
 
+### Two conventions that must not drift
+
+Both of these were broken at once and cost 14 assertions on `development`:
+
+1. **Multipart fixture paths are relative to THIS directory.** The upload
+   requests carry `"src": "fixtures/<file>"`. Newman resolves a formdata `src`
+   against `--working-dir`, which **defaults to the process CWD**. The shared CI
+   workflow (`ConductionNL/.github` → `.github/workflows/quality.yml`, job
+   `newman`) does `cd server/apps/<app>/<newman-collection-path>` and then runs
+   newman with no `--working-dir`, so in CI the working dir is this directory.
+   `run-newman.sh` pins `--working-dir` to the same place. If a path is ever made
+   repo-root-relative again it will resolve to nothing in CI, newman will send
+   the request **without the file part**, and the app will answer
+   `400 No file uploaded.` for a payload the test believes it uploaded — which
+   reads as "the upload feature is broken", not "the test cannot find its file".
+
+2. **The CI variable names are aliased in a collection pre-request script.**
+   CI passes `base_url` / `admin_user` / `admin_password`; the requests use
+   `{{baseUrl}}` / `{{adminUser}}` / `{{adminPass}}`. The collection-level
+   `prerequest` script maps the former onto the latter and derives `noAuthBase`
+   from the effective base URL. Without it those three flags are inert and the
+   suite silently tests whatever is on `localhost:8080` regardless of what it
+   was told to target. An explicitly supplied camelCase variable still wins
+   (environment scope outranks collection scope), so `run-newman.sh` is
+   unaffected.
+
 ## Design (matches the procest `tests/integration/` pattern)
 
 - **Host-split auth.** Authenticated requests hit `{{baseUrl}}` (`localhost`)
@@ -44,7 +70,7 @@ are rejected `401`. There is no `#[PublicPage]` endpoint in this app.
 
 ## Coverage
 
-23 requests / 50 assertions, all green. Families:
+46 requests / 108 assertions, all green. Families:
 
 0. Setup — capture live `token_set` + `overrides`.
 1. Token sets — list available, set (200), invalid id (400), preview (200),
@@ -54,6 +80,12 @@ are rejected `401`. There is no `#[PublicPage]` endpoint in this app.
 3. Custom token overrides — write (200, written count) + read-back, non-object
    body (400), CSS export (200, `text/css`), import-without-file (400),
    authz 401 on read + write.
+4. Custom token sets — multipart upload of a compliant CSS set (200, namespaced
+   `custom-*` id + `imported`/`skipped`/`warnings`), name-collision (409),
+   disallowed selector (422), malformed JSON (422), missing file (400), missing
+   name (400), list, export (200, `text/css`), unknown export (404), delete
+   (200), delete of a shipped id (400), authz 401 on upload + list.
+   Fixtures live in `fixtures/` — see "Two conventions" above.
 9. Teardown — restore the captured token set + overrides.
 
 ## Notes

--- a/tests/integration/nldesign.postman_collection.json
+++ b/tests/integration/nldesign.postman_collection.json
@@ -4,6 +4,58 @@
     "description": "Newman/Postman API-contract tests for the nldesign (NL Design System Theme) Nextcloud app. Locks the HTTP contract of nldesign's admin-theming controllers (appinfo/routes.php + lib/Controller/SettingsController.php + lib/Controller/OverridesController.php): token-set selection, theming values, login-page slogan/menu-label toggles, and the custom CSS-token overrides. nldesign is a server-rendered admin theming app with a small but real JSON API; this suite exercises the real endpoints (reads + writes + validation + authz).\n\nEvery family is exercised for a happy path, a validation/error case (clean 4xx, not 500 where the controller is correct), and an authorization case (no auth -> 401). Every endpoint is #[AuthorizedAdminSetting(Admin::class)]: the admin user (admin:admin) is an admin, so authed requests return 200/4xx; unauthenticated requests are rejected 401.\n\nThe suite is self-contained and idempotent: it first reads and stashes the live token_set, hide_slogan and overrides, then asserts the write round-trips, and finally restores all three to their captured values in teardown so a CI run leaves no theming drift.\n\nAUTH MODEL: collection auth is noauth; every authenticated request carries an EXPLICIT basic-auth block (admin:admin via adminUser/adminPass) plus the OCS-APIRequest:true header (which lets state-changing POSTs through NC's CSRF middleware for an API client). The no-auth authz requests target {{noAuthBase}} (127.0.0.1) so the host-scoped NC session cookie established on {{baseUrl}} (localhost) is never sent to them. Run with --ignore-redirects so an unauthenticated request asserts NC's 401 directly instead of following a 303 to the HTML login page. See run-newman.sh.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Honour the snake_case variable names the shared CI workflow passes.",
+          "//",
+          "// ConductionNL/.github .github/workflows/quality.yml (job `newman`) runs",
+          "// every collection with:",
+          "//   --env-var base_url=... --env-var admin_user=... --env-var admin_password=...",
+          "// This collection's requests use {{baseUrl}} / {{adminUser}} / {{adminPass}}.",
+          "// Nothing mapped one onto the other, so those three CI flags were INERT:",
+          "// the run silently fell back to the collection defaults instead. Today the",
+          "// defaults happen to equal what CI passes, so it looked fine — but point",
+          "// base_url anywhere else and the suite keeps testing localhost:8080 while",
+          "// reporting on it, which is how a run targets a completely different",
+          "// instance and still calls itself green.",
+          "//",
+          "// Precedence is preserved: an explicitly supplied camelCase variable lives",
+          "// in the environment scope, which outranks the collection scope written",
+          "// here, so `--env-var baseUrl=...` (what run-newman.sh passes) still wins.",
+          "const alias = (snake, camel) => {",
+          "  const explicit = pm.environment.get(camel);",
+          "  if (explicit !== undefined && explicit !== null && explicit !== '') { return; }",
+          "  const supplied = pm.environment.get(snake);",
+          "  if (supplied !== undefined && supplied !== null && supplied !== '') {",
+          "    pm.collectionVariables.set(camel, supplied);",
+          "  }",
+          "};",
+          "",
+          "alias('base_url', 'baseUrl');",
+          "alias('admin_user', 'adminUser');",
+          "alias('admin_password', 'adminPass');",
+          "",
+          "// The authz requests must reach the SAME instance through a DIFFERENT host",
+          "// alias, so the host-scoped NC session cookie established on {{baseUrl}} is",
+          "// never sent with them and they stay genuinely unauthenticated. Derive it",
+          "// from the effective base URL unless one was supplied explicitly.",
+          "const explicitNoAuth = pm.environment.get('noAuthBase');",
+          "if (explicitNoAuth === undefined || explicitNoAuth === null || explicitNoAuth === '') {",
+          "  const base = pm.collectionVariables.get('baseUrl') || '';",
+          "  if (base.indexOf('localhost') !== -1) {",
+          "    pm.collectionVariables.set('noAuthBase', base.replace('localhost', '127.0.0.1'));",
+          "  } else if (base.indexOf('127.0.0.1') !== -1) {",
+          "    pm.collectionVariables.set('noAuthBase', base.replace('127.0.0.1', 'localhost'));",
+          "  }",
+          "}"
+        ]
+      }
+    }
+  ],
   "variable": [
     {
       "key": "baseUrl",
@@ -1339,7 +1391,7 @@
               "formdata": [
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-valid.css",
+                  "src": "fixtures/newman-valid.css",
                   "type": "file"
                 }
               ]
@@ -1416,7 +1468,7 @@
                 },
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-valid.css",
+                  "src": "fixtures/newman-valid.css",
                   "type": "file"
                 }
               ]
@@ -1488,7 +1540,7 @@
                 },
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-valid.css",
+                  "src": "fixtures/newman-valid.css",
                   "type": "file"
                 }
               ]
@@ -1560,7 +1612,7 @@
                 },
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-bad-selector.css",
+                  "src": "fixtures/newman-bad-selector.css",
                   "type": "file"
                 }
               ]
@@ -1632,7 +1684,7 @@
                 },
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-malformed.tokens.json",
+                  "src": "fixtures/newman-malformed.tokens.json",
                   "type": "file"
                 }
               ]

--- a/tests/integration/run-newman.sh
+++ b/tests/integration/run-newman.sh
@@ -31,9 +31,19 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COLLECTION="${SCRIPT_DIR}/nldesign.postman_collection.json"
-# Repo root — multipart formdata file `src` paths in the collection are
-# resolved relative to --working-dir (e.g. tests/integration/fixtures/*.css).
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# Multipart formdata file `src` paths in the collection (fixtures/*.css) are
+# resolved by newman relative to --working-dir, which DEFAULTS TO THE PROCESS
+# CWD. The shared CI workflow (ConductionNL/.github .github/workflows/quality.yml,
+# job `newman`) does `cd server/apps/<app>/<newman-collection-path>` and then
+# invokes newman with no --working-dir, so in CI the working dir is THIS
+# directory. The `src` paths are therefore relative to the collection file, and
+# this runner must pin --working-dir to the same place — otherwise every file
+# part silently resolves to nothing, newman sends the request WITHOUT the file,
+# and the app answers 400 "No file uploaded." for a payload the test believes it
+# uploaded. That is exactly how 14 assertions failed on `development`: the paths
+# were repo-root-relative, which only ever worked because this script passed the
+# repo root, and CI never did.
+FIXTURE_ROOT="${SCRIPT_DIR}"
 
 BASE_URL="${BASE_URL:-http://localhost:8080}"
 ADMIN_USER="${ADMIN_USER:-admin}"
@@ -65,7 +75,7 @@ fi
   --env-var "adminUser=${ADMIN_USER}" \
   --env-var "adminPass=${ADMIN_PASS}" \
   --ignore-redirects \
-  --working-dir "${REPO_ROOT}" \
+  --working-dir "${FIXTURE_ROOT}" \
   --reporters cli \
   --color on \
   "$@"


### PR DESCRIPTION
## What

Clears all 14 Newman failures on `development`. **No test was skipped, disabled or relaxed, and no application code changed** — both defects were in the test harness.

## Root causes (one cluster, two defects)

### 1. Multipart fixture paths could never resolve in CI — classification (c) fixture/seed wrong

The upload requests carried `"src": "tests/integration/fixtures/*"`. Newman resolves a formdata `src` against `--working-dir`, which **defaults to the process CWD**. The shared workflow (`ConductionNL/.github` → `.github/workflows/quality.yml`, job `newman`) does `cd server/apps/<app>/<newman-collection-path>` and then invokes newman with **no** `--working-dir` — so CWD is the collection directory and a repo-root-relative path resolves to nothing.

Newman does not fail on an unresolvable file part; it sends the request **without it**. The app then correctly answers `400 No file uploaded.` This is why all 14 failures presented as "custom token set upload is broken":

| Symptom | Actual cause |
|---|---|
| upload → 400 (want 200) | no file part sent |
| collision → 400 (want 409) | never got far enough to collide |
| disallowed selector → 400 (want 422) | no CSS to inspect |
| malformed JSON → 400 (want 422) | no JSON to parse |
| list empty, export 404, delete 400 | downstream of the failed upload |

This only ever worked locally because `run-newman.sh` passed the repo root as `--working-dir`; CI never did.

**Fix:** paths are relative to the collection file (which is CWD in CI), and `run-newman.sh` pins `--working-dir` to the same directory so both agree.

### 2. CI's `base_url` / `admin_user` / `admin_password` were inert — classification (b) collection wrong

CI passes those three snake_case variables; the requests use `{{baseUrl}}` / `{{adminUser}}` / `{{adminPass}}`. Nothing mapped one onto the other, so **all three flags did nothing** and the suite silently fell back to its collection defaults.

Measured directly: with `--env-var base_url=http://localhost:8199`, the old collection still sent every single request to `localhost:8080`. Today the defaults happen to equal what CI passes, so it looked fine — but a run could target a completely different instance and report on it as if it were the one under test. (This bit during investigation: an early measurement silently hit the shared dev instance instead of the disposable replica.)

**Fix:** a collection-level `prerequest` script aliases the three names and derives `noAuthBase` from the effective base URL so the authz host-split stays intact. Environment scope still outranks collection scope, so an explicit `--env-var baseUrl=` (what `run-newman.sh` passes) continues to win.

## Five numbers

Measured on a disposable pgsql-backed Nextcloud with `openregister` + `nldesign` enabled, invoking newman **exactly as CI does** (cwd = collection dir, snake_case env vars, no `--working-dir`):

| | collections | requests | assertions | passed | failed |
|---|---|---|---|---|---|
| **Before** | 1 | 46 | 108 | 94 | **14** |
| **After** | 1 | 46 | 108 | **108** | **0** |

Exit code `0`. Identical result via the shipped `run-newman.sh`. This reproduces CI run `31045984082` / job `92442612396` exactly (same 14 assertions, same order).

## Failure proofs

Every fix was shown able to go red:

1. **Fixture resolution** — hid `fixtures/newman-valid.css`: 12 of the 14 failures return (the other 2 use the bad-selector and malformed-JSON fixtures, still present). Restored → green.
2. **The assertions exercise the app, not just file presence** — changed the disallowed-selector status from `422` to `418` in `CustomTokenSetController`. Confirmed live with a direct `curl` (`STATUS=418`) *before* trusting the run; newman then reported exactly **1** failure and logged `[418 I'm a teapot]`. Reverted → green.
3. **The alias fix** — with `base_url` pointed at a dead port `8199`, the old collection still hit `:8080` and reported its usual 14; the fixed collection follows to `:8199` and fails loudly (50 failed). Proves the variable now actually takes effect.

## Also fixed (pre-existing)

`README-newman.md` claimed "23 requests / 50 assertions" and documented no folder 4 — stale since the custom-token-set family landed. Corrected to 46/108 with the family documented, plus both conventions written down so they cannot drift back.