### PR TITLE
ci(quality): unpin hydra-gates — a pin cannot carry a fix made after it was cut

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -190,38 +190,41 @@ jobs:
       # ── Hydra mechanical gates ───────────────────────────────────────────
       # `enable-hydra-gates` defaults to FALSE, so this tier has never executed
       # here — the job reported `skipped`, which the Quality Report renders
-      # identically to a pass. Pinned to v1.0.1 so a change to the gate package
-      # cannot move this repo's verdict without a commit here.
+      # identically to a pass.
       # `enable-axe` deliberately NOT set: a vanilla Nextcloud 34 already carries
       # serious/critical violations from core's own UI.
       #
-      # v1.0.1 -> v1.3.0 (ConductionNL/.github#159). Two defects, one bump.
+      # NO `hydra-gates-ref` ON PURPOSE — it defaults to `main`.
       #
-      # 1. STALE. v1.0.1 is `f4d9756` (2026-08-03) and predates three gate
-      #    fixes, so every Hydra Gates run this repo has ever made executed a
-      #    script in which 16 gates reported PASS when their helper never ran
-      #    (#147), gate-33 had no axe report to read and never said so (#148),
-      #    and gates 6 and 7 reported PASS on an EMPTY scope (#149). A gate
-      #    that reports PASS without running emits a tick identical to a real
-      #    one, which is why nothing in this repo's history shows it.
+      # This repo pinned the package for two releases (v1.0.1, then v1.3.0 via
+      # ConductionNL/.github#159) on the theory that a pin stops a gate change
+      # from moving this repo's verdict without a commit here. That theory cost
+      # more than it bought, twice, and both failures are the same shape:
       #
-      # 2. RED. quality.yml is referenced `@main` while this package is
-      #    PINNED, so the two can desync — and on 2026-08-05 they did. #164
-      #    flipped `hydra-gates-require-full-coverage` to default TRUE, but
-      #    the accounting that makes that flag survivable (NOT APPLICABLE, as
-      #    distinct from a structural or a wiring gap) ships in the PACKAGE.
-      #    So every pin older than `f7eaf2a` now fails the coverage assertion
-      #    for gates it has no subject matter for. Measured on this repo's own
-      #    blocked PHPMD PR branch (#220), diff-scoped exactly as CI scopes it:
-      #      v1.0.1  exit 98  FAIL — "GATES THAT DID NOT RUN: 24 33",
-      #                              byte-identical to that PR's real CI log
-      #      v1.3.0  exit 0   PASS — 6 7 24 33 named NOT APPLICABLE
-      #    The old pin was not merely stale, it was failing this repo's CI for
-      #    a reason that had nothing to do with this repo — and it is what is
-      #    currently blocking #220 and #217.
+      #   quality.yml is consumed `@main` while the PACKAGE was pinned, so the
+      #   two move independently and a change on one side reaches an old runner
+      #   on the other.
       #
-      # v1.3.0 is `f7eaf2a` = .github@main, tagged so the ref stays
-      # reproducible and a later gate change cannot move this repo's verdict
-      # without a commit here.
+      # 1. #164 flipped `hydra-gates-require-full-coverage` to default TRUE, but
+      #    the accounting that makes the flag survivable ships in the PACKAGE.
+      #    Every older pin then failed a coverage assertion for gates it has no
+      #    subject matter for — red for a reason that had nothing to do with
+      #    this repo, and it blocked #220 and #217 here.
+      # 2. #177 added a step that verifies the pinned package contains every
+      #    path the workflow executes by name. v1.3.0 ships none of
+      #    check_spec_anchors.py, check_form_labels.py or check_license_triangle.py,
+      #    so the job now fails before a single gate runs. Verified by listing
+      #    those paths at each tag: only v1.5.0 and `main` carry all nine.
+      #
+      # A pin is a silent expiry date on every upstream fix, and it made each
+      # fix a 23-PR treadmill. Tracking `main` is the fleet contract as of
+      # ConductionNL/.github#177, which also added the guard that made this
+      # safe: `main` cannot serve an unresolvable workflow silently any more —
+      # quality-resolve-probe.yml counts the jobs a caller materialises and
+      # asserts `> 0`, because an unresolvable reusable workflow produces no
+      # red check at all, just zero jobs.
+      #
+      # ROLLBACK, if a gate change ever does break this repo: set
+      # `hydra-gates-ref:` here explicitly. Still supported and still honoured
+      # — an escape hatch, not a resting state.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.5.0


### PR DESCRIPTION
Reopens the work from #230, which I closed by accident while batch-merging the fleet sweep. The branch is unchanged and rebased onto current `development`.

nldesign is the last repo still carrying `hydra-gates-ref`, and the pin now actively costs more than it buys.

## Why unpin rather than bump again

`development` moved v1.3.0 → v1.5.0 while this branch was open, which fixes the symptom that opened it: v1.5.0 satisfies #177's capability probe, so Hydra Gates no longer fails before a gate runs.

But **v1.5.0 carries a fleet-wide falsely-RED gate**. gate-28 `license-triangle` reported a `structural` coverage gap whenever the diff scope was empty — i.e. on every PR that does not touch `lib/**/*.php`, which is most of them. With `hydra-gates-require-full-coverage` defaulting TRUE, that is `exit 98`. Fixed in ConductionNL/.github#182, **on main**. A repo pinned to v1.5.0 cannot see that fix, and the tag will not move.

That is the whole argument for #177's contract in one branch: pinned at v1.3.0, bumped to v1.5.0 to clear one breakage, and a third commit would have been needed for the next.

## Measured here, against the real runner

| diff | before | after |
|---|---|---|
| `.github/workflows/code-quality.yml` | SKIPPED (structural) → exit 98 | NOT APPLICABLE |
| 3 files under `lib/` | PASS | PASS |
| a `lib/*.php` declaring AGPL vs composer's EUPL-1.2 | — | **FAIL — 1 file(s)** |

Verified on this branch's own run after the unpin: **Hydra Gates PASS in 20s, 58 applicable gates green, 5 correctly NOT APPLICABLE.**

Rollback for this repo alone stays available: set `hydra-gates-ref:` explicitly. An escape hatch, not a resting state.