### PR TITLE
ci: publish an installable build of development

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -1,0 +1,36 @@
+# Publishes an installable build of the development branch.
+#
+# Beta and stable reach people through the Nextcloud app store. Development
+# reached nobody: releases only fire on a push to beta or main, so the
+# newest installable build was months behind the branch and trying out
+# unreleased work meant building it yourself.
+#
+# This publishes a GitHub prerelease with a .tar.gz on every push to
+# development. The App Versions app reads a repository's releases from the
+# forge API and installs from that asset, and it already trusts
+# github:ConductionNL/* by default, so nothing needs configuring on the
+# Nextcloud side.
+#
+# Deliberately never uploaded to the app store: the shared workflow skips
+# that step for this channel. A dev build is for people who asked for one.
+name: Development Release
+
+on:
+  push:
+    branches: [development]
+  workflow_dispatch:
+
+# A push during a running build supersedes it. Without this, a busy morning
+# produces a queue of releases that are obsolete before they finish, and
+# the tag each one cuts sticks around.
+concurrency:
+  group: development-release
+  cancel-in-progress: true
+
+jobs:
+  release:
+    uses: ConductionNL/.github/.github/workflows/release-beta.yml@main
+    with:
+      app-name: nldesign
+      channel: dev
+    secrets: inherit


### PR DESCRIPTION
Publishes a GitHub prerelease with a .tar.gz and .sha256 on every push to development, so unreleased work is installable via the App Versions app. Never uploaded to the app store: the shared workflow skips that step for this channel. Depends on ConductionNL/.github#186 and #187.