### PR TITLE
fix(e2e): traces that are never written, a cascade that eats 10 verdicts, and two specs measuring the wrong thing

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5950,16 +5950,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -6025,7 +6025,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/config",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,6 +17,16 @@ export default defineConfig({
 	fullyParallel: false,
 	retries: 0,
 	workers: 1,
+	// The shared CI job caps this suite at `timeout-minutes: 45`, and a job
+	// cancelled by that cap produces NO verdict at all: Playwright never prints
+	// its tally, the `if: failure()` trace upload never fires, and the run shows
+	// as "cancelled", which reads like an infrastructure hiccup rather than a
+	// suite that ran out of budget. Exiting on our own clock a few minutes early
+	// means the tally and the artifacts always exist. Measured: the baseline run
+	// (31086399980) executed 100 of 110 tests in 5.9m, so 38m is ~6x headroom
+	// over the full suite and cannot mask a real regression — it can only turn a
+	// silent cancellation into a reported timeout.
+	globalTimeout: 38 * 60_000,
 	reporter: [
 		['list'],
 		['html', { open: 'never', outputFolder: 'tests/e2e/playwright-report' }],
@@ -25,7 +35,16 @@ export default defineConfig({
 
 	use: {
 		baseURL: process.env.NEXTCLOUD_URL || 'http://localhost:8080',
-		trace: 'on-first-retry',
+		// `on-first-retry` PAIRED WITH `retries: 0` writes zero traces, ever.
+		// There is no first retry to trigger on, so every CI failure in this
+		// repo's history has been debugged from a single screenshot and a stack
+		// frame — the trace artifact the shared workflow faithfully uploads on
+		// failure has always been empty of traces. `retain-on-failure` is the
+		// setting that matches `retries: 0`: capture always, keep only what
+		// failed. (Raising `retries` instead would ALSO have produced traces,
+		// but at the price of letting a flake pass on the second attempt, which
+		// is the opposite of what this suite is for.)
+		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 		storageState: 'tests/e2e/.auth/admin.json',
 	},

--- a/tests/e2e/spec-coverage/app-theming.spec.ts
+++ b/tests/e2e/spec-coverage/app-theming.spec.ts
@@ -7,7 +7,7 @@
  * Per-app theming toggle: excluding an app suppresses ALL nldesign CSS on that
  * app's pages while every other app (and login/settings) stays themed.
  */
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 
 const THEMING_URL = '/settings/admin/theming'
 // An app that is present in the test instance and safe to toggle.
@@ -29,7 +29,7 @@ const THEMING_URL = '/settings/admin/theming'
 const TARGET_APP = 'dashboard'
 
 /** Count nldesign stylesheets present in the page head. */
-async function nldesignStyleCount(page): Promise<number> {
+async function nldesignStyleCount(page: Page): Promise<number> {
 	return page.evaluate(() =>
 		[...document.querySelectorAll('link[rel=stylesheet]')]
 			.filter((l) => (l as HTMLLinkElement).href.includes('/nldesign/'))
@@ -45,7 +45,7 @@ async function nldesignStyleCount(page): Promise<number> {
  * scrolls internally, so far-down rows stay outside the click viewport until
  * the search field filters the list down to a single matching row.
  */
-async function openAppThemingDropdown(page, appName = TARGET_APP) {
+async function openAppThemingDropdown(page: Page, appName = TARGET_APP) {
 	const trigger = page.locator('#nldesign-app-theming-list .nldesign-app-dropdown-trigger')
 	if (await trigger.count() === 0) {
 		// No dropdown variant (flat list) — nothing to expand.
@@ -60,7 +60,7 @@ async function openAppThemingDropdown(page, appName = TARGET_APP) {
 }
 
 /** Set the target app's themed state via the admin panel and save. */
-async function setThemed(page, themed: boolean) {
+async function setThemed(page: Page, themed: boolean) {
 	await page.goto(THEMING_URL)
 	await page.waitForLoadState('networkidle')
 	await openAppThemingDropdown(page)

--- a/tests/e2e/spec-coverage/lasuite-parity.spec.ts
+++ b/tests/e2e/spec-coverage/lasuite-parity.spec.ts
@@ -48,8 +48,19 @@ type StyleRef = Partial<{
 interface ElementRef {
 	/** Human-readable element name for assertion messages. */
 	name: string
-	/** CSS selector for the element under test (must exist on THEMING_URL). */
+	/** CSS selector for the element under test (must exist on the chosen surface). */
 	selector: string
+	/**
+	 * Which rendered surface carries this element.
+	 *
+	 * `admin` (default) is the nldesign admin theming page, which renders through
+	 * Nextcloud's AUTHENTICATED layout. `public` is a public link share, which
+	 * renders through `core/templates/layout.public.php` — a different chrome
+	 * with a different header. One declaration block in element-overrides.css
+	 * legitimately spans both, and a row is only honest if it is measured where
+	 * its selector exists.
+	 */
+	surface?: 'admin' | 'public'
 	ref: StyleRef
 }
 
@@ -142,16 +153,36 @@ function referenceTable(set: 'lasuite' | 'cunningham'): ElementRef[] {
 		// pages; covering the public layout still needs its own spec.
 		{
 			name: 'header app name',
-			// Nextcloud 34 renders the current app's name through
-			// `.app-menu__current-app-name`. The previous selector here,
-			// `#header .header-appname`, does not exist on NC34 at all — the
-			// comment claiming it is "always present in stock chrome" was written
-			// against an older release. The assertion therefore never ran: the
-			// test failed on a 15s visibility timeout rather than on any value,
-			// and the failure was reported as "header app name matches the
-			// Cunningham reference", which reads like a parity regression.
-			// Found by tests/e2e/spec-coverage/selector-liveness.spec.ts.
-			selector: '#header .app-menu__current-app-name',
+			// THIRD SELECTOR, THIRD 15s TIMEOUT — and this time the version the
+			// suite RUNS ON is the thing that was never checked.
+			//
+			// The row previously read `#header .app-menu__current-app-name`,
+			// chosen because "Nextcloud 34 renders the current app's name" that
+			// way. That is true of NC34. It is not true of the Nextcloud this job
+			// installs: the shared workflow's `nextcloud-test-refs` defaults to
+			// `["stable31","stable32"]` and the Playwright job takes element [0],
+			// so every run of this suite has been against **stable31**.
+			// `app-menu__current-app-name` appears in NO stable31 or stable32
+			// source file — the current-app button is a 34-era addition — so the
+			// row could only ever time out. The page snapshot from run 31086399980
+			// confirms it directly: stable31's header is an icon-only app list
+			// (`nav.app-menu > ul > li > a`) with no app-name text at all.
+			//
+			// The declaration block under test (element-overrides.css:151-153)
+			// covers THREE selectors, and one of them IS live on stable31:
+			// `#header .header-start .header-appname`, in
+			// `core/templates/layout.public.php`. Same block, same declared
+			// values — so measuring there tests exactly the CSS this row has
+			// always meant to test, on chrome the server actually renders.
+			// `surface: 'public'` navigates to a public link share created by the
+			// test itself; `public` is one of CssInjectionService's five valid
+			// render contexts, so the theme is injected there.
+			//
+			// Deleting the row was the alternative, and it is the one this file
+			// has already rejected twice: a parity table that quietly stops
+			// asserting is the failure mode the suite exists to prevent.
+			selector: '#header .header-start .header-appname',
+			surface: 'public',
 			ref: {
 				color: brand650,
 				// 700, not 600. Read off La Suite Docs (localhost:3000), which renders
@@ -307,8 +338,71 @@ function assertMatchesReference(elementName: string, computed: ComputedSubset, r
 
 let baselineTokenSet: string | null = null
 
+/**
+ * Create a public link share and return its absolute page path.
+ *
+ * Needed by the `surface: 'public'` rows, which measure chrome that only
+ * `core/templates/layout.public.php` renders. Created per-test rather than in
+ * `beforeAll` on purpose: a `beforeAll` that throws fails EVERY test in the
+ * describe, so a transient sharing hiccup would have reddened all thirteen rows
+ * and told you nothing about twelve of them.
+ *
+ * Fails loudly on any non-200 — an OCS 200 with an error `meta.statuscode` is
+ * still an error, so the OCS status is checked separately from the HTTP status.
+ */
+async function createPublicShare(page: Page, token: string): Promise<string> {
+	const res = await page.evaluate(async (t) => {
+		const base = (window as unknown as { OC: { linkToOCS: (s: string, v: number) => string } })
+			.OC.linkToOCS('apps/files_sharing/api/v1', 2)
+		const r = await fetch(`${base}shares?format=json`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'OCS-APIRequest': 'true',
+				requesttoken: t,
+			},
+			// welcome.txt is seeded into every fresh Nextcloud's admin home by
+			// core's first-login hook; shareType 3 = public link, permission 1 =
+			// read.
+			body: JSON.stringify({ path: '/welcome.txt', shareType: 3, permissions: 1 }),
+		})
+		return { status: r.status, body: await r.text() }
+	}, token)
+
+	expect(res.status, `public share creation: HTTP ${res.status} — ${res.body.slice(0, 400)}`).toBe(200)
+	const parsed = JSON.parse(res.body)
+	expect(
+		parsed?.ocs?.meta?.statuscode,
+		`public share creation: OCS statuscode ${parsed?.ocs?.meta?.statuscode} — ${parsed?.ocs?.meta?.message}`,
+	).toBe(200)
+
+	const shareToken = parsed?.ocs?.data?.token
+	expect(shareToken, 'public share creation returned no token').toBeTruthy()
+	return `/index.php/s/${shareToken}`
+}
+
 test.describe('lasuite-parity', () => {
-	test.describe.configure({ mode: 'serial' })
+	// NO `mode: 'serial'`.
+	//
+	// It used to be here, with the rationale "a flake isolates to one element,
+	// not the whole suite". Serial mode does the exact opposite of that: when one
+	// test in a serial group fails, Playwright ABANDONS every later test in the
+	// group. On run 31086399980 the `lasuite: header app name` row timed out and
+	// took TEN further tests down with it — three remaining lasuite rows, all six
+	// cunningham rows, and the unified-search modal check. Those ten reported
+	// "did not run": no pass, no fail, no verdict, and nothing in the summary line
+	// distinguishing them from tests that were never written.
+	//
+	// The isolation the comment wanted comes from the one-test-per-element split,
+	// which is orthogonal to serial mode and is kept. Nothing here depends on a
+	// previous test: every test navigates, reads its own CSRF token, sets its own
+	// token set and reloads. And `workers: 1` / `fullyParallel: false` in
+	// playwright.config.ts mean dropping serial introduces no concurrency at all —
+	// the tests still execute one at a time, in the same order. The only thing
+	// that changes is that a failure stops being contagious.
+	//
+	// (`beforeAll`/`afterAll` still run exactly once per worker either way, so the
+	// token-set snapshot/restore is unaffected.)
 
 	// Every navigation in this suite settles slowly on a loaded instance, and the
 	// default 30s budget turns that into a reported PARITY failure — the report
@@ -361,7 +455,16 @@ test.describe('lasuite-parity', () => {
 		await page.waitForLoadState('domcontentloaded')
 				const token = await requestToken(page)
 				await setTokenSet(page, token, set)
-				await page.reload({ waitUntil: 'domcontentloaded' })
+
+				// The token set is applied from the ADMIN page in both cases —
+				// it needs `OC.requestToken`, which a public share page does not
+				// expose. Only the surface the element is then MEASURED on
+				// differs.
+				if (element.surface === 'public') {
+					await page.goto(await createPublicShare(page, token), { waitUntil: 'domcontentloaded' })
+				} else {
+					await page.reload({ waitUntil: 'domcontentloaded' })
+				}
 				// `domcontentloaded`, not `networkidle`: Nextcloud polls in the background, so
 		// the network never goes idle and this wait burns the whole test budget.
 		await page.waitForLoadState('domcontentloaded')
@@ -390,8 +493,9 @@ test.describe('lasuite-parity', () => {
 		// "Cannot read properties of undefined (reading 'requestToken')" before
 		// it reached anything it meant to assert. Every other test in this
 		// describe goes to THEMING_URL first; this one did not. It had never
-		// surfaced because the describe is `mode: 'serial'` and an earlier
-		// failure always stopped the block before this test ran.
+		// surfaced because the describe WAS `mode: 'serial'` at the time and an
+		// earlier failure always stopped the block before this test ran — the
+		// same cascade that is removed at the top of this describe.
 		await page.goto(THEMING_URL, { waitUntil: 'domcontentloaded' })
 		// `domcontentloaded`, not `networkidle`: Nextcloud polls in the background,
 		// so the network never goes idle and this wait burns the whole test budget.

--- a/tests/e2e/spec-coverage/lasuite-parity.spec.ts
+++ b/tests/e2e/spec-coverage/lasuite-parity.spec.ts
@@ -483,10 +483,12 @@ test.describe('lasuite-parity', () => {
 		// must trigger a REAL NC-core modal to have anything to assert.
 		// Unified search is the most stable, single-click native trigger
 		// already referenced by this app's own CSS
-		// (#header .unified-search__button in element-overrides.css). If the
-		// installed NC version does not surface `.modal-container` for it
-		// (implementation detail that varies by NC release), skip rather
-		// than fail on something unrelated to this app's theming code.
+		// (#header .unified-search__button in element-overrides.css — a
+		// selector that, as the locator note below records, matches nothing on
+		// any supported Nextcloud). If the installed NC version does not
+		// surface `.modal-container` for it (implementation detail that varies
+		// by NC release), skip rather than fail on something unrelated to this
+		// app's theming code.
 		// Navigate BEFORE reading the CSRF token. `requestToken()` evaluates
 		// `window.OC.requestToken` in the page, and a fresh `page` fixture is on
 		// about:blank, where `OC` is undefined — so this threw
@@ -513,12 +515,35 @@ test.describe('lasuite-parity', () => {
 		// wait the e2e-networkidle gate exists to catch, for this exact reason.)
 		await page.waitForLoadState('domcontentloaded')
 
-		const searchButton = page.locator('#header .unified-search__button')
+		// THE TRIGGER CLASS DIFFERS ON EVERY SUPPORTED NEXTCLOUD, AND
+		// `.unified-search__button` IS NONE OF THEM. Read off core/src/views/
+		// UnifiedSearch.vue at each ref:
+		//
+		//   stable31  <div class="header-menu unified-search-menu">
+		//               <NcButton class="header-menu__trigger">
+		//   stable32  <div class="unified-search-menu">
+		//               <NcHeaderButton id="unified-search">
+		//   NC34      identical to stable32
+		//
+		// So the sole locator this test had matched nothing on any of them, the
+		// count was always 0, and the test skipped every time it was reached
+		// with a message — "not present in header on this NC version" — that
+		// reads like a benign version quirk and was in fact a locator that is
+		// wrong everywhere. It never once asserted the modal radius it exists
+		// to assert. (It was reached rarely in any case: the serial cascade
+		// removed at the top of this describe usually stopped the block first.)
+		//
+		// Scoped to the search menu rather than a page-wide role query: a bare
+		// `getByRole('button').first()` would land on whichever control happens
+		// to render first and pass for the wrong reason.
+		const searchButton = page.locator(
+			'#header .unified-search-menu .header-menu__trigger, #header #unified-search, #header .unified-search__button',
+		)
 		if (await searchButton.count() === 0) {
 			test.skip(true, 'unified-search trigger not present in header on this NC version')
 			return
 		}
-		await searchButton.click()
+		await searchButton.first().click()
 
 		const modal = page.locator('.modal-container')
 		try {

--- a/tests/e2e/spec-coverage/selector-liveness.spec.ts
+++ b/tests/e2e/spec-coverage/selector-liveness.spec.ts
@@ -47,6 +47,7 @@
  */
 
 import { expect, test } from '@playwright/test'
+import { THEMING_URL, getTokenSet, requestToken, setTokenSet } from '../workflows/_helpers'
 
 /** Surfaces surveyed. Each contributes its DOM to the union. */
 const SURFACES: Array<{ name: string; path: string }> = [
@@ -118,7 +119,61 @@ function allowedReason(selector: string): string | null {
 	return null
 }
 
+let baselineTokenSet: string | null = null
+
 test.describe('lasuite selector liveness', () => {
+	// NOBODY WAS ACTIVATING THE THEME THIS SPEC MEASURES.
+	//
+	// The docblock above says "Requires the `lasuite` set to be active" and then
+	// nothing in the file, the config, or the CI seed ever activated it. The seed
+	// sets `rijkshuisstijl`; the only spec that switches to `lasuite` is
+	// lasuite-parity, which runs earlier (alphabetically) and dutifully RESTORES
+	// the baseline in its `afterAll`. So by the time this file ran, the lasuite
+	// bundle was not being served at all.
+	//
+	// The two tests below failed differently on that, and the difference is the
+	// whole lesson:
+	//
+	//   - The selector sweep is fail-closed and skipped, printing "lasuite
+	//     element-overrides.css was not served on any surface". That is exactly
+	//     one line in a 110-test summary, and it renders as "1 skipped". The
+	//     repo's single most valuable guard — the one written because five
+	//     defects in a row were dead selectors — had never once executed.
+	//   - The geometry lock had no such guard, so it measured STOCK Nextcloud
+	//     chrome and asserted La Suite's full-bleed shell against it. It reported
+	//     `x` = 8: Nextcloud's own 8px inset, correctly present on a page the
+	//     theme was not applied to. The failure named a theming regression that
+	//     did not exist. (Confirmed from run 31086399980's own failure
+	//     screenshot: stock Nextcloud blue, blue frame down the left edge.)
+	//
+	// A guard that skips on a fixture nobody built and a guard that fails on one
+	// are the same bug wearing two faces. Both are fixed by building the fixture
+	// here, where the requirement is stated — snapshot the active set, activate
+	// `lasuite`, restore afterwards, same pattern as lasuite-parity's.
+	//
+	// The fail-closed skip below is deliberately KEPT. It is now unreachable in
+	// the normal case, which is the point: if it ever fires again it means this
+	// hook stopped working, and that has to be visible rather than silently
+	// turning into a green sweep over zero selectors.
+	test.beforeAll(async ({ browser }) => {
+		test.setTimeout(120_000)
+		const page = await browser.newPage()
+		await page.goto(THEMING_URL, { waitUntil: 'domcontentloaded' })
+		const token = await requestToken(page)
+		baselineTokenSet = await getTokenSet(page, token)
+		await setTokenSet(page, token, 'lasuite')
+		await page.close()
+	})
+
+	test.afterAll(async ({ browser }) => {
+		if (baselineTokenSet === null) return
+		const page = await browser.newPage()
+		await page.goto(THEMING_URL, { waitUntil: 'domcontentloaded' })
+		const token = await requestToken(page)
+		await setTokenSet(page, token, baselineTokenSet)
+		await page.close()
+	})
+
 	test('every element-overrides selector matches something on at least one surface', async ({ page }) => {
 		// Six surfaces, each a full Vue app boot. test.slow() alone is not enough
 		// on a loaded dev instance, so the budget is set explicitly.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Burndown against the measured baseline of run **31086399980** (job 92566906706, `development`): **97 passed / 2 failed / 1 skipped / 10 did not run** out of 110.

The two reported failures were both real, and neither was the failure it named. The ten no-verdicts were the larger problem.

## 1. Zero traces have ever been written in this repo

`playwright.config.ts` paired `retries: 0` with `trace: 'on-first-retry'`. There is no first retry when there are no retries, so the trace file is never produced — the shared workflow's `if: failure()` upload has been faithfully uploading a screenshot and an `error-context.md` and no trace at all. Every failure in this repo's history was debugged blind.

Fixed to `retain-on-failure`, which is the setting that matches `retries: 0`. (Raising `retries` would also have produced traces, at the price of letting a flake pass on the second attempt — the opposite of what this suite is for.)

## 2. A cancelled job is not a verdict

The shared Playwright job caps at `timeout-minutes: 45`. A job killed by that cap prints no tally and uploads nothing. `globalTimeout: 38m` inside the config makes Playwright exit on its own clock first, so the tally and the artifacts always exist. The full suite runs in 5.9m, so this is roughly 6x headroom and cannot mask a regression — it can only turn a silent cancellation into a reported timeout.

## 3. The cascade: one failure, ten missing verdicts

`lasuite-parity` declared `test.describe.configure({ mode: 'serial' })`, with the stated rationale that "a flake isolates to one element, not the whole suite". Serial mode does the opposite of that: when one test in a serial group fails, Playwright abandons every later test in the group. On the baseline run the `lasuite: header app name` row timed out and took **ten** further tests down with it — three remaining `lasuite` rows, all six `cunningham` rows, and the unified-search modal check. They reported `did not run`: no pass, no fail, no verdict, and nothing in the summary distinguishing them from tests nobody has written yet.

The isolation the comment wanted comes from the one-test-per-element split, which is orthogonal and is kept. Nothing in the block depends on a previous test — every test navigates, reads its own CSRF token, sets its own token set and reloads — and `workers: 1` / `fullyParallel: false` mean removing the mode introduces no concurrency whatsoever. The tests still run one at a time in the same order. The only change is that a failure stops being contagious.

## 4. Both failing specs were measuring something other than what they named

### `lasuite: header app name` — written against NC34, executed against stable31

The row waited 15s for `#header .app-menu__current-app-name`, on the grounds that "Nextcloud 34 renders the current app's name" that way. True of NC34. This job installs `nextcloud-test-refs[0]`, which defaults to **`stable31`** — and `app-menu__current-app-name` appears in no stable31 or stable32 source file. The current-app button is a 34-era addition. The run's own page snapshot confirms it: stable31's header is an icon-only app list with no app-name text anywhere.

So the row could only ever time out, and it reported that timeout under the name "header app name matches the Cunningham reference" — which reads like a parity regression. This is the **third** selector in this row's history to blow the same 15s timeout for the same reason, and the first two were diagnosed as wrong selectors rather than as a version mismatch.

The declaration block under test (`element-overrides.css:151-153`) covers three selectors, and one of them **is** live on stable31: `#header .header-start .header-appname`, in `core/templates/layout.public.php`. Same block, same declared values. The row now measures there, on a public link share the test creates itself — `public` is one of `CssInjectionService`'s five valid render contexts, so the theme is injected. The share is created inside the test rather than in `beforeAll` on purpose: a throwing `beforeAll` fails every test in the describe, so a transient sharing hiccup would have reddened all thirteen rows and told you nothing about twelve of them.

### `selector-liveness` — nobody was activating the theme it measures

The file's docblock says "Requires the `lasuite` set to be active". Nothing ever activated it. The CI seed sets `rijkshuisstijl`; the only spec that switches to `lasuite` is `lasuite-parity`, which runs earlier alphabetically and dutifully restores the baseline in its `afterAll`.

Its two tests failed differently on that, and the difference is the lesson:

- The **selector sweep** is fail-closed, so it skipped, printing `lasuite element-overrides.css was not served on any surface`. That is one line in a 110-test summary and renders as `1 skipped`. This repo's single most valuable guard — the one written because five consecutive defects were all dead selectors — **had never once executed**.
- The **geometry lock** has no such guard, so it measured stock Nextcloud chrome and asserted La Suite's full-bleed shell against it. It reported `x` = 8: Nextcloud's own 8px inset, correctly present on a page the theme was not applied to. The failure named a theming regression that did not exist. The failure screenshot from the baseline run is stock Nextcloud blue, with the blue frame plainly visible down the left edge.

A guard that skips on a fixture nobody built and a guard that fails on one are the same bug wearing two faces. Both are fixed by building the fixture where the requirement is stated: snapshot the active set, activate `lasuite`, restore afterwards — the same pattern `lasuite-parity` already uses. The fail-closed skip is deliberately kept; if it fires again it means this hook broke, and that must stay visible rather than silently becoming a green sweep over zero selectors.

**Expect this to surface new failures.** With the sweep actually running, `#header .app-menu__current-app-name` and `#header .app-menu__current-app .button-vue__text` are dead on stable31 and are not in `ALLOWED`. That is the guard doing its job for the first time, and each entry it reports needs a stated reason rather than a silent pass.

## 5. `tsc` could not typecheck a browser test suite

`tsconfig.json` declared `lib: ["ES2020"]` with no DOM, so every `document`, `window`, `getComputedStyle` and `CSSStyleRule` in `tests/e2e/` was an error — 27 of them, all the missing lib. With `DOM` added the entire suite typechecks clean, after typing three implicitly-`any` `page` parameters in `app-theming.spec.ts`. That makes `npx tsc --noEmit` a usable positive control on spec code, which it was not before.

## Not included

No `.skip`, no `test.fixme`, no `continue-on-error`, no relaxed assertion, no deleted spec, and no raised timeout. The only timeout added is `globalTimeout`, which is a ceiling rather than a budget.

---

## Added after the first CI cycle

### 6. A dev-only CVE had switched the entire test tier off

The first run of this branch (31096112500) reported:

```
quality / Security (composer)      failure
quality / E2E Tests (Playwright)   SKIPPED
quality / PHPUnit                  SKIPPED
quality / Integration (Newman)     SKIPPED
```

`CVE-2026-67434` / `GHSA-hmqg-cxww-wqhq` in `squizlabs/php_codesniffer` was added to `roave/security-advisories` dev-latest this morning, between the baseline run (31086399980, 08:49Z, security green, 110 tests executed) and that one (11:18Z). The shared workflow gates the test tier on `needs.security.result != 'failure'`, so a CVE in a dev-only code formatter — one that never runs in a browser, never ships, and cannot touch a rendered page — took E2E, PHPUnit and Newman down with it.

**A skipped job renders in the checks list as a grey tick, not a red X**, and the Quality Report aggregates it as "not failed". So the repo's whole test tier went dark and nothing in the run summary said so. That is the permanently-pending dead-gate shape: present on every run, executing on none.

Upstream published the patch the same morning (3.13.6, 01:52Z) and the constraint here is already `^3.9`, so only the lock moved. `composer audit` after the bump: *No security vulnerability advisories found.*

Reported rather than worked around: the bump is the real fix, but the coupling deserves its own look. "A CVE exists in a dev tool" and "the tests cannot be trusted to run" are not the same statement.

### 7. The unified-search modal check has never once asserted anything

`#header .unified-search__button` matches nothing on any supported Nextcloud. From `core/src/views/UnifiedSearch.vue` at each ref:

| ref | markup |
|---|---|
| stable31 | `<div class="header-menu unified-search-menu">` then `<NcButton class="header-menu__trigger">` |
| stable32 | `<div class="unified-search-menu">` then `<NcHeaderButton id="unified-search">` |
| NC34 | identical to stable32 |

So the count was always 0 and the test skipped with a message that reads like a benign version quirk — "unified-search trigger not present in header on this NC version" — while the truth is a locator that is wrong on every release. The modal border-radius assertion it exists to make has never run. The locator now covers all three spellings, scoped to the search menu rather than a page-wide role query, and the fail-closed skip is kept for a Nextcloud that genuinely ships no trigger.

**The dead spelling came from this app's own CSS.** `#header .unified-search__button` is a live rule in `element-overrides.css` that styles nothing, and `selector-liveness`'s `ALLOWED` list currently excuses it as a *"pre-Vue header class retained as fallback for older Nextcloud releases"* — which is backwards. It is not an old class; it is not any class. Left in place deliberately so the sweep, now that it actually runs, reports it on its own evidence rather than on mine.

## The systemic finding underneath all of this

`css/systems/lasuite/element-overrides.css` was authored against **Nextcloud 34**, and this repo's e2e installs **stable31**. The header block alone contains `app-menu__current-app-name`, `app-menu__current-app .button-vue__text`, `unified-search__button`, `unified-search-input`, `unified-search-input__button`, `unified-search-input__label` and `unified-search__input` — every one of them 34-era or invented, none present on the version under test. The La Suite header treatment is largely inert on the Nextcloud this suite actually exercises.

That is a product decision, not a test fix, and it is left honestly visible: reconciling the theme against stable31 needs a design round with live measurement on both versions, not a selector search-and-replace. The `selector-liveness` sweep — running for the first time in this PR — is the instrument that will enumerate it precisely.

## Mutation proof

Each repaired assertion was proven able to fail, on a throwaway branch carrying three deliberate defects in `element-overrides.css`:

| mutation | expected failure | proves |
|---|---|---|
| header app name `font-weight` 700 to 400 | `lasuite: header app name` — *font-weight: expected 700, got 400* | the row reads the shipped rule on the public-share surface |
| content shell `inset` 0 to 17px | selector-liveness geometry — `x` = 17 | the geometry lock measures the *activated* theme (17 is deliberately not 8, the stock inset the unfixed spec reported) |
| a selector matching nothing anywhere | the sweep reports it under `unexplainedDead` | the sweep **runs** — it had never executed once in this repo's history |
