### PR TITLE
fix(deps): php_codesniffer 3.13.6 — CVE-2026-67434 OS command injection

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5950,16 +5950,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -6025,7 +6025,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/config",


### PR DESCRIPTION
## New advisory, fleet-wide

**squizlabs/php_codesniffer — CVE-2026-67434 / GHSA-hmqg-cxww-wqhq — OS command injection.** Reported **2026-08-05**. Affected: `<3.13.6 | >=4.0.0,<4.0.2`.

All 16 Conduction repos checked were on **3.13.5**. This is currently failing the `Security (composer)` gate on every one of them.

The advisory landed mid-session: `composer audit --locked` returned **zero** advisories for this repo about an hour before it returned this one. The audit DB is live, so a lockfile that was clean this morning is not clean now.

## Change

`composer.lock` only — `squizlabs/php_codesniffer 3.13.5 → 3.13.6`. The `composer.json` constraint already allowed it.

## Verification

- `composer audit --locked` → **"No security vulnerability advisories found"** (was 1 advisory).
- `vendor/bin/phpcs --version` → **3.13.6**.
- `composer phpcs` → **rc=0**.
- **Positive control**: a deliberately non-conforming file under `lib/` made phpcs exit **2** with **13 findings**, then was deleted. A green check that cannot fail is not evidence. `git status` confirmed clean afterwards.