### PR TITLE
fix(newman): fixture src paths are relative to the COLLECTION dir, not the app root

### DIFF
--- a/tests/integration/nldesign.postman_collection.json
+++ b/tests/integration/nldesign.postman_collection.json
@@ -1339,7 +1339,7 @@
               "formdata": [
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-valid.css",
+                  "src": "fixtures/newman-valid.css",
                   "type": "file"
                 }
               ]
@@ -1416,7 +1416,7 @@
                 },
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-valid.css",
+                  "src": "fixtures/newman-valid.css",
                   "type": "file"
                 }
               ]
@@ -1488,7 +1488,7 @@
                 },
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-valid.css",
+                  "src": "fixtures/newman-valid.css",
                   "type": "file"
                 }
               ]
@@ -1560,7 +1560,7 @@
                 },
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-bad-selector.css",
+                  "src": "fixtures/newman-bad-selector.css",
                   "type": "file"
                 }
               ]
@@ -1632,7 +1632,7 @@
                 },
                 {
                   "key": "file",
-                  "src": "tests/integration/fixtures/newman-malformed.tokens.json",
+                  "src": "fixtures/newman-malformed.tokens.json",
                   "type": "file"
                 }
               ]


### PR DESCRIPTION
The `quality / Integration Tests (Newman)` job has been red on `development` with **14 assertion failures**, all in *"4. Custom token sets (upload/list/export/delete)"*. Every upload returned 400 — including the one asserting 200 — and the follow-on assertions then failed on `undefined`, because there was no body to read.

**None of it was an API bug.** The three multipart fixtures were declared with a `src` relative to the **app root**:

```
"src": "tests/integration/fixtures/newman-valid.css"
```

But the shared workflow runs:

```
cd server/apps/<app>/tests/integration
newman run "$collection" ...
```

so newman's working directory *is* `tests/integration`, and it looked for `tests/integration/tests/integration/fixtures/…`. The file was never attached, the request arrived with no upload, and `CustomTokenSetController::readUpload()` correctly answered `No file uploaded.` with 400.

**The endpoint was doing exactly the right thing. The collection was lying about where its fixtures live.**

## The cascade is worth naming

**One** unresolvable path produced **14** failures across six named cases — 409-on-collision, 422-on-bad-selector, 422-on-malformed-json, listing, export, delete — because each depends on the token set the first case was supposed to create. Read bottom-up, that failure list looks like a broken feature. It is a single missing file.

## Verified

Ran newman against a dead port, so only file resolution is exercised:

| | result |
|---|---|
| **before** | `unable to load data for "…/fixtures/newman-bad-selector.css", no such file` — and the same for `newman-malformed.tokens.json` and `newman-valid.css` |
| **after** | no file-resolution errors at all |

Each rewritten path was also checked to resolve from CI's working directory.

## Why the collection and not the workflow

Adding `--working-dir` to the shared workflow would also work, but that workflow's contract is already *"cwd is the collection directory"* — and a fixture path relative to its own collection is what any other consumer of that contract would expect. A fleet sweep found nldesign is the only repo with app-root-relative `src` paths, so there is nothing else to bring along.
