### PR TITLE
ci: drop the stable31 leg — openregister cannot install there

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -60,6 +60,26 @@ jobs:
     with:
       app-name: nldesign
       php-version: "8.3"
+      # Pinned, because the shared workflow's DEFAULT is '["stable31", "stable32"]'
+      # and stable31 CANNOT WORK here. `additional-apps` below installs
+      # openregister, which declares min-version="32" (its
+      # lib/ContextChat/ContentProvider.php implements
+      # OCP\ContextChat\IContentProvider, absent from core before NC32). On NC31
+      # `occ app:enable openregister` fails with
+      #   App "Open Register" cannot be installed because it is not compatible
+      #   with this version of the server.
+      # and the run continues anyway, because that failure is only a ::warning::.
+      # Every /apps/openregister/... call then returns Nextcloud's HTML 404 page.
+      #
+      # Order matters as much as membership: newman, playwright and
+      # journeydoc-capture all check out `fromJSON(nextcloud-test-refs)[0]` as
+      # their single server, so with the inherited default those three jobs ran
+      # entirely on the version openregister cannot load.
+      #
+      # nldesign's own appinfo/info.xml floor stays at 28: this app declares no
+      # <app> dependency and src/manifest.json declares none either — the NC32
+      # constraint is a property of the CI fixture, not of nldesign's code.
+      nextcloud-test-refs: '["stable32"]'
       # These three were `false`, and that is worse than it sounds. The shared
       # workflow builds one matrix leg per tool unconditionally; a disabled leg
       # prints "<tool> is disabled — skipping." and `exit 0`. The job therefore


### PR DESCRIPTION
## What changed

**`nextcloud-test-refs` pinned to `["stable32"]`.** This repo set no value, so it inherited the shared workflow's default of `["stable31","stable32"]` — and `additional-apps` installs openregister, which cannot install on NC31.

**`appinfo/info.xml` is deliberately NOT changed.** nldesign declares no `<app>` dependency and `src/manifest.json` declares none either; there are no OpenRegister references in its PHP. The NC32 constraint here is a property of the **CI fixture**, not of nldesign's code — so its floor stays at 28. Raising it would be asserting something about this app that is not true.

## The defect

openregister raised its own floor this morning — `<nextcloud min-version="32" max-version="34"/>`, commit `8d5181f7a` (openregister#2378), *"require Nextcloud 32, which is where the ContextChat interfaces exist"*. Its `lib/ContextChat/ContentProvider.php` implements `OCP\ContextChat\IContentProvider`, and core does not have that interface before NC32. **That raise is correct and is not being reverted here.**

The consequence lands on every app that depends on openregister but still tests on `stable31`:

```
Enabling app: openregister
App "Open Register" cannot be installed because it is not compatible with this version of the server.
##[warning]Failed to enable openregister, continuing...
```

The enable failure is only a `::warning::` (shared `quality.yml`, "Install Nextcloud" step), so the run **continues without its data layer** and every `/apps/openregister/...` call returns Nextcloud's HTML 404 page.

## This was measured, not inferred

- One **unchanged commit's** job passed at 08:05 and failed at 08:35, with zero code change in between — the only thing that moved was openregister's floor.
- Re-running `development`'s own Newman on yesterday's commits: **decidesk 93 → 191** failures, **larpingapp 10 → 22**.
- docudesk was immune, and only because it already tests `stable32` only.

## `stable31` is removed, not "dropped for coverage"

A `stable31` leg was exercising a configuration that **cannot exist**: the app under test declares openregister as a hard dependency, and openregister cannot install there. Nothing was being covered on that leg — its red said nothing about this app's code. Removing it corrects an impossible configuration. It does not reduce coverage.

The matrix is **not widened** either: no `stable33` is added where it was not already present.

## The ordering bug in the same family

Membership was not the only problem. In the shared `quality.yml`, three jobs pin the **first** entry rather than iterating the list:

| job | line | server |
|---|---|---|
| `newman` | 1748 | `fromJSON(inputs.nextcloud-test-refs)[0]` |
| `playwright` | 2024 | `fromJSON(inputs.nextcloud-test-refs)[0]` |
| `journeydoc-capture` | 2775 | `fromJSON(inputs.nextcloud-test-refs)[0]` |

(`phpunit` iterates the whole list, so it was broken by *membership*; the coverage-guard and coverage-artifact steps at 1644/1671/1684 are also `[0]`-pinned.)

So wherever `stable31` sat **first**, those three jobs ran *entirely* on the version openregister cannot load. doriath had already reordered for exactly this reason.

## Precedent

This is the same defect as **openconnector#1173**, which declared `min-version="28"` while its own `<app>openregister</app>` dependency required 32 — advertising, in the app store, a range it could not deliver. This PR follows that shape.

## Scope

No app version bump — only the supported-server range and the CI matrix change, so there are no `occ upgrade` implications.