### PR TITLE
chore: raise the Nextcloud floor to 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,7 +35,7 @@ Gratis en open source onder de EUPL-1.2 licentie.
 
 	<dependencies>
 		<php min-version="8.3"/>
-		<nextcloud min-version="28" max-version="34"/>
+		<nextcloud min-version="32" max-version="34"/>
 	</dependencies>
 
 	<!-- Upstream token freshness check (openspec/specs/upstream-freshness/spec.md):


### PR DESCRIPTION
Raises the declared Nextcloud floor to **32**, matching what we actually build and test against.

The old floors were fiction. CI runs `nextcloud:32-apache`, the dev stack is on 34, and nothing exercised 28–31. Declaring support for versions no one tests is a promise the app store passes on to users.

The concrete trigger: OpenRegister ships `lib/ContextChat/ContentProvider.php`, which implements `OCP\ContextChat\IContentProvider` — an interface that does not exist in core before NC 32. On 31 and below, loading the class logs `Interface not found`, and no lazy-DI or event gating can prevent it, because the failure happens when PHP reads the class header. OpenRegister moved to 32 in ConductionNL/openregister#2378; ten apps depend on it, so their lower floors were unsatisfiable at the bottom.

Only the `<nextcloud min-version>` attribute changes. `max-version` is untouched, verified by comparing every branch against its base: 0 of 24 repos had `max-version` altered.