### PR TITLE
fix(e2e): 46 waits that can never resolve — networkidle on a Nextcloud page

### DIFF
--- a/tests/e2e/spec-coverage/admin-settings.spec.ts
+++ b/tests/e2e/spec-coverage/admin-settings.spec.ts
@@ -26,7 +26,7 @@ test.describe('admin-settings', () => {
 		'Settings panel appears in admin area',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const heading = page.locator('h2:has-text("NL Design System Theme")')
 			await expect(heading).toBeVisible()
 		},
@@ -37,7 +37,7 @@ test.describe('admin-settings', () => {
 		'Settings panel position relative to Nextcloud theming',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// Both sections are present — the native "Theming" heading and the
 			// NL Design heading, which must come after.
 			const sections = page.locator('main h2')
@@ -80,7 +80,7 @@ test.describe('admin-settings', () => {
 		'Dropdown populated with token sets',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const select = page.locator('#nldesign-token-set-select')
 			await expect(select).toBeVisible()
 			const options = await select.locator('option').count()
@@ -97,7 +97,7 @@ test.describe('admin-settings', () => {
 		'Dropdown label is associated with select',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// The label element with for="nldesign-token-set-select" must exist
 			const label = page.locator('label[for="nldesign-token-set-select"]')
 			await expect(label).toBeVisible()
@@ -110,7 +110,7 @@ test.describe('admin-settings', () => {
 		'Design system badge is present after page load',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const badge = page.locator('#nldesign-design-system-badge')
 			await expect(badge).toBeAttached()
 		},
@@ -135,7 +135,7 @@ test.describe('admin-settings', () => {
 		'Preview box renders with token set colors',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// Live preview is rendered as `.nldesign-preview` (id #nldesign-preview)
 			// containing app/login `.nldesign-preview-stage` shells. The primary
 			// action is the `.nl-btn--primary` button inside the app-shell stage.
@@ -164,7 +164,7 @@ test.describe('admin-settings', () => {
 		'Hide slogan checkbox is present and has correct label',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const checkbox = page.locator('#nldesign-hide-slogan')
 			await expect(checkbox).toBeAttached()
 			const label = page.locator('label[for="nldesign-hide-slogan"]')
@@ -182,7 +182,7 @@ test.describe('admin-settings', () => {
 		'Hide slogan checkbox label text and accessibility',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const label = page.locator('label[for="nldesign-hide-slogan"]')
 			await expect(label).toContainText('Hide Nextcloud slogan/payoff on login page')
 			// label[for] links it to the checkbox — WCAG SC 1.3.1
@@ -204,7 +204,7 @@ test.describe('admin-settings', () => {
 		'Show menu labels checkbox is present and has correct label',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const checkbox = page.locator('#nldesign-show-menu-labels')
 			await expect(checkbox).toBeAttached()
 			const label = page.locator('label[for="nldesign-show-menu-labels"]')
@@ -222,7 +222,7 @@ test.describe('admin-settings', () => {
 		'Show menu labels checkbox label text and accessibility',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const label = page.locator('label[for="nldesign-show-menu-labels"]')
 			await expect(label).toContainText('Show text labels in app menu (hide icons)')
 			const checkbox = page.locator('#nldesign-show-menu-labels')
@@ -243,7 +243,7 @@ test.describe('admin-settings', () => {
 		'Documentation link rendered with correct attributes',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const link = page.locator('a[href="https://nldesign.app"]')
 			await expect(link).toBeVisible()
 			await expect(link).toHaveAttribute('target', '_blank')
@@ -256,7 +256,7 @@ test.describe('admin-settings', () => {
 		'NL Design System info link rendered',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const link = page.locator('a[href="https://nldesignsystem.nl/"]')
 			await expect(link).toBeVisible()
 			await expect(link).toHaveAttribute('target', '_blank')
@@ -309,7 +309,7 @@ test.describe('admin-settings', () => {
 		'Token editor mount point rendered with content',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const editorEl = page.locator('#nldesign-token-editor')
 			await expect(editorEl).toBeAttached()
 		},
@@ -332,7 +332,7 @@ test.describe('admin-settings', () => {
 		'Settings hint text rendered',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const hint = page.locator('.settings-hint').filter({ hasText: 'Select a Dutch government design token set' })
 			await expect(hint).toBeVisible()
 		},
@@ -355,7 +355,7 @@ test.describe('admin-settings', () => {
 		'Token sets data attribute present on settings div',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const settingsDiv = page.locator('#nldesign-settings')
 			await expect(settingsDiv).toBeAttached()
 			const attr = await settingsDiv.getAttribute('data-token-sets')
@@ -372,7 +372,7 @@ test.describe('admin-settings', () => {
 		'Current token set data attribute present on settings div',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const settingsDiv = page.locator('#nldesign-settings')
 			const attr = await settingsDiv.getAttribute('data-current-token-set')
 			expect(attr).toBeTruthy()

--- a/tests/e2e/spec-coverage/app-theming.spec.ts
+++ b/tests/e2e/spec-coverage/app-theming.spec.ts
@@ -62,7 +62,7 @@ async function openAppThemingDropdown(page: Page, appName = TARGET_APP) {
 /** Set the target app's themed state via the admin panel and save. */
 async function setThemed(page: Page, themed: boolean) {
 	await page.goto(THEMING_URL)
-	await page.waitForLoadState('networkidle')
+	await page.waitForLoadState('domcontentloaded')
 	await openAppThemingDropdown(page)
 	const box = page.locator(`#nldesign-app-theming-list input[data-app-id="${TARGET_APP}"]`)
 	// The raw <input> is visually hidden off-canvas (position:absolute, left:-9999px),
@@ -113,11 +113,11 @@ test.describe('per-app-theming', () => {
 			await setThemed(page, false)
 
 			await page.goto(`/apps/${TARGET_APP}/`)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			expect(await nldesignStyleCount(page)).toBe(0)
 
 			await page.goto('/apps/files/')
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			expect(await nldesignStyleCount(page)).toBeGreaterThan(0)
 		},
 	)
@@ -130,7 +130,7 @@ test.describe('per-app-theming', () => {
 			await setThemed(page, true)
 
 			await page.goto(`/apps/${TARGET_APP}/`)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			expect(await nldesignStyleCount(page)).toBeGreaterThan(0)
 		},
 	)
@@ -141,7 +141,7 @@ test.describe('per-app-theming', () => {
 		async ({ page }) => {
 			await setThemed(page, false)
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			expect(await nldesignStyleCount(page)).toBeGreaterThan(0)
 		},
 	)
@@ -151,7 +151,7 @@ test.describe('per-app-theming', () => {
 		'Every app row exposes a checkbox associated with a visible label',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			await openAppThemingDropdown(page)
 			const box = page.locator(`#nldesign-app-theming-list input[data-app-id="${TARGET_APP}"]`)
 			await box.waitFor({ state: 'visible' })

--- a/tests/e2e/spec-coverage/component-tokens.spec.ts
+++ b/tests/e2e/spec-coverage/component-tokens.spec.ts
@@ -60,7 +60,7 @@ test.describe('component-tokens', () => {
 		'Admin theming page loads without CSS errors (component-tokens infrastructure)',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// The NL Design section must render — proves CSS stack (incl. component tokens) loaded
 			await expect(page.locator('#nldesign-settings')).toBeAttached()
 		},

--- a/tests/e2e/spec-coverage/css-architecture.spec.ts
+++ b/tests/e2e/spec-coverage/css-architecture.spec.ts
@@ -169,7 +169,7 @@ test.describe('css-architecture', () => {
 				if (msg.type() === 'error') errors.push(msg.text())
 			})
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// Admin settings section must render — proves CSS stack bootstrapped OK
 			await expect(page.locator('#nldesign-settings')).toBeAttached()
 			// The NL Design h2 heading confirms the PHP template rendered (CSS was injected)

--- a/tests/e2e/spec-coverage/custom-css-overrides.spec.ts
+++ b/tests/e2e/spec-coverage/custom-css-overrides.spec.ts
@@ -57,7 +57,7 @@ test.describe('custom-css-overrides', () => {
 		'Token editor Save overrides button is present (custom-overrides.css write entry point)',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const saveBtn = page.locator('button:has-text("Save overrides")')
 			await expect(saveBtn).toBeVisible()
 		},

--- a/tests/e2e/spec-coverage/custom-token-set-upload.spec.ts
+++ b/tests/e2e/spec-coverage/custom-token-set-upload.spec.ts
@@ -26,7 +26,7 @@ test.describe('custom-token-set-upload', () => {
 		'Custom token set upload form is present with name field and upload button',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 
 			const section = page.locator('#nldesign-custom-token-sets')
 			await expect(section).toBeVisible()
@@ -40,7 +40,7 @@ test.describe('custom-token-set-upload', () => {
 		'Uploading a valid CSS set adds it to the custom-set list and the dropdown',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 
 			const setName = 'E2E Voorbeeld ' + Date.now()
 			await page.fill('#nldesign-upload-name', setName)
@@ -115,7 +115,7 @@ test.describe('custom-token-set-upload', () => {
 		'Low-contrast upload succeeds and surfaces a WCAG AA warning',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 
 			const setName = 'E2E Lowcontrast ' + Date.now()
 			await page.fill('#nldesign-upload-name', setName)
@@ -194,7 +194,7 @@ test.describe('custom-token-set-upload', () => {
 		'Uploaded set exposes Download and Delete actions; delete removes the row',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 
 			const setName = 'E2E Manage ' + Date.now()
 			await page.fill('#nldesign-upload-name', setName)

--- a/tests/e2e/spec-coverage/extended-token-sets.spec.ts
+++ b/tests/e2e/spec-coverage/extended-token-sets.spec.ts
@@ -56,7 +56,7 @@ test.describe('extended-token-sets', () => {
 		'Token set dropdown lists many options (extended token set discovery works)',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const select = page.locator('#nldesign-token-set-select')
 			await expect(select).toBeVisible()
 			// Should have many options reflecting extended token set support

--- a/tests/e2e/spec-coverage/hide-slogan.spec.ts
+++ b/tests/e2e/spec-coverage/hide-slogan.spec.ts
@@ -117,7 +117,7 @@ test.describe('hide-slogan', () => {
 		'Hide slogan checkbox is present in admin settings panel',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const checkbox = page.locator('#nldesign-hide-slogan')
 			await expect(checkbox).toBeAttached()
 			const label = page.locator('label[for="nldesign-hide-slogan"]')

--- a/tests/e2e/spec-coverage/menu-labels.spec.ts
+++ b/tests/e2e/spec-coverage/menu-labels.spec.ts
@@ -131,7 +131,7 @@ test.describe('menu-labels', () => {
 		'Show menu labels checkbox is present in admin settings panel',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const checkbox = page.locator('#nldesign-show-menu-labels')
 			await expect(checkbox).toBeAttached()
 			const label = page.locator('label[for="nldesign-show-menu-labels"]')

--- a/tests/e2e/spec-coverage/theming-sync-dialog.spec.ts
+++ b/tests/e2e/spec-coverage/theming-sync-dialog.spec.ts
@@ -111,7 +111,7 @@ test.describe('theming-sync-dialog', () => {
 				if (msg.type() === 'error') errors.push(msg.text())
 			})
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// nldesign-theming-dialog-overlay must NOT exist on page load (no spurious dialog)
 			const dialog = page.locator('#nldesign-theming-dialog-overlay')
 			await expect(dialog).not.toBeVisible()

--- a/tests/e2e/spec-coverage/token-editor-ui.spec.ts
+++ b/tests/e2e/spec-coverage/token-editor-ui.spec.ts
@@ -22,7 +22,7 @@ test.describe('token-editor-ui', () => {
 		'Admin opens settings — token editor panel is visible',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// Token editor is inside #nldesign-token-editor
 			const editorEl = page.locator('#nldesign-token-editor')
 			await expect(editorEl).toBeVisible()
@@ -45,7 +45,7 @@ test.describe('token-editor-ui', () => {
 		'Login page & Branding tab shows primary-color tokens',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// The "Login page & Branding" tab should be active by default or clickable
 			const tab = page.locator('button:has-text("Login page & Branding")')
 			await expect(tab).toBeVisible()
@@ -92,7 +92,7 @@ test.describe('token-editor-ui', () => {
 		'All four tabs are rendered in token editor',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			await expect(page.locator('button:has-text("Login page & Branding")')).toBeVisible()
 			await expect(page.locator('button:has-text("Content area")')).toBeVisible()
 			await expect(page.locator('button:has-text("Buttons & Status")')).toBeVisible()
@@ -113,7 +113,7 @@ test.describe('token-editor-ui', () => {
 		'Excluded tokens like --color-main-background are not shown in any tab',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// Check all tabs for the excluded token
 			const tabs = ['Login page & Branding', 'Content area', 'Buttons & Status', 'Typography']
 			for (const tabText of tabs) {
@@ -186,7 +186,7 @@ test.describe('token-editor-ui', () => {
 		'Save overrides button is present',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const saveBtn = page.locator('button:has-text("Save overrides")')
 			await expect(saveBtn).toBeVisible()
 		},
@@ -205,7 +205,7 @@ test.describe('token-editor-ui', () => {
 		'Per-token reset buttons are present in the editor',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			await page.locator('button:has-text("Login page & Branding")').click()
 			// Each token row must have a reset button (↺)
 			const resetBtns = page.locator('button:has-text("↺")')

--- a/tests/e2e/spec-coverage/token-import-export.spec.ts
+++ b/tests/e2e/spec-coverage/token-import-export.spec.ts
@@ -22,7 +22,7 @@ test.describe('token-import-export', () => {
 		'Download button is present in the token editor panel',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// The export/download control of the editor panel is the canonical
 			// `#nldesign-export-btn`. Uploaded custom token sets each render their
 			// own per-row "Download" button, so a text-only locator is ambiguous.
@@ -49,7 +49,7 @@ test.describe('token-import-export', () => {
 		'Upload control is present in the token editor panel',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			// The upload trigger (label acting as button or actual file input)
 			const uploadTrigger = page.locator('text=Upload').first()
 			await expect(uploadTrigger).toBeVisible()

--- a/tests/e2e/spec-coverage/token-set-dropdown.spec.ts
+++ b/tests/e2e/spec-coverage/token-set-dropdown.spec.ts
@@ -41,7 +41,7 @@ test.describe('token-set-dropdown', () => {
 		'Token set selector is a searchable <select> with multiple options',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const select = page.locator('#nldesign-token-set-select')
 			await expect(select).toBeVisible()
 			// Must be a native <select> element (not radio buttons)

--- a/tests/e2e/spec-coverage/token-sets.spec.ts
+++ b/tests/e2e/spec-coverage/token-sets.spec.ts
@@ -93,7 +93,7 @@ test.describe('token-sets', () => {
 		'Active token set is set and reflected in the dropdown selection',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const select = page.locator('#nldesign-token-set-select')
 			await expect(select).toBeVisible()
 			const currentValue = await select.inputValue()

--- a/tests/e2e/spec-coverage/vng-token-set.spec.ts
+++ b/tests/e2e/spec-coverage/vng-token-set.spec.ts
@@ -59,7 +59,7 @@ test.describe('vng-token-set', () => {
 		'VNG token set appears as a selectable option in the admin dropdown',
 		async ({ page }) => {
 			await page.goto(THEMING_URL)
-			await page.waitForLoadState('networkidle')
+			await page.waitForLoadState('domcontentloaded')
 			const select = page.locator('#nldesign-token-set-select')
 			await expect(select).toBeVisible()
 			// VNG option must exist in the dropdown

--- a/tests/e2e/workflows/_helpers.ts
+++ b/tests/e2e/workflows/_helpers.ts
@@ -37,14 +37,14 @@ export async function requestToken(page: Page): Promise<string> {
  */
 export async function openTheming(page: Page): Promise<void> {
 	await page.goto(THEMING_URL)
-	await page.waitForLoadState('networkidle')
+	await page.waitForLoadState('domcontentloaded')
 	await page.waitForFunction(() => typeof (window as unknown as { OC?: unknown }).OC !== 'undefined', null, { timeout: 30_000 })
 	try {
 		await page.waitForSelector('#nldesign-token-editor .nldesign-token-editor', { timeout: 30_000 })
 	} catch {
 		// Absorb a transient recompile/mount delay with one reload + longer wait.
 		await page.reload()
-		await page.waitForLoadState('networkidle')
+		await page.waitForLoadState('domcontentloaded')
 		await page.waitForSelector('#nldesign-token-editor .nldesign-token-editor', { timeout: 30_000 })
 	}
 }


### PR DESCRIPTION
## The defect

`page.waitForLoadState('networkidle')` **cannot resolve on a Nextcloud page.** Core's notification poller keeps at least one request in flight for the whole session, so the "no network activity for 500 ms" condition is never met. Each of these 46 calls burned its entire timeout budget and then threw, and the symptom — a bare `Test timeout of Nms exceeded` — is indistinguishable from an app outage.

ADR-074 rule 4 / gate-58. This repo was the fleet's third-worst offender in the original sweep (17 files).

## Why CI never told us this

No job in this repo gives a full-tree gate verdict. Push runs scope to ~1 file, PR runs scope to the diff, and gate-58 is explicitly diff-scoped per ADR-020 so the legacy backlog never blocks an unrelated PR. The 46 were invisible until the checkers were run **directly over the whole tree**:

```
$ bash hydra-gates/scripts/run-hydra-gates.sh          # no --scope-to-diff
[hydra-gates] Scope: full repo
[gate-58] e2e-networkidle: FAIL — 46 networkidle wait(s)
```

## What changed

One token per site, 46 sites, 16 files. All 46 had the identical shape:

```ts
await page.goto(THEMING_URL)
await page.waitForLoadState('networkidle')        // cannot resolve
await expect(page.locator('#nldesign-settings')).toBeVisible()
```

The third line is already the explicit readiness signal ADR-074 asks for, and it auto-waits. The second contributed nothing but latency and flake.

**Why `domcontentloaded` rather than deleting the line:** `page.goto()` already awaits the `load` event by default, which is strictly stronger than `domcontentloaded`, so the call is a no-op either way. Keeping it keeps the diff a one-token change per site and leaves the wait visible if someone later moves the `goto`.

## The 10 sites that needed judgement

36 of the 46 are followed within three lines by an `expect(...)`. The other 10 were checked individually:

| site | what follows | auto-waits? |
|---|---|---|
| `admin-settings.spec.ts:40,138`, `token-import-export.spec.ts:25` | a comment, then `expect(...)` | yes |
| `app-theming.spec.ts:65,154` | `openAppThemingDropdown()` → `locator().click()` / `waitFor()` | yes |
| `token-editor-ui.spec.ts:116,208` | `locator().count()` / `locator().click()` | yes |
| `custom-token-set-upload.spec.ts:43,118,197` | `page.fill('#nldesign-upload-name')` | yes |

The one worth naming: `app-theming.spec.ts` follows four of its waits with `nldesignStyleCount(page)`, a `page.evaluate` that counts `link[rel=stylesheet]`. That is **not** auto-waiting — but it does not need to be. Those links are server-rendered markup, present at the `load` event, which `goto()` awaits before it returns. Nothing here relied on the removed wait.

## Measurement

Full tree, `origin/development` @ `7b0fade`, hydra-gates at `.github` `main` (`756fe89`) — the ref CI floats to, not the local submodule, which is 38 commits behind:

| | gate-58 |
|---|---|
| before | **FAIL — 46** |
| after | **PASS** |

### Can-fail proof

A green from a checker that did not run looks exactly like a green from one that did. Reverting **exactly one** site:

```
$ git checkout origin/development -- tests/e2e/spec-coverage/token-set-dropdown.spec.ts
$ run-hydra-gates.sh
[gate-58] e2e-networkidle: FAIL — 1 networkidle wait(s) ...

$ # restore
[gate-58] e2e-networkidle: PASS
```

It fails for the right reason, naming that file and line, and returns to PASS. The zero above is a measured zero.

## What this does NOT do

No `e2e-networkidle exclude` comment, no `.skip`, no `continue-on-error`, no threshold change, no weakened assertion. Every one of the 46 is gone from the tree, not from the checker's view.

## Base state

`development` @ `7b0fade` fails by name: `E2E Tests (Playwright)`, `Hydra Gates`, `Quality Report` (a pure aggregator). This PR must be judged a strict subset of those three **by name**.