### PR TITLE
chore: raise the Nextcloud floor to 32, and make it impossible to drift again

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -35,7 +35,32 @@ Gratis en open source onder de EUPL-1.2 licentie.
 
 	<dependencies>
 		<php min-version="8.3"/>
-		<nextcloud min-version="28" max-version="34"/>
+		<!-- Floor 32, aligned with the fleet. Two reasons, both verifiable here:
+
+		     1. PHP. This app already requires 8.3. Nextcloud 31 and below run on
+		        8.1/8.2 as well, so a 28 floor advertised a range where the app
+		        store could offer this app to an instance whose PHP it cannot run
+		        on. NC32 is the first release whose own floor is 8.3, so 32 is
+		        where the two declarations stop contradicting each other.
+
+		     2. It is what is actually tested. `.github/workflows/code-quality.yml`
+		        pins `nextcloud-test-refs: '["stable32"]'` (#240) and the only
+		        PHPUnit legs that exist are `NC stable32`. Nothing has exercised
+		        28-31 since #240. Declaring support for versions no leg touches is
+		        a promise the app store passes on to users.
+
+		     History, because this attribute has moved twice: #241 raised it to 32
+		     and #242 restored 28, on the stated premise that "this repo does not
+		     set nextcloud-test-refs, so it inherits the shared default of
+		     [stable31, stable32]". That premise was already false when #242
+		     landed — #240 had pinned the list to stable32 one commit earlier —
+		     and it is false now: development's own run has only `NC stable32`
+		     legs. #242's other premise (openregister restoring its 28 floor) does
+		     not bear on this app at all, which declares no <app> dependency.
+
+		     max-version stays 34, which is the fleet-wide value; openconnector is
+		     the only repo that says 35. -->
+		<nextcloud min-version="32" max-version="34"/>
 	</dependencies>
 
 	<!-- Upstream token freshness check (openspec/specs/upstream-freshness/spec.md):

--- a/openspec/specs/claim-accuracy/spec.md
+++ b/openspec/specs/claim-accuracy/spec.md
@@ -103,3 +103,39 @@ app-relative, no CDN.
 - AND the documentation MUST NOT claim CDN loading nor that Marianne is fetched from an external
   server
 
+### Requirement: Declared Nextcloud Range Matches What CI Actually Tests
+
+The `<nextcloud min-version>` declared in `appinfo/info.xml` is a promise the Nextcloud app store
+passes on to administrators: it decides which servers are offered this app. That promise MUST be
+backed by an exercised configuration. The declared floor MUST equal the LOWEST Nextcloud ref in
+`nextcloud-test-refs` in `.github/workflows/code-quality.yml`, and `max-version` MUST be at least
+the highest such ref.
+
+Both directions are defects, and this repository has shipped each of them:
+
+- **Floor above the matrix.** `min-version` is enforced at install time, so a floor higher than a
+  tested ref makes `occ app:enable` refuse on that leg, and the failure surfaces as an unrelated
+  "app is not installed or enabled" error much later in the run.
+- **Floor below the matrix.** A floor lower than every tested ref advertises versions no leg has
+  ever exercised. Nothing reports it, because a version that is never tested cannot go red.
+
+#### Scenario: Declared floor equals the lowest tested Nextcloud ref
+@e2e exclude manifest/CI invariant — PHPUnit reads `appinfo/info.xml` and the workflow, not a UI flow
+
+- GIVEN `appinfo/info.xml` declares `<nextcloud min-version="X" max-version="Y"/>`
+- AND `.github/workflows/code-quality.yml` pins `nextcloud-test-refs` to a JSON list of `stableNN`
+  refs
+- WHEN the declared range is compared with that list
+- THEN no tested ref MUST be below `X`
+- AND the lowest tested ref MUST equal `X`
+- AND `Y` MUST be greater than or equal to the highest tested ref
+
+#### Scenario: Declared PHP floor is satisfiable on the declared Nextcloud floor
+@e2e exclude manifest invariant — PHPUnit reads `appinfo/info.xml`
+
+- GIVEN `appinfo/info.xml` declares `<php min-version="8.3"/>`
+- WHEN the declared Nextcloud floor is read
+- THEN it MUST be at least 32, the first Nextcloud release whose own PHP floor is 8.3
+- AND a lower Nextcloud floor MUST be treated as a contradiction between the two declarations,
+  not as a wider support range
+

--- a/tests/Unit/ClaimAccuracyTest.php
+++ b/tests/Unit/ClaimAccuracyTest.php
@@ -412,4 +412,136 @@ class ClaimAccuracyTest extends TestCase
             'css/systems/lasuite/marianne.css must not load Marianne from an external http(s):// URL.'
         );
     }
+
+    /**
+     * The Nextcloud refs CI actually provisions, read out of the workflow.
+     *
+     * `nextcloud-test-refs` is a JSON array embedded in YAML, e.g.
+     * `nextcloud-test-refs: '["stable32"]'`. Returned as integers so the
+     * comparison against `min-version` is numeric, not lexical — "stable9"
+     * sorts above "stable32" as a string and below it as a number, and only
+     * the second is the meaning anyone intends.
+     *
+     * @return int[] the major versions provisioned by CI, ascending
+     */
+    private function testedNextcloudMajors(): array
+    {
+        $workflow = $this->readFile('.github/workflows/code-quality.yml');
+
+        // Anchored to the start of a (possibly indented) line so the many
+        // COMMENTS in this file that quote the key — including one quoting the
+        // shared workflow's own default of ["stable31","stable32"] — cannot be
+        // mistaken for the live setting. A comment line starts with '#'.
+        $matched = preg_match(
+            '/^[ \t]*nextcloud-test-refs:[ \t]*[\'"](?P<json>\[[^\]]*\])[\'"]/m',
+            $workflow,
+            $m
+        );
+        $this->assertSame(
+            1,
+            $matched,
+            '.github/workflows/code-quality.yml must pin `nextcloud-test-refs` explicitly. '
+            . 'Inheriting the shared default silently widens the tested matrix, which is how '
+            . 'the floor and the matrix drifted apart in #241/#242.'
+        );
+
+        $refs = json_decode($m['json'], true);
+        $this->assertIsArray($refs, 'nextcloud-test-refs must be a JSON array.');
+        $this->assertNotEmpty($refs, 'nextcloud-test-refs must not be empty.');
+
+        $majors = [];
+        foreach ($refs as $ref) {
+            $this->assertIsString($ref, 'Every nextcloud-test-refs entry must be a string.');
+            $this->assertSame(
+                1,
+                preg_match('/^stable(?P<major>\d+)$/', $ref, $r),
+                "nextcloud-test-refs entry '{$ref}' must be of the form stableNN."
+            );
+            $majors[] = (int) $r['major'];
+        }
+
+        sort($majors);
+        return $majors;
+    }
+
+    /**
+     * The declared Nextcloud range and the CI matrix say the same thing.
+     *
+     * `min-version` is enforced at install time and decides which servers the
+     * app store offers this app to. A floor ABOVE the matrix makes
+     * `occ app:enable` refuse on a tested leg; a floor BELOW it advertises
+     * versions that no leg has ever exercised. This repo shipped each defect
+     * once — #241 then #242 — because nothing compared the two files.
+     *
+     * @spec openspec/specs/claim-accuracy/spec.md
+     */
+    public function testDeclaredNextcloudRangeMatchesTheTestedMatrix(): void
+    {
+        $info = simplexml_load_string($this->readFile('appinfo/info.xml'));
+        $this->assertNotFalse($info, 'appinfo/info.xml must be well-formed XML.');
+
+        $min = (int) $info->dependencies->nextcloud['min-version'];
+        $max = (int) $info->dependencies->nextcloud['max-version'];
+        $this->assertGreaterThan(0, $min, 'appinfo/info.xml must declare <nextcloud min-version>.');
+        $this->assertGreaterThan(0, $max, 'appinfo/info.xml must declare <nextcloud max-version>.');
+
+        $tested = $this->testedNextcloudMajors();
+        $lowest = $tested[0];
+        $highest = $tested[\count($tested) - 1];
+        $list = implode(', ', $tested);
+
+        $this->assertGreaterThanOrEqual(
+            $min,
+            $lowest,
+            "appinfo/info.xml declares min-version={$min}, but CI provisions stable{$lowest}. "
+            . 'min-version is enforced at install time, so `occ app:enable` will REFUSE on that '
+            . 'leg and the run fails later with an unrelated "app is not installed or enabled".'
+        );
+
+        $this->assertSame(
+            $min,
+            $lowest,
+            "appinfo/info.xml declares min-version={$min}, but the lowest ref CI tests is "
+            . "stable{$lowest} (matrix: {$list}). Every version between {$min} and {$lowest} is "
+            . 'advertised to the app store and exercised by nothing.'
+        );
+
+        $this->assertGreaterThanOrEqual(
+            $highest,
+            $max,
+            "appinfo/info.xml declares max-version={$max}, but CI tests stable{$highest}."
+        );
+    }
+
+    /**
+     * The declared PHP floor is satisfiable on the declared Nextcloud floor.
+     *
+     * Nextcloud 32 is the first release whose own PHP floor is 8.3. Declaring
+     * `<php min-version="8.3"/>` alongside a Nextcloud floor below 32 is not a
+     * wider support range — it is two declarations that contradict each other,
+     * and the app store resolves the contradiction by offering the app to
+     * instances whose PHP it cannot run on.
+     *
+     * @spec openspec/specs/claim-accuracy/spec.md
+     */
+    public function testDeclaredPhpFloorIsSatisfiableOnTheDeclaredNextcloudFloor(): void
+    {
+        $info = simplexml_load_string($this->readFile('appinfo/info.xml'));
+        $this->assertNotFalse($info, 'appinfo/info.xml must be well-formed XML.');
+
+        $php = (string) $info->dependencies->php['min-version'];
+        $nc = (int) $info->dependencies->nextcloud['min-version'];
+
+        if (version_compare($php, '8.3', '>=') === false) {
+            $this->markTestSkipped('PHP floor is below 8.3 — this invariant does not apply.');
+        }
+
+        $this->assertGreaterThanOrEqual(
+            32,
+            $nc,
+            "appinfo/info.xml declares php min-version={$php} with nextcloud min-version={$nc}. "
+            . 'Nextcloud 32 is the first release whose own PHP floor is 8.3; below it the two '
+            . 'declarations contradict each other.'
+        );
+    }
 }


### PR DESCRIPTION
## What changed

`appinfo/info.xml`: `<nextcloud min-version="28" max-version="34"/>` → `min-version="32"`. `max-version` untouched.

Plus a test that stops this attribute drifting again, and the spec requirement it implements.

## Why 32

Two independent reasons, both verifiable in this repo:

1. **PHP.** This app already declares `<php min-version="8.3"/>`. Nextcloud 31 and below also run on 8.1/8.2, so a 28 floor let the app store offer this app to instances whose PHP it cannot run on. **NC 32 is the first release whose own PHP floor is 8.3** — it is where the two declarations stop contradicting each other.
2. **It is what is actually tested.** `.github/workflows/code-quality.yml` pins `nextcloud-test-refs: '["stable32"]'` (#240). `development`'s own run `31181042953` has exactly two version legs, `PHPUnit (PHP 8.3, NC stable32)` and `PHPUnit (PHP 8.4, NC stable32)`. `grep -rn stable31 .github/` returns **nothing**. Versions 28–31 were advertised to the app store and exercised by nothing.

## This is not a re-run of #241

That attribute has moved twice today, so this needs saying explicitly.

| | |
|---|---|
| #240 | pinned `nextcloud-test-refs: '["stable32"]'`, deliberately left info.xml at 28 |
| #241 | raised the floor to 32 |
| #242 | **restored 28** |

**#242's stated premise is falsified by the tree it landed on.** It says:

> This repo does not set nextcloud-test-refs, so it inherits the shared default of [stable31, stable32].

`.github/workflows/code-quality.yml:82` says `nextcloud-test-refs: '["stable32"]'`, put there by **#240, one commit earlier**. It was false then and it is false now.

#242's other premise — that openregister restored its own 28 floor — does not bear on this app at all. nldesign declares **no `<app>` dependency**, so the `min-version ≥ max(every <app> dependency's floor)` rule from openconnector#1172/#1173 is vacuous here and this is straightforward alignment.

## CI matrix

**Unchanged.** There is no sub-32 leg to drop — #240 already removed it. No leg now targets an unsupported configuration. `max-version` stays **34**, the fleet-wide value; openconnector is the only repo that says **35**.

## The reason it drifted twice, and the fix

Nothing compared the two files. Both directions are real defects and this repo has now shipped each once:

- **Floor above the matrix** (#241) — `min-version` is enforced at install time, so `occ app:enable` refuses on that leg and the run fails much later with an unrelated *"app is not installed or enabled"*.
- **Floor below the matrix** (#242) — advertises versions no leg exercises. Nothing reports it, because *a version that is never tested cannot go red*.

`tests/Unit/ClaimAccuracyTest.php` now asserts both directions: no tested ref below the floor, the lowest tested ref **equals** the floor, `max-version` at least the highest tested ref, and a PHP 8.3 floor implies an NC floor of at least 32. New requirement added to `openspec/specs/claim-accuracy/spec.md`.

## Can-fail proof

A passing invariant test and an invariant test that never ran look identical. Three mutations:

| mutation | result |
|---|---|
| floor → **28** (the #242 state) | **2 failures** — *"the lowest ref CI tests is stable32 (matrix: 32). Every version between 28 and 32 is advertised to the app store and exercised by nothing"* and *"php min-version=8.3 with nextcloud min-version=28"* |
| floor → **33** (the #241 shape) | **1 failure** — *"CI provisions stable32 ... `occ app:enable` will REFUSE on that leg"* |
| matrix → `["stable31","stable32"]` | **1 failure** — *"CI provisions stable31 ... `occ app:enable` will REFUSE on that leg"* |

Restored: `OK (11 tests, 290 assertions)`.

The third mutation doubles as a **positive control on the parser**. That workflow file contains several comments quoting the shared default `["stable31","stable32"]`; the regex is anchored to line start so a comment cannot be mistaken for the live setting, and the mutation was picked up at line 82 — the real one. Majors are compared as integers, not strings, so `stable9` sorts below `stable32`.

## Not done

No `@spec exclude`, no skip, no threshold change, no baseline entry. The CI matrix is not narrowed to make the floor true — the floor is moved to match a matrix that was already narrowed, on its own evidence, in #240.

## Base state

`development` @ `7b0fade` fails by name: `E2E Tests (Playwright)`, `Hydra Gates`, `Quality Report` (a pure aggregator). Full-tree gate measurement on this branch is identical to `development`'s: gate-7 (2), gate-38 (1), gate-46 (25), gate-58 (46) — this PR neither adds nor removes a gate finding.