### PR TITLE
chore: raise Nextcloud floor to 32 and PHP floor to 8.3

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,8 +28,17 @@ Configure which token set to use in the admin settings.
 	<screenshot>https://raw.githubusercontent.com/ConductionNL/nldesign/main/img/screenshot.png</screenshot>
 
 	<dependencies>
-		<php min-version="8.1"/>
-		<nextcloud min-version="28" max-version="33"/>
+		<!--
+			Nextcloud floor raised from 28 to 32 so the app may require PHP 8.3.
+			Fleet wide product directive: standardise on Nextcloud 32.
+			Rationale (openconnector issue 1172): an app must never advertise a
+			Nextcloud floor lower than the highest floor of any app it depends on,
+			or the App Store offers the app on releases where the dependency
+			refuses to install. openregister on development declares a Nextcloud
+			floor of 32. The max-version below is unchanged by this commit.
+		-->
+		<php min-version="8.3"/>
+		<nextcloud min-version="32" max-version="33"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\NLDesign\Settings\Admin</admin>


### PR DESCRIPTION
## What

Raise `appinfo/info.xml` on **`main`** to the fleet Nextcloud floor:

| field | before | after |
|---|---|---|
| `nextcloud@min-version` | `28` | **`32`** |
| `nextcloud@max-version` | `33` | `33` (unchanged) |
| `php@min-version` | `8.1` | **`8.3`** |

Nothing else in the file is touched. This is a floor-only change.

## Why

**Product directive (PO, Ruben):** the fleet standardises on Nextcloud 32 so it can require PHP 8.3 - *"we want php 8.3 so going for min version nc 32 fleet wide is a good thing."*

**Governing rule (openconnector#1172 / #1173):** an app's `min-version` must be **>= the max of every `<app>` dependency's floor**. If it is lower, the App Store advertises the app on Nextcloud releases where the dependency refuses to install, and the app is non-functional there - the App Store advertises a range the app cannot deliver.

**Measured, not quoted:** `openregister@development` currently declares `nextcloud min-version="32" max-version="34"` and `php min-version="8.3"` - re-measured on this branch with an XML parser rather than repeating a number (openregister#2384, merged 2026-08-08T10:45Z).

**`<app>` dependency check for this repo:** `main`'s `info.xml` declares **no `<app>` dependency at all** - parsed `./dependencies/app`, empty. So for this repo the rule is not *binding* via a declared dependency; the change lands on the product directive above, and pre-aligns the floor before any app dependency is declared.

## Shape: floor-only PR directly to `main`

`main` trails `development` by 188-5206 commits across this fleet, so a `development` -> `main` merge would be a **full release**, not a floor fix. This PR therefore changes only the two floor attributes on `main`.

## Measurement method

Values were read by parsing `appinfo/info.xml` with an XML parser (`xml.etree.ElementTree`), **never grep**: these files contain literal nextcloud element examples inside XML comments, and grepping has already produced false floor readings today. The comment added by this PR is deliberately **prose only, with no angle-bracket XML element syntax**, because floor guards count raw regex matches of the nextcloud element across the whole file *including comments* - a quoted example would trip the guard as a second, contradictory declaration.

Pre-push validation on this branch: the file parses as XML **and** the raw regex for the nextcloud element matches **exactly once**.

## CI on `main` - verified for this repo

Listed every file in `.github/workflows` on `main` and grepped each for `quality.yml@` and for any `stable3[0-9]` token:

- **No workflow on `main` references** `ConductionNL/.github/.github/workflows/quality.yml@` - 0 hits.
- **No `stable3[0-9]` token anywhere** in `main`'s workflows - 0 hits.
- **No workflow on `main` installs Nextcloud at all.** `main`'s `code-quality.yml` is the old self-contained shape: PHP lint/quality only.

So there is no CI leg pinned to a Nextcloud version below 32 that needs to be dropped in this PR.

**Follow-up (out of scope here):** `main`'s `code-quality.yml` sets `php-version: '8.1'` while `info.xml` will now declare a PHP floor of **8.3**. The lint matrix and the declared floor disagree. Deliberately **not** rewriting those legacy workflows in this PR - out of scope, and it would surface unrelated failures.

## Risk

Floor-only metadata change. No PHP, JS, schema, or lockfile is touched.