### PR TITLE
fix(e2e): wait for the Vue chrome instead of sleeping, and report the surfaces that never mount

### DIFF
--- a/tests/e2e/spec-coverage/selector-liveness.spec.ts
+++ b/tests/e2e/spec-coverage/selector-liveness.spec.ts
@@ -49,6 +49,15 @@
 import { expect, test } from '@playwright/test'
 import { THEMING_URL, getTokenSet, requestToken, setTokenSet } from '../workflows/_helpers'
 
+/**
+ * A node that only exists once Nextcloud's Vue chrome has mounted.
+ *
+ * Both halves are Vue-rendered and absent from the server document, so the
+ * presence of either is proof that the bundles have run and the header
+ * subtree the theme targets is really there to be probed.
+ */
+const CHROME_READY = '#header .app-menu, #header .unified-search-input'
+
 /** Surfaces surveyed. Each contributes its DOM to the union. */
 const SURFACES: Array<{ name: string; path: string }> = [
 	{ name: 'files', path: '/apps/files/' },
@@ -184,6 +193,7 @@ test.describe('lasuite selector liveness', () => {
 		let sheetSeenOnce = false
 
 		const unreachable: string[] = []
+		const chromeless: string[] = []
 
 		for (const surface of SURFACES) {
 			// A surface that will not load on a loaded dev box must not fail the
@@ -198,8 +208,49 @@ test.describe('lasuite selector liveness', () => {
 				unreachable.push(surface.name)
 				continue
 			}
-			// Vue apps mount after load; give the shell a moment to render.
-			await page.waitForTimeout(2500)
+			// WAIT FOR THE CHROME TO EXIST, DO NOT GUESS AT IT.
+			//
+			// This was `await page.waitForTimeout(2500)` after a
+			// `waitUntil: 'domcontentloaded'` goto, and that pair is a race
+			// this guard loses on a loaded runner. Nextcloud's header and
+			// navigation are Vue components: they are absent from the
+			// server-rendered document and appear only once the bundles have
+			// executed. DOMContentLoaded fires long before that.
+			//
+			// Measured 2026-08-09. The run that motivated this reported 31
+			// selectors "dead", and EVERY ONE of them resolves inside a
+			// Vue-scoped subtree — 15 under `#header`, 11 under
+			// `#app-navigation-vue` / `.app-navigation-entry.active`, plus
+			// four that belong to surfaces this list does not survey. Probed
+			// by hand against a real Nextcloud, all fifteen header selectors
+			// and all eleven navigation selectors MATCH, with counts of 1 or
+			// 2 each. The arithmetic of that run settles it: six surfaces in
+			// 24.5s total is ~4s per surface INCLUDING the 2.5s sleep, so
+			// every probe ran ~1.5s after navigation began.
+			//
+			// The consequence was worse than a red run. The failure message
+			// invites the reader to "fix them against the real DOM", and
+			// acting on it would have meant rewriting or deleting 27 rules
+			// of working theme CSS to satisfy a measurement taken before the
+			// markup existed.
+			//
+			// So: wait for a Vue-rendered node, and record the surfaces where
+			// none ever appeared instead of silently probing an empty shell.
+			let chromeMounted = true
+			try {
+				await page.waitForSelector(CHROME_READY, { state: 'attached', timeout: 60_000 })
+			} catch {
+				chromeMounted = false
+				chromeless.push(surface.name)
+			}
+			// The left navigation is legitimately absent on some surfaces
+			// (Dashboard has none), so this one is opportunistic — the hard
+			// gate is the header above.
+			if (chromeMounted) {
+				await page
+					.waitForSelector('#app-navigation-vue', { state: 'attached', timeout: 10_000 })
+					.catch(() => {})
+			}
 
 			const result = await page.evaluate(() => {
 				const sheet = [...document.styleSheets].find(
@@ -260,6 +311,22 @@ test.describe('lasuite selector liveness', () => {
 			// surfaces looks identical to a clean one otherwise.
 			console.warn(`[selector-liveness] surfaces that did not load: ${unreachable.join(', ')}`)
 		}
+		if (chromeless.length > 0) {
+			console.warn(`[selector-liveness] surfaces whose Vue chrome never mounted: ${chromeless.join(', ')}`)
+		}
+
+		// A survey that reached its surfaces but never saw the chrome mount
+		// measured a server-rendered skeleton, and EVERY selector under
+		// `#header` or `#app-navigation-vue` would be reported dead. That is
+		// the exact false accusation this test made before the wait above
+		// existed, and it must be impossible to make silently: fail on the
+		// measurement, naming it, rather than on the CSS it cannot see.
+		expect(
+			chromeless.length,
+			`The Vue chrome never mounted on ${chromeless.join(', ')} — those surfaces were measured as a `
+				+ `server-rendered skeleton. Every #header / #app-navigation-vue selector would read as dead. `
+				+ `This is a failure of the MEASUREMENT, not of the stylesheet: do not "fix" the CSS on it.`,
+		).toBeLessThan(SURFACES.length)
 		expect(
 			unreachable.length,
 			`Too few surfaces loaded (${unreachable.join(', ')}) — the union would be too narrow to trust`,

--- a/tests/e2e/spec-coverage/selector-liveness.spec.ts
+++ b/tests/e2e/spec-coverage/selector-liveness.spec.ts
@@ -211,28 +211,29 @@ test.describe('lasuite selector liveness', () => {
 			// WAIT FOR THE CHROME TO EXIST, DO NOT GUESS AT IT.
 			//
 			// This was `await page.waitForTimeout(2500)` after a
-			// `waitUntil: 'domcontentloaded'` goto, and that pair is a race
-			// this guard loses on a loaded runner. Nextcloud's header and
-			// navigation are Vue components: they are absent from the
-			// server-rendered document and appear only once the bundles have
-			// executed. DOMContentLoaded fires long before that.
+			// `waitUntil: 'domcontentloaded'` goto. Nextcloud's header and
+			// navigation are Vue components — absent from the server-rendered
+			// document, present only once the bundles execute — so a fixed
+			// sleep is a race, and losing it makes every selector under
+			// `#header` or `#app-navigation-vue` read as dead.
 			//
-			// Measured 2026-08-09. The run that motivated this reported 31
-			// selectors "dead", and EVERY ONE of them resolves inside a
-			// Vue-scoped subtree — 15 under `#header`, 11 under
-			// `#app-navigation-vue` / `.app-navigation-entry.active`, plus
-			// four that belong to surfaces this list does not survey. Probed
-			// by hand against a real Nextcloud, all fifteen header selectors
-			// and all eleven navigation selectors MATCH, with counts of 1 or
-			// 2 each. The arithmetic of that run settles it: six surfaces in
-			// 24.5s total is ~4s per surface INCLUDING the 2.5s sleep, so
-			// every probe ran ~1.5s after navigation began.
+			// WHAT THIS DID NOT FIX, MEASURED. I expected this to clear most
+			// of the 31 selectors the guard reports dead. It cleared NONE:
+			// 31 before, 31 after, with the run's own log confirming the
+			// chrome DID mount on files, dashboard and settings. So the
+			// timing was real but it was not the cause, and the honest
+			// reading of the remaining 31 is still open — see the PR.
 			//
-			// The consequence was worse than a red run. The failure message
-			// invites the reader to "fix them against the real DOM", and
-			// acting on it would have meant rewriting or deleting 27 rules
-			// of working theme CSS to satisfy a measurement taken before the
-			// markup existed.
+			// The reason the sleep still had to go is the FAILURE MODE, not
+			// the count. A run that probes before the chrome mounts and a run
+			// that probes a genuinely stale stylesheet produced the SAME
+			// output, and the message invites the reader to "fix them against
+			// the real DOM" — which, acted on, means deleting theme CSS to
+			// satisfy a measurement. Probed by hand against a full Nextcloud,
+			// all 15 `#header` and 11 `#app-navigation-vue` selectors match
+			// with counts of 1-2, so at least some of this list is not dead
+			// CSS but a survey whose instance does not render the chrome
+			// these rules target.
 			//
 			// So: wait for a Vue-rendered node, and record the surfaces where
 			// none ever appeared instead of silently probing an empty shell.


### PR DESCRIPTION
## ⚠️ Retraction first

This PR originally claimed the 31 "dead" selectors were an artefact of probing before Nextcloud's Vue chrome mounted, and that fixing the wait would clear 27 of them.

**It cleared none. 31 before, 31 after** — measured on this branch's own CI run, whose log confirms the chrome **did** mount on files, dashboard and settings. Only contacts, mail and calendar failed, because they are not installed there; the new reporting now says that out loud.

The correlation I built the claim on is real and still holds: every one of the 31 sits inside a Vue-scoped (`data-v-*`) subtree, and probed by hand against a full Nextcloud all 15 `#header` and 11 `#app-navigation-vue` selectors match with counts of 1–2. **What I got wrong was the inference.** The instance I probed was the shared dev box with ~30 apps installed; CI runs a minimal seeded instance. *"These selectors exist on a rich instance"* does not establish *"these selectors exist on CI's"* — a different Nextcloud is a different DOM.

## What this PR still does, and why it is still worth landing

Replaces `waitForTimeout(2500)` after a `domcontentloaded` goto with an explicit wait for a Vue-rendered node, and adds an assertion that **fails on the measurement, naming it**, when the chrome never mounts.

The reason is the **failure mode, not the count**. Before this, a run that probed before mount and a run that probed a genuinely stale stylesheet produced *the same output* — and that output invites the reader to "fix them against the real DOM", which, acted on, means deleting theme CSS to satisfy a measurement. Those two cases are now distinguishable.

It also produced new, true information on its first run:

```
[selector-liveness] surfaces whose Vue chrome never mounted: contacts, mail, calendar
```

Three of the six surveyed surfaces contribute nothing, and nobody knew.

## What is still open

**What the remaining 31 actually are.** This PR does not answer it. The likeliest reading, explicitly unverified: CI's minimal instance does not render the header and navigation chrome these rules target at all — which would make this a fixture problem (the survey's instance is not representative), not dead CSS and not timing.

The four I can characterise:

| selector | status |
|---|---|
| `.guest-box.login-box` | **alive — measured as matching 1 on `/login`**, which `SURFACES` does not include |
| `body#body-public` | public share page, not surveyed |
| `body[data-theme-dark]` / `body[data-themes*="dark"]` | dark theme not enabled during the run |

**No `ALLOWED` entry is added for any of them** — an allowlist entry would hide the gap rather than close it, and I would be hiding a gap I have not diagnosed.

**This PR does not make the E2E job green**, and the E2E job was already red on `development` for this same test.