### PR TITLE
fix(a11y): name the three hidden file inputs

### DIFF
--- a/templates/settings/admin.php
+++ b/templates/settings/admin.php
@@ -130,7 +130,19 @@ style('nldesign', 'admin');
 			<input type="text" id="nldesign-upload-name" class="nldesign-upload-name"
 				   placeholder="<?php p($l->t('e.g. Gemeente Voorbeeld')); ?>"
 				   maxlength="64">
-			<input type="file" id="nldesign-upload-input" accept=".css,.json,.tokens.json" style="display:none">
+			<!-- Named, even though it is hidden. The visible <button> below is
+			     the trigger; this input only ever opens the file dialog via
+			     .click(). A `display:none` control is out of the
+			     accessibility tree WHILE hidden — but unlike an
+			     `aria-hidden` one it can be exposed again by a single style
+			     change from script or a user stylesheet, and at that moment
+			     an unnamed file input is a real WCAG 4.1.2 failure. The name
+			     costs nothing while hidden and is correct the instant it is
+			     not. (ConductionNL/.github#273 declines to exempt this shape
+			     for exactly that reason.) -->
+			<input type="file" id="nldesign-upload-input" accept=".css,.json,.tokens.json"
+				   aria-label="<?php p($l->t('Token set file to upload (NL Design CSS or W3C Design Tokens JSON)')); ?>"
+				   style="display:none">
 			<button type="button" id="nldesign-upload-btn" class="button">
 				<?php p($l->t('Choose file and upload')); ?>
 			</button>
@@ -161,7 +173,9 @@ style('nldesign', 'admin');
 				<option value="body"><?php p($l->t('Body text')); ?></option>
 				<option value="heading"><?php p($l->t('Heading')); ?></option>
 			</select>
-			<input type="file" id="nldesign-font-input" accept=".woff2" style="display:none">
+			<input type="file" id="nldesign-font-input" accept=".woff2"
+				   aria-label="<?php p($l->t('Font file to upload (WOFF2)')); ?>"
+				   style="display:none">
 			<button type="button" id="nldesign-font-upload-btn" class="button">
 				<?php p($l->t('Choose font and upload')); ?>
 			</button>
@@ -499,7 +513,9 @@ style('nldesign', 'admin');
 			<button type="button" id="nldesign-config-bundle-download-btn" class="button">
 				<?php p($l->t('Download configuration')); ?>
 			</button>
-			<input type="file" id="nldesign-config-bundle-input" accept=".json" style="display:none">
+			<input type="file" id="nldesign-config-bundle-input" accept=".json"
+				   aria-label="<?php p($l->t('Configuration bundle file to upload (JSON)')); ?>"
+				   style="display:none">
 			<button type="button" id="nldesign-config-bundle-upload-btn" class="button">
 				<?php p($l->t('Upload configuration')); ?>
 			</button>


### PR DESCRIPTION
**gate-40 form-label-association: FAIL 3 → PASS.** Package `566ac8c0e42934233daba70c8d6bb7a523200087`.

(Supersedes #253, which still carried #252's commit after that merged. Same content, rebased to a single commit — the diff is one file, +19/−3.)

The three `<input type="file">` controls behind the *Upload* / *Choose font* / *Upload configuration* buttons carried no accessible name. Each is `style="display:none"` and is only ever opened by `.click()` from its adjacent visible button.

## Why this is not an inert attribute

I nearly left this red. [ConductionNL/.github#273](https://github.com/ConductionNL/.github/issues/273) documents a gate-40 finding that genuinely **cannot** be closed: an input carrying `aria-hidden="true"`, where a name can never be announced because the element is not in the accessibility tree at all, and where both remediations regress gate-37.

That issue explicitly separates **this repo's three findings** from that shape:

> nldesign's three gate-40 findings are the same *shape* but use `style="display:none"`, not `aria-hidden`. **Excluding `display:none` would be genuinely unsafe — a style can be toggled by JS, so the element may well be exposed at runtime.**

That is the whole argument for naming them. `display:none` removes the control from the tree *while it is hidden*, but one style change from script or a user stylesheet puts it back, and at that moment an unnamed file input is a real WCAG 4.1.2 failure. The name costs nothing while hidden and is correct the instant it is not — which is what distinguishes it from the `aria-hidden` case, where the name can never do anything at all.

Each label says what the input *accepts* rather than repeating the button, and all three go through `$l->t()`.

**No visible label is overridden.** These inputs have no visible label and no default slot to name themselves from — the case where an `aria-label` would have been a regression rather than a fix.

## Evidence

- gate-40 **FAIL 3 → PASS**.
- gates 31 / 35 / 39 / 41 / 43 / 44 **unchanged at PASS**, so the added attributes did not silence a neighbouring rule.
- vitest **81/81**.
- Proven able to fail first: a planted unlabelled `<input type="text">` took this gate from 3 findings to 4 on this tree in a control run.

With this merged, a **full-scope** run of this repo is down to **gate-7 (2) and gate-19 (156)** — from six failing gates this morning.

No waivers, no baselines, no threshold changes.