### PR TITLE
fix(bootstrap): add the ADR-040 OpenRegister autoload prelude before the federated-config probe

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -110,8 +110,35 @@ class Application extends App implements IBootstrap
 
         // Federated configuration sharing (openregister): contribute the NL Design
         // theme as a shareable config type so a theme can be published to and
-        // installed from GitHub over OpenRegister's one fleet mechanism. Guarded
-        // on the event class so an instance without OpenRegister still boots.
+        // installed from GitHub over OpenRegister's one fleet mechanism.
+        //
+        // THE PRELUDE IS LOAD-BEARING, NOT DEFENSIVE (ADR-040).
+        //
+        // `Coordinator::registerApps()` walks the SORTED app list, calling
+        // `OC_App::registerAutoloading()` and then `register()` for one app at
+        // a time. `nldesign` sorts before `openregister`, so this method runs
+        // while the `OCA\OpenRegister\` PSR-4 prefix does not yet exist — on a
+        // completely healthy instance with OpenRegister installed and enabled.
+        //
+        // Without the prelude below, the `class_exists()` on the next line
+        // answered FALSE every time, the listener was never registered, and
+        // nldesign contributed NO shareable config type at all. Nothing
+        // reported it: the app stayed enabled, every route resolved, the
+        // theme still applied — the only symptom was that federated config
+        // sharing (openspec/specs/federated-config-sharing/spec.md) silently
+        // did nothing.
+        //
+        // `registerAutoloading()` touches only the autoloader and is
+        // idempotent, so pulling the prefix in here is safe regardless of
+        // which apps ran before this one.
+        try {
+            $orPath = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppPath('openregister');
+            \OC_App::registerAutoloading('openregister', $orPath);
+        } catch (\Throwable) {
+            // OpenRegister absent or disabled — the guard below then answers
+            // FALSE truthfully, and the app degrades as designed.
+        }
+
         if (class_exists(\OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent::class) === true) {
             $context->registerEventListener(
                 \OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent::class,

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -128,16 +128,10 @@ class Application extends App implements IBootstrap
         // sharing (openspec/specs/federated-config-sharing/spec.md) silently
         // did nothing.
         //
-        // `registerAutoloading()` touches only the autoloader and is
-        // idempotent, so pulling the prefix in here is safe regardless of
-        // which apps ran before this one.
-        try {
-            $orPath = \OCP\Server::get(\OCP\App\IAppManager::class)->getAppPath('openregister');
-            \OC_App::registerAutoloading('openregister', $orPath);
-        } catch (\Throwable) {
-            // OpenRegister absent or disabled — the guard below then answers
-            // FALSE truthfully, and the app degrades as designed.
-        }
+        // See lib/AppInfo/OpenRegisterAutoloader.php: idempotent, swallows a
+        // missing/disabled OpenRegister, and returns false in that case so the
+        // guard below answers FALSE truthfully.
+        (new OpenRegisterAutoloader())->ensure();
 
         if (class_exists(\OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent::class) === true) {
             $context->registerEventListener(

--- a/lib/AppInfo/OpenRegisterAutoloader.php
+++ b/lib/AppInfo/OpenRegisterAutoloader.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * The ADR-040 OpenRegister autoload prelude, as one named, testable unit.
+ *
+ * @category  AppInfo
+ * @package   OCA\NLDesign\AppInfo
+ * @author    Conduction B.V. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://github.com/ConductionNL/nldesign
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\AppInfo;
+
+use OCP\App\IAppManager;
+use OCP\Server;
+use Throwable;
+
+/**
+ * Makes `OCA\OpenRegister\*` resolvable during this app's `register()`.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `Coordinator::registerApps()` walks the SORTED app list, calling
+ * `OC_App::registerAutoloading()` and then `register()` for one app at a time.
+ * `nldesign` sorts before `openregister`, so `Application::register()` runs
+ * while the `OCA\OpenRegister\` PSR-4 prefix does not yet exist — on a
+ * completely healthy instance with OpenRegister installed and enabled.
+ *
+ * Any `class_exists()` probe on an OpenRegister class in that window answers
+ * FALSE and the branch it guards silently takes the wrong path, permanently
+ * and with no error anywhere. See ADR-040.
+ *
+ * WHY IT IS A CLASS AND NOT FOUR INLINE LINES
+ * -------------------------------------------
+ * Three reasons, all practical. It is independently unit-testable, which four
+ * lines inside `register()` are not — `Application` cannot be constructed in a
+ * unit test without a server container. It confines the one unavoidable
+ * static call to a single method instead of spreading it through bootstrap
+ * code. And `ensure()` is deliberately an INSTANCE method so the call site in
+ * `register()` is an ordinary method call: the PHPMD StaticAccess suppression
+ * below then covers exactly one line in one class, and the rule keeps its
+ * teeth in the bootstrap and everywhere else.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess) - `OC_App::registerAutoloading()` is
+ * the ONLY way to pull another app's PSR-4 prefix into the running process and
+ * Nextcloud exposes no instance API for it; ADR-040 prescribes this exact
+ * call.
+ *
+ * @spec openspec/specs/federated-config-sharing/spec.md
+ */
+final class OpenRegisterAutoloader
+{
+
+    /**
+     * The app whose autoloading this prelude pulls in.
+     *
+     * @var string
+     */
+    public const OPENREGISTER_APP_ID = 'openregister';
+
+    /**
+     * Register OpenRegister's PSR-4 prefix with the running process.
+     *
+     * `registerAutoloading()` touches only the autoloader and is idempotent,
+     * so calling it is safe regardless of which apps registered before this
+     * one. Every failure is swallowed on purpose: OpenRegister is a SOFT
+     * dependency, and "absent or disabled" is a supported state in which the
+     * caller's `class_exists()` guard then answers FALSE truthfully.
+     *
+     * The path is resolved into a local BEFORE the static call, deliberately.
+     * Written as one expression, PHP resolves `OC_App` first and raises its
+     * Error before `getAppPath()` is ever evaluated — so in any environment
+     * without the legacy class (a unit test, for one) the prelude would never
+     * even ask which path it wanted, and a test asserting that it does would
+     * fail for a reason unrelated to what it meant to check.
+     *
+     * @param IAppManager|null $appManager Injected for tests; resolved from the
+     *                                     server container when omitted.
+     *
+     * @return bool True when the prefix was registered, false when OpenRegister
+     *              is absent, disabled, or otherwise unreachable.
+     *
+     * @spec openspec/specs/federated-config-sharing/spec.md
+     */
+    public function ensure(?IAppManager $appManager=null): bool
+    {
+        try {
+            $manager = ($appManager ?? Server::get(IAppManager::class));
+            $path    = $manager->getAppPath(self::OPENREGISTER_APP_ID);
+            \OC_App::registerAutoloading(self::OPENREGISTER_APP_ID, $path);
+            return true;
+        } catch (Throwable) {
+            // OpenRegister absent, disabled, or the server container is not
+            // available (unit tests). The caller degrades as designed.
+            return false;
+        }
+    }//end ensure()
+}//end class

--- a/psalm.xml
+++ b/psalm.xml
@@ -21,6 +21,11 @@
              interface and the RegisterShareableConfigTypesEvent generic in
              lib/Service/Config/ + lib/Listener/. Never autoloaded at runtime. -->
         <file name="stubs/openregister-config.php" />
+        <!-- Nextcloud's legacy global OC_App. It lives in lib/private/ in the
+             server, so it is absent from the nextcloud/ocp package the
+             analysers see. Required by the ADR-040 autoload prelude in
+             lib/AppInfo/Application.php. Never autoloaded at runtime. -->
+        <file name="stubs/nextcloud-legacy.php" />
     </stubs>
     <issueHandlers>
         <UndefinedDocblockClass errorLevel="suppress"/>

--- a/stubs/nextcloud-legacy.php
+++ b/stubs/nextcloud-legacy.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Static-analysis stub for Nextcloud's legacy global `OC_App`.
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * `OC_App::registerAutoloading()` is the ONLY way to pull another app's PSR-4
+ * prefix into the current process, and lib/AppInfo/Application.php needs it in
+ * `register()` — see ADR-040. It lives in `lib/private/legacy/OC_App.php` in
+ * the server, which is not part of the `nextcloud/ocp` public-API package the
+ * analysers see, so both phpstan and psalm resolve it to nothing. phpstan is
+ * satisfied by `scanDirectories: stubs`; psalm reported
+ * `UndefinedClass - Class, interface or enum named OC_App does not exist`.
+ *
+ * A declaration-only stub is the right tool here rather than an issue
+ * suppression: a suppression would hide a genuine typo in the call as
+ * readily as it hides this, whereas a stub makes the analysers CHECK the
+ * signature. Wired into analysis only — phpstan.neon `scanDirectories` and
+ * psalm.xml `<stubs>` — and never autoloaded at runtime, so the server's real
+ * class is always the one that executes.
+ *
+ * Signature mirrors `lib/private/legacy/OC_App.php`; keep it in sync if the
+ * server changes it.
+ *
+ * @psalm-suppress UnrecognizedStatement
+ */
+
+declare(strict_types=1);
+
+// phpcs:disable
+class OC_App
+{
+    /**
+     * Register an app's composer/PSR-4 autoloading with the current process.
+     *
+     * @param string $appId The app id whose prefix to register.
+     * @param string $path  Absolute path to the app directory.
+     * @param bool   $force Re-register even if already done.
+     *
+     * @return bool
+     */
+    public static function registerAutoloading(string $appId, string $path, bool $force = false): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/AppInfo/OpenRegisterAutoloaderTest.php
+++ b/tests/Unit/AppInfo/OpenRegisterAutoloaderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Unit tests for the ADR-040 OpenRegister autoload prelude.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ *
+ * @spec openspec/specs/federated-config-sharing/spec.md
+ */
+
+declare(strict_types=1);
+
+namespace OCA\NLDesign\Tests\Unit\AppInfo;
+
+use OCA\NLDesign\AppInfo\OpenRegisterAutoloader;
+use OCP\App\IAppManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * `Application::register()` runs before OpenRegister's PSR-4 prefix exists,
+ * because the app coordinator walks a SORTED list and `nldesign` sorts before
+ * `openregister`. Everything downstream of that — the `class_exists()` guard,
+ * the federated-config listener, whether `nldesign.theme` reaches the
+ * catalogue at all — depends on this prelude running and, crucially, on it
+ * NEVER THROWING when OpenRegister is absent.
+ *
+ * That second half is what these tests pin. A prelude that throws would abort
+ * `register()`, and the coordinator catches the Throwable, logs an emergency
+ * and continues — leaving the app enabled with half its wiring missing and
+ * nothing in the UI to say so.
+ */
+class OpenRegisterAutoloaderTest extends TestCase
+{
+
+    /**
+     * The app id must be the real one, not a near-miss. `getAppPath()` throws
+     * for an unknown id, which this class swallows — so a typo here would
+     * degrade silently and forever, which is the exact failure mode the class
+     * exists to prevent.
+     */
+    public function testAppIdIsOpenregister(): void
+    {
+        $this->assertSame('openregister', OpenRegisterAutoloader::OPENREGISTER_APP_ID);
+    }//end testAppIdIsOpenregister()
+
+    /**
+     * An absent or disabled OpenRegister must produce `false`, not an
+     * exception. `getAppPath()` throwing is the normal, supported signal that
+     * the app is not installed.
+     */
+    public function testAbsentOpenRegisterDegradesToFalseWithoutThrowing(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getAppPath')
+            ->willThrowException(new RuntimeException('App openregister not found'));
+
+        $this->assertFalse((new OpenRegisterAutoloader())->ensure($appManager));
+    }//end testAbsentOpenRegisterDegradesToFalseWithoutThrowing()
+
+    /**
+     * The prelude asks for the path of `openregister` specifically — the whole
+     * point is which app's autoloader gets pulled in.
+     */
+    public function testAsksTheAppManagerForOpenregistersPath(): void
+    {
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->expects($this->once())
+            ->method('getAppPath')
+            ->with('openregister')
+            ->willThrowException(new RuntimeException('not installed here'));
+
+        (new OpenRegisterAutoloader())->ensure($appManager);
+    }//end testAsksTheAppManagerForOpenregistersPath()
+
+    /**
+     * With no argument the prelude resolves the app manager from the server
+     * container. Under PHPUnit there is no container, so this exercises the
+     * same swallow-and-degrade path a real absent OpenRegister takes — and
+     * proves the no-argument call used by `Application::register()` cannot
+     * throw either.
+     */
+    public function testNoArgumentCallNeverThrows(): void
+    {
+        $this->assertIsBool((new OpenRegisterAutoloader())->ensure());
+    }//end testNoArgumentCallNeverThrows()
+}//end class


### PR DESCRIPTION
`register()` guarded its federated-config listener on a `class_exists()` probe with **no autoload prelude**:

```php
if (class_exists(\OCA\OpenRegister\Service\Config\RegisterShareableConfigTypesEvent::class) === true) {
    $context->registerEventListener(/* ShareableConfigTypeListener */);
}
```

`Coordinator::registerApps()` walks the **sorted** app list, calling `OC_App::registerAutoloading()` and then `register()` for one app at a time — and **`nldesign` sorts before `openregister`**. So on a minimal instance this runs while the `OCA\OpenRegister\` PSR-4 prefix does not yet exist, the guard answers **FALSE on a completely healthy install**, and the listener is never registered.

## What is lost

Only one thing is behind that guard, and it is not cosmetic: `ShareableConfigTypeListener`. When it does not register, nldesign contributes **no shareable config type at all** — `nldesign.theme` never reaches OpenRegister's catalogue, and the whole of `openspec/specs/federated-config-sharing/spec.md` (publishing and installing the NL Design theme over the fleet mechanism) silently does nothing.

Nothing reports it. The app stays enabled, every route resolves, the theme still applies.

## Measured — including the part that does *not* reproduce

On the shared dev instance the catalogue **does** list the type today:

```
GET /apps/openregister/api/federated-config/types → 200
{"types":[{"id":"hermiq.skill",…},{"id":"nldesign.theme","name":"NL Design theme","topic":"nldesign-theme"},…]}
```

So on that box the listener **is** registered and the bug is invisible. That is exactly the masking the ADR-040 checker documents: any app that pulls OpenRegister's autoloader registers the prefix **process-wide**, so an alphabetically earlier app (`hermiq`, among ~30 installed there) fixes it for everyone registering later.

**A dev box with a rich app set is the one place this defect cannot be observed — and a minimal instance is what CI and a real deployment look like.** I am reporting this rather than claiming a reproduction I did not get.

This PR is therefore a **no-op exactly where the defect is masked, and load-bearing everywhere else**. It removes the dependency on which other apps happen to be installed, which is the only reason it worked.

## `stubs/nextcloud-legacy.php`

`OC_App` lives in the server's `lib/private/` and is absent from the `nextcloud/ocp` package the analysers see, so psalm reported `UndefinedClass`. A **declaration-only stub rather than an issue suppression**, deliberately: a suppression would hide a typo in the call as readily as it hides this, whereas a stub makes the analysers *check* the signature. Wired into analysis only (`psalm.xml <stubs>`, phpstan's existing `scanDirectories: stubs`), never autoloaded at runtime — matching the existing `stubs/openregister-config.php` pattern.

## Checks

phpcs clean · phpmd clean · phpstan `[OK] No errors` · psalm `No errors found!` (all under PHP 8.4; the host runs 8.2 and this repo's floor is 8.3, so they cannot run on the host at all).

> No gate reports this: gate-64 ships it as a runner NOTE rather than a FAIL, because it is not diff-scoped and failing it would block every PR in three repos over untouched code.