### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@fontsource/fira-sans": "^5.0.0"
 			},
 			"devDependencies": {
-				"@conduction/nextcloud-vue": "2.2.0-vue3.3",
+				"@conduction/nextcloud-vue": "2.2.0-vue3.7",
 				"@cyclonedx/cyclonedx-npm": "^4.2.1",
 				"@openfun/cunningham-tokens": "^3.0.0",
 				"@playwright/test": "^1.60.0",
@@ -485,9 +485,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.2.0-vue3.3",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.3.tgz",
-			"integrity": "sha512-kO6qtFPnQx1gNFZO/l5YVaSnpnsJspaqazWn5pWiwpma1DbTO9Oa6Jfk5svzFOfR85QB37HKqDqL0JnHpKiXJw==",
+			"version": "2.2.0-vue3.7",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.7.tgz",
+			"integrity": "sha512-x0aj0ACfLUDIak3/A51jVyxCPWPIFYfhv7FG2WIQA5+WKfxfJ2rzt8mIl65AmW646PZxsOz4iPo1pCm3EUeuIQ==",
 			"dev": true,
 			"license": "EUPL-1.2",
 			"dependencies": {
@@ -1566,6 +1566,14 @@
 			"engines": {
 				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
+		},
+		"node_modules/@gouvfr/dsfr-token": {
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/@gouvfr/dsfr-weave": {
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@img/colour": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@gouvfr/dsfr": "^1.15.1"
 	},
 	"devDependencies": {
-		"@conduction/nextcloud-vue": "2.2.0-vue3.3",
+		"@conduction/nextcloud-vue": "2.2.0-vue3.7",
 		"@cyclonedx/cyclonedx-npm": "^4.2.1",
 		"@openfun/cunningham-tokens": "^3.0.0",
 		"@playwright/test": "^1.60.0",


### PR DESCRIPTION
## What

Hard-pins `@conduction/nextcloud-vue` to exactly **`2.2.0-vue3.7`** (from `2.2.0-vue3.3`), the current `vue3` dist-tag head.

No caret, no range: `^2.2.0` does **not** match `2.2.0-vue3.7` (caret ranges do not cross prerelease boundaries), and `latest`/`beta` are the retired Vue 2 lineage.

## Lockfile control — and a pre-existing breakage it exposed

The lockfile was regenerated with the pin **unchanged** before applying the bump. It was **not** a no-op:

| | lock lines |
|---|---|
| control (pin unchanged) | **+8** — two `@gouvfr/dsfr-*` optional-peer stubs |
| bump itself | 4 changed (version, resolved, integrity, root dep) |
| total in this PR | +12 / −4 |

Those 8 lines are **not** part of this bump. They repair a pre-existing defect: on `development`, `npm ci` **fails outright**:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json are in sync.
npm error Missing: @gouvfr/dsfr-token@ from lock file
npm error Missing: @gouvfr/dsfr-weave@ from lock file
```

Without the control run this PR would have looked like a 12-line bump, and the two `@gouvfr` entries would have been blamed on `@conduction/nextcloud-vue`. With the regenerated lockfile, `npm ci` succeeds again.

## Verification

- **Off disk** after a real `npm ci`: exactly **one** copy, `2.2.0-vue3.7`, peer `vue ^3.5.0`.
- **Registry controls**: `2.2.0-vue3.7` resolves; `3.0.0` / `3.0.0-vue3.0` return **E404** (3.x depublished).

| | before (`vue3.3`) | after (`vue3.7`) |
|---|---|---|
| `npm ci` | exit 0 (from regenerated lock) | exit 0 |
| `npm run build` | exit 0 | exit 0 |
| `npm run test:unit` | 8 files / **81 passed** | 8 files / **81 passed** |
| `css/` output | 2,684,041 B | 2,684,041 B |

Bundle delta: **0 bytes** — expected, since `@conduction/nextcloud-vue` is a `devDependency` here and nldesign's build is CSS/fonts/icons only.

> Note on the baseline: `development`'s push run is already red on **E2E Tests (Playwright)** (+ `Quality Report`, a pure aggregator). That failure predates this PR and is unrelated to the pin.

Part of a fleet-wide pin to `2.2.0-vue3.7` across 8 repos.
