### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@fontsource/fira-sans": "^5.0.0"
 			},
 			"devDependencies": {
-				"@conduction/nextcloud-vue": "2.2.0-vue3.7",
+				"@conduction/nextcloud-vue": "2.2.0-vue3.9",
 				"@cyclonedx/cyclonedx-npm": "^4.2.1",
 				"@openfun/cunningham-tokens": "^3.0.0",
 				"@playwright/test": "^1.60.0",
@@ -485,9 +485,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "2.2.0-vue3.7",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.7.tgz",
-			"integrity": "sha512-x0aj0ACfLUDIak3/A51jVyxCPWPIFYfhv7FG2WIQA5+WKfxfJ2rzt8mIl65AmW646PZxsOz4iPo1pCm3EUeuIQ==",
+			"version": "2.2.0-vue3.9",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.9.tgz",
+			"integrity": "sha512-9HC1dhYfCqw7JeZ3mn4Zr260iBCWlWa/1slrPTdmIbODvbWlf82guAZEnMq17XvWmDJRcAVNBzYtIT2kWwZutA==",
 			"dev": true,
 			"license": "EUPL-1.2",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@gouvfr/dsfr": "^1.15.1"
 	},
 	"devDependencies": {
-		"@conduction/nextcloud-vue": "2.2.0-vue3.7",
+		"@conduction/nextcloud-vue": "2.2.0-vue3.9",
 		"@cyclonedx/cyclonedx-npm": "^4.2.1",
 		"@openfun/cunningham-tokens": "^3.0.0",
 		"@playwright/test": "^1.60.0",


### PR DESCRIPTION
## What

Hard-pins `@conduction/nextcloud-vue` to exactly **`2.2.0-vue3.9`** (from `2.2.0-vue3.7`), the current `vue3` dist-tag head.

Follow-up to #257. The tag moved twice more while the fleet wave was running — `vue3.7` → `vue3.8` → `vue3.9` — because every merge to nc-vue's `feat/vue-3` cuts a publish. The fleet converges on **`2.2.0-vue3.9`**.

No caret, no range: `^2.2.0` does **not** match a prerelease, and `latest`/`beta` are the retired Vue 2 lineage.

## Lockfile control (npm 10.8.2)

| | result |
|---|---|
| control (pin **unchanged**) | **0 lines** |
| after bump | 8 lock lines + 2 package.json lines |

Generated with **npm 10.8.2**, the version CI runs. Under npm 10 the control is a clean no-op — the `@gouvfr/dsfr-*` stubs that npm 11 injected during the 3.7 pin are already in the lockfile and stay put.

## Verification

- **`npm ci` under npm 10.8.2**: exit 0.
- **Off disk**: exactly **one** copy, `2.2.0-vue3.9`, peer `vue ^3.5.0`.
- **Registry controls**: `2.2.0-vue3.9` resolves; `3.0.0` / `3.0.0-vue3.0` return **E404**.

`2.2.0-vue3.9` is **not** pre-verified against our apps the way `2.2.0-vue3.7` was, so this run is the verification:

| | before (`vue3.7`) | after (`vue3.9`) |
|---|---|---|
| `npm ci` (npm 10.8.2) | exit 0 | exit 0 |
| `npm run build` | exit 0 | exit 0 |
| `npm run test:unit` (vitest) | 8 files / **81 passed** | 8 files / **81 passed** |
| `css/` output | 2,684,041 B | 2,684,041 B |

Bundle delta: **0 bytes** — expected, since `@conduction/nextcloud-vue` is a `devDependency` here and nldesign's build is CSS/fonts/icons only. No regression.
