### PR TITLE
fix(lasuite): the search control had no NC 32 treatment, and 8 selectors were dead on every supported server

### DIFF
--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -45,21 +45,30 @@ header#header {
 	display: none !important;
 }
 
-/* Header foreground — dark text/icons on the white bar. */
-#header .header-appname,
-#header .header-left a {
-	color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
-	font-weight: 600 !important;
-}
+/* Two rules stood here — `.header-appname`/`.header-left a` and
+   `.header-right a`/`.header-right button`/`.menutoggle`/`.unified-search__button`
+   — carried as "pre-Vue header classes retained as fallbacks for older
+   Nextcloud releases".
 
-#header .header-right a,
-#header .header-right button,
-#header .menutoggle,
-#header .unified-search__button {
-	color: var(--lasuite-content-primary, var(--lasuite-color-gray-900)) !important;
-	filter: none !important;
-	opacity: 1 !important;
-}
+   THE OLDEST SUPPORTED RELEASE REFUTES THAT. appinfo/info.xml declares
+   `min-version="32"`, so NC 32 IS the oldest server this theme can run on.
+   Counted on /apps/files/ at rest with `lasuite` active, on two disposable
+   instances built for the comparison:
+
+       selector                        NC 32.0.12   NC 34.0.2
+       #header .header-appname              0            0
+       #header .header-left a               0            0
+       #header .header-right a              0            0
+       #header .header-right button         0            0
+       #header .menutoggle                  0            0
+       #header .unified-search__button      0            0
+
+   Zero at BOTH ends of the supported range is not a fallback, it is dead CSS:
+   there is no server this app supports on which these can match. Deleted.
+
+   The header foreground they were meant to set is delivered on both versions by
+   the `.header-end`/`.header-start` glyph rule and the app-menu rules below,
+   which are live on 32 and 34 alike. */
 
 /* Nextcloud ships every header glyph WHITE, because its own header is normally
    a dark brand colour. On our white bar they render white-on-white and the bar
@@ -84,11 +93,16 @@ header#header {
         black disc — the exclusion list below it could never have worked, no
         matter which avatar selector it named. Colour inherits; filters do not
         un-inherit. */
+/* `#header .header-start .icon-vue` was listed here and is deleted: counted 0
+   on NC 32.0.12 AND 0 on NC 34.0.2, i.e. dead across the whole supported range.
+   Its siblings are NOT dead and stay — `.header-start .button-vue__icon` (0 on
+   32, 2 on 34) and `.header-start svg` (0 on 32, 1 on 34) are NC33+ markup with
+   a live target on the newer half of the range, which is what the SINCE list in
+   tests/e2e/spec-coverage/selector-liveness.spec.ts exists to defer. */
 #header .header-end .button-vue__icon,
 #header .header-end .icon-vue,
 #header .header-end svg,
 #header .header-start .button-vue__icon,
-#header .header-start .icon-vue,
 #header .header-start svg,
 #header .app-menu__waffle,
 #header .app-menu__waffle svg {
@@ -148,9 +162,17 @@ header#header {
    visual weight is what makes the two headers read alike; the two strings are
    not structurally the same thing (product name vs current app), so this is a
    deliberate visual match rather than a like-for-like mapping. */
+/* `#header .header-start .header-appname` was a third selector here and is
+   deleted for the same reason as the two rules near the top of the file:
+   `.header-appname` counts 0 on NC 32.0.12 and 0 on NC 34.0.2.
+
+   NC 32 needs no replacement for this. It has no current-app chip at all — the
+   active app is an entry in the always-visible app menu, and the app-menu rules
+   below already give it brand-650 at weight 600 with the 3px underline. The
+   wordmark treatment is NC33+ markup with an NC32 equivalent that is already
+   styled, not a hole. */
 #header .app-menu__current-app-name,
-#header .app-menu__current-app .button-vue__text,
-#header .header-start .header-appname {
+#header .app-menu__current-app .button-vue__text {
 	/* MEASURED, not estimated. La Suite Docs renders its wordmark as TEXT (unlike
 	   Messages, which ships an image and offers no computed value), so these are
 	   read straight off the live app at localhost:3000:
@@ -183,9 +205,12 @@ header#header {
    structural hairline (see the sidebar rule), rather than the measured
    #d3d4e0 — that value falls between two ramp steps and consistency with the
    rest of the theme is worth more than matching one control exactly. */
+/* `#header .unified-search__input` was listed here as "pre-NC34 unified-search
+   markup, retained as a fallback for older servers" and is deleted: 0 on NC
+   32.0.12 and 0 on NC 34.0.2. NC 32 is the oldest server this app supports, so
+   there is no "older server" left for it to be a fallback FOR. */
 #header .unified-search-input,
-#header .unified-search-input__button,
-#header .unified-search__input {
+#header .unified-search-input__button {
 	background-color: var(--lasuite--contextuals--background--surface--tertiary, var(--lasuite-color-gray-025)) !important;
 	border: 1px solid var(--lasuite--contextuals--border--surface--primary, var(--lasuite-color-gray-100)) !important;
 	border-radius: var(--lasuite-border-radius) !important;
@@ -221,6 +246,81 @@ header#header {
    so it opts out of the brand colour applied to header glyphs above. */
 #header .unified-search-input__icon,
 #header .unified-search-input svg {
+	color: var(--lasuite-content-muted, var(--lasuite-color-gray-500)) !important;
+}
+
+/* ─── THE SAME CONTROL ON NEXTCLOUD 32 ────────────────────────────────────────
+ *
+ * Everything above targets `.unified-search-input`, which NC 32 does not have.
+ * NC 32 renders unified search as an icon-only 50x50 button instead:
+ *
+ *     <div class="unified-search-menu">
+ *       <div id="unified-search" class="header-menu">
+ *         <button class="header-menu__trigger button-vue button-vue--icon-only"
+ *                 aria-label="Unified search">
+ *
+ * so on the oldest server this theme supports, the one control that carries La
+ * Suite's most recognisable header affordance had NO treatment at all: a bare
+ * transparent square where NC 34 shows a bordered field. Measured at rest on
+ * /apps/files/ with `lasuite` active:
+ *
+ *                                              NC 32.0.12   NC 34.0.2
+ *     #header .unified-search-input                 0            1
+ *     #header .unified-search-menu                  1            1
+ *     #header .unified-search-menu
+ *             .header-menu__trigger                 1            0
+ *
+ * THE SELECTOR IS VERSION-DISCRIMINATING ON ITS OWN. `.header-menu__trigger`
+ * inside `.unified-search-menu` exists only on 32 (on 34 the three
+ * `.header-menu__trigger`s in the bar are Notifications, Contacts and the
+ * settings menu — none of them is search), so this block needs no `:has()`
+ * guard, no version sniff and no `@supports`: on NC 34 it matches nothing and
+ * changes nothing. That is asserted in both directions below.
+ *
+ * The values are the ones measured on NC 34's own pill in the same session —
+ * background rgb(248,248,249), 1px rgb(226,226,234), 34px, radius 4px — so the
+ * two servers land on the same control rather than on two interpretations of it.
+ *
+ * THE LABEL IS `attr(aria-label)`, NOT A STRING. NC 32's trigger has no visible
+ * text, and hard-coding an English prompt here would ship an untranslated word
+ * to every locale. `aria-label` is already translated by Nextcloud, so the
+ * generated text follows the user's language for free. It reads "Unified
+ * search" where NC 34 reads "Search apps, files, tags, messages …"; the two
+ * servers word it differently and that is Nextcloud's wording, not ours.
+ * Generated content cannot alter the accessible name here — `aria-label` wins
+ * over contents in the name computation — so this is decorative only, and the
+ * control keeps a 34px hit box (above the 24x24 WCAG 2.5.8 minimum, and the
+ * same height NC 34's pill already uses). */
+#header .unified-search-menu .header-menu__trigger {
+	background-color: var(--lasuite--contextuals--background--surface--tertiary, var(--lasuite-color-gray-025)) !important;
+	border: 1px solid var(--lasuite--contextuals--border--surface--primary, var(--lasuite-color-gray-100)) !important;
+	border-radius: var(--lasuite-border-radius) !important;
+	block-size: 34px !important;
+	min-block-size: 0 !important;
+	min-inline-size: 0 !important;
+	inline-size: auto !important;
+	padding: 0 10px !important;
+	justify-content: flex-start !important;
+}
+
+#header .unified-search-menu .header-menu__trigger .button-vue__wrapper {
+	gap: 8px !important;
+}
+
+#header .unified-search-menu .header-menu__trigger::after {
+	content: attr(aria-label);
+	color: var(--lasuite-content-muted, var(--lasuite-color-gray-500)) !important;
+	font-size: 14px !important;
+	font-weight: 500 !important;
+	white-space: nowrap;
+}
+
+/* Same reasoning as the NC 34 magnifier above: neutral affordance, not a
+   brand-tinted action. This has to out-specify the `.header-end svg` brand tint
+   earlier in the file, and it does — (1 id, 2 classes, 1 type) against
+   (1 id, 1 class, 1 type) — so the ordering here is not load-bearing. */
+#header .unified-search-menu .header-menu__trigger .icon-vue,
+#header .unified-search-menu .header-menu__trigger svg {
 	color: var(--lasuite-content-muted, var(--lasuite-color-gray-500)) !important;
 }
 

--- a/css/systems/lasuite/element-overrides.css
+++ b/css/systems/lasuite/element-overrides.css
@@ -45,30 +45,21 @@ header#header {
 	display: none !important;
 }
 
-/* Two rules stood here — `.header-appname`/`.header-left a` and
-   `.header-right a`/`.header-right button`/`.menutoggle`/`.unified-search__button`
-   — carried as "pre-Vue header classes retained as fallbacks for older
-   Nextcloud releases".
+/* Header foreground — dark text/icons on the white bar. */
+#header .header-appname,
+#header .header-left a {
+	color: var(--lasuite-content-brand, var(--lasuite-color-brand-650)) !important;
+	font-weight: 600 !important;
+}
 
-   THE OLDEST SUPPORTED RELEASE REFUTES THAT. appinfo/info.xml declares
-   `min-version="32"`, so NC 32 IS the oldest server this theme can run on.
-   Counted on /apps/files/ at rest with `lasuite` active, on two disposable
-   instances built for the comparison:
-
-       selector                        NC 32.0.12   NC 34.0.2
-       #header .header-appname              0            0
-       #header .header-left a               0            0
-       #header .header-right a              0            0
-       #header .header-right button         0            0
-       #header .menutoggle                  0            0
-       #header .unified-search__button      0            0
-
-   Zero at BOTH ends of the supported range is not a fallback, it is dead CSS:
-   there is no server this app supports on which these can match. Deleted.
-
-   The header foreground they were meant to set is delivered on both versions by
-   the `.header-end`/`.header-start` glyph rule and the app-menu rules below,
-   which are live on 32 and 34 alike. */
+#header .header-right a,
+#header .header-right button,
+#header .menutoggle,
+#header .unified-search__button {
+	color: var(--lasuite-content-primary, var(--lasuite-color-gray-900)) !important;
+	filter: none !important;
+	opacity: 1 !important;
+}
 
 /* Nextcloud ships every header glyph WHITE, because its own header is normally
    a dark brand colour. On our white bar they render white-on-white and the bar
@@ -93,16 +84,11 @@ header#header {
         black disc — the exclusion list below it could never have worked, no
         matter which avatar selector it named. Colour inherits; filters do not
         un-inherit. */
-/* `#header .header-start .icon-vue` was listed here and is deleted: counted 0
-   on NC 32.0.12 AND 0 on NC 34.0.2, i.e. dead across the whole supported range.
-   Its siblings are NOT dead and stay — `.header-start .button-vue__icon` (0 on
-   32, 2 on 34) and `.header-start svg` (0 on 32, 1 on 34) are NC33+ markup with
-   a live target on the newer half of the range, which is what the SINCE list in
-   tests/e2e/spec-coverage/selector-liveness.spec.ts exists to defer. */
 #header .header-end .button-vue__icon,
 #header .header-end .icon-vue,
 #header .header-end svg,
 #header .header-start .button-vue__icon,
+#header .header-start .icon-vue,
 #header .header-start svg,
 #header .app-menu__waffle,
 #header .app-menu__waffle svg {
@@ -162,17 +148,9 @@ header#header {
    visual weight is what makes the two headers read alike; the two strings are
    not structurally the same thing (product name vs current app), so this is a
    deliberate visual match rather than a like-for-like mapping. */
-/* `#header .header-start .header-appname` was a third selector here and is
-   deleted for the same reason as the two rules near the top of the file:
-   `.header-appname` counts 0 on NC 32.0.12 and 0 on NC 34.0.2.
-
-   NC 32 needs no replacement for this. It has no current-app chip at all — the
-   active app is an entry in the always-visible app menu, and the app-menu rules
-   below already give it brand-650 at weight 600 with the 3px underline. The
-   wordmark treatment is NC33+ markup with an NC32 equivalent that is already
-   styled, not a hole. */
 #header .app-menu__current-app-name,
-#header .app-menu__current-app .button-vue__text {
+#header .app-menu__current-app .button-vue__text,
+#header .header-start .header-appname {
 	/* MEASURED, not estimated. La Suite Docs renders its wordmark as TEXT (unlike
 	   Messages, which ships an image and offers no computed value), so these are
 	   read straight off the live app at localhost:3000:
@@ -205,12 +183,9 @@ header#header {
    structural hairline (see the sidebar rule), rather than the measured
    #d3d4e0 — that value falls between two ramp steps and consistency with the
    rest of the theme is worth more than matching one control exactly. */
-/* `#header .unified-search__input` was listed here as "pre-NC34 unified-search
-   markup, retained as a fallback for older servers" and is deleted: 0 on NC
-   32.0.12 and 0 on NC 34.0.2. NC 32 is the oldest server this app supports, so
-   there is no "older server" left for it to be a fallback FOR. */
 #header .unified-search-input,
-#header .unified-search-input__button {
+#header .unified-search-input__button,
+#header .unified-search__input {
 	background-color: var(--lasuite--contextuals--background--surface--tertiary, var(--lasuite-color-gray-025)) !important;
 	border: 1px solid var(--lasuite--contextuals--border--surface--primary, var(--lasuite-color-gray-100)) !important;
 	border-radius: var(--lasuite-border-radius) !important;
@@ -259,10 +234,11 @@ header#header {
  *         <button class="header-menu__trigger button-vue button-vue--icon-only"
  *                 aria-label="Unified search">
  *
- * so on the oldest server this theme supports, the one control that carries La
+ * so on the oldest server this theme supports, the one control carrying La
  * Suite's most recognisable header affordance had NO treatment at all: a bare
- * transparent square where NC 34 shows a bordered field. Measured at rest on
- * /apps/files/ with `lasuite` active:
+ * transparent square where NC 34 shows a bordered field. Counted at rest on
+ * /apps/files/ with `lasuite` active, on two disposable instances built for the
+ * comparison:
  *
  *                                              NC 32.0.12   NC 34.0.2
  *     #header .unified-search-input                 0            1
@@ -275,7 +251,9 @@ header#header {
  * `.header-menu__trigger`s in the bar are Notifications, Contacts and the
  * settings menu — none of them is search), so this block needs no `:has()`
  * guard, no version sniff and no `@supports`: on NC 34 it matches nothing and
- * changes nothing. That is asserted in both directions below.
+ * changes nothing. Both directions were asserted — NC 34's pill was measured
+ * byte-identical on all six properties before and after, and a planted
+ * `background-color: rgb(9,9,9)` proved that reading could still move.
  *
  * The values are the ones measured on NC 34's own pill in the same session —
  * background rgb(248,248,249), 1px rgb(226,226,234), 34px, radius 4px — so the

--- a/tests/e2e/spec-coverage/selector-liveness.spec.ts
+++ b/tests/e2e/spec-coverage/selector-liveness.spec.ts
@@ -189,36 +189,23 @@ const SURFACES: Array<Surface> = [
 /**
  * Selectors permitted to match nothing on every surveyed surface.
  * Each entry is a substring or /regex/ plus the reason it cannot match.
- *
- * `olderServer: true` marks the entries whose ONLY justification is "kept for
- * older Nextcloud releases". Those are checked against the oldest release this
- * app supports — see MIN_SUPPORTED_NC and the assertion that uses it. An
- * excuse that names a server the app cannot even run on is not an excuse.
  */
-const ALLOWED: Array<{ pattern: RegExp; reason: string; olderServer?: boolean }> = [
+const ALLOWED: Array<{ pattern: RegExp; reason: string }> = [
 	{
 		pattern: /^#app-navigation(?![-\w])/,
 		reason: 'Deliberate pre-NC34 fallback; NC34 renders #app-navigation-vue. Kept so the theme still applies on older servers.',
-		// MEASURED opt-out: #app-navigation counts 1 on NC 32.0.12 at
-		// /settings/user, which IS one of the surveyed surfaces — so it is live
-		// in the union and never reaches the assertion anyway. The flag records
-		// the measurement rather than relying on that.
-		olderServer: false,
 	},
 	{
 		pattern: /#content\.content|#app-content(?!-vue)/,
 		reason: 'Cross-version shell fallbacks. NC34 uses #content (no class) + #content-vue + #app-content-vue.',
-		// Same: #app-content = 1 on NC 32.0.12 /settings/user.
 	},
 	{
 		pattern: /nav\.app-menu/,
-		reason: 'Structural prefix for the NC32 app-menu rules. `nav.app-menu` itself is LIVE on both 32.0.12 '
-			+ 'and 34.0.2 (count 1 each); it is the NC32-only descendants (.app-menu__list, .app-menu-entry*) '
-			+ 'that the surveyed NC34 markup replaces with .app-menu__waffle / .app-menu__current-app.',
-		// Corrected 2026-08-10. The previous reason read "NC34 renders the app
-		// menu through a different structure; kept for older servers", which is
-		// wrong about the selector it excuses: nav.app-menu counts 1 on NC34.
-		// An allowance that misdescribes what it allows cannot be audited.
+		reason: 'NC34 renders the app menu through a different structure; kept for older servers.',
+	},
+	{
+		pattern: /\.header-appname|\.header-left|\.header-right|\.menutoggle|\.unified-search__button|\.header-start \.icon-vue/,
+		reason: 'Pre-Vue header classes retained as fallbacks for older Nextcloud releases.',
 	},
 	{
 		pattern: /^(button|input)\.(primary|secondary)\b/,
@@ -246,19 +233,10 @@ const ALLOWED: Array<{ pattern: RegExp; reason: string; olderServer?: boolean }>
 			+ 'Vue apps that render their own components instead, but these still apply on form-bearing '
 			+ 'admin pages and inside dialogs.',
 	},
-	// REMOVED 2026-08-10, together with the CSS they excused:
-	//
-	//   /\.header-appname|\.header-left|\.header-right|\.menutoggle
-	//     |\.unified-search__button|\.header-start \.icon-vue/
-	//       "Pre-Vue header classes retained as fallbacks for older Nextcloud releases."
-	//   /unified-search__input/
-	//       "Pre-NC34 unified-search markup, retained as a fallback for older servers."
-	//
-	// Both reasons named a server this app cannot run on. Counted at rest on
-	// /apps/files/ with `lasuite` active, on two disposable instances:
-	// every one of those selectors is 0 on NC 32.0.12 AND 0 on NC 34.0.2, and
-	// info.xml declares min-version="32". The CSS is deleted in
-	// css/systems/lasuite/element-overrides.css; see the notes there.
+	{
+		pattern: /unified-search__input/,
+		reason: 'Pre-NC34 unified-search markup, retained as a fallback for older servers.',
+	},
 ]
 
 function allowedReason(selector: string): string | null {
@@ -269,51 +247,11 @@ function allowedReason(selector: string): string | null {
 }
 
 /**
- * True when the selector's excuse is "kept for an OLDER Nextcloud".
- *
- * DERIVED FROM THE REASON TEXT, NOT FROM A HAND-SET FLAG, and deliberately so.
- * A flag someone must remember to set is a check that quietly stops working the
- * first time someone forgets — and the entries this is meant to catch are
- * written by whoever is in a hurry to make the suite green. The reason string
- * is the thing they cannot avoid writing, so that is what gets audited.
- *
- * `olderServer: false` opts an entry out, and is only honest with a measured
- * count on the oldest supported server recorded next to it (both current
- * opt-outs carry one).
- */
-const OLDER_SERVER_EXCUSE = /older (nextcloud|server)/i
-
-function excusedAsOlderServerFallback(selector: string): boolean {
-	return ALLOWED.some(({ pattern, reason, olderServer }) =>
-		olderServer !== false && OLDER_SERVER_EXCUSE.test(reason) && pattern.test(selector))
-}
-
-/**
  * The newest Nextcloud this app declares support for (appinfo/info.xml
  * `<nextcloud min-version="32" max-version="34"/>`). It is the expiry date on
  * every SINCE entry below: once CI surveys this major, nothing may be deferred.
  */
 const MAX_SUPPORTED_NC = 34
-
-/**
- * The OLDEST Nextcloud this app declares support for (info.xml min-version).
- *
- * THE OLDEST SUPPORTED SERVER IS THE POSITIVE CONTROL FOR "KEPT FOR OLDER
- * SERVERS". MAX_SUPPORTED_NC expires the SINCE list — nothing may be deferred
- * to a newer server once we survey the newest one. This is the missing mirror:
- * nothing may be excused as a fallback for an OLDER server once we survey the
- * oldest one, because there is no older server left for it to be a fallback for.
- *
- * The gap this closes was not hypothetical. CI pins `nextcloud-test-refs:
- * ["stable32"]`, so the survey has ALWAYS run on the oldest supported release —
- * and seven selectors sat in ALLOWED reading "retained as fallbacks for older
- * Nextcloud releases" while matching nothing on the very server that was
- * supposed to be the reason they existed. The data that refutes them was in
- * hand on every single run; nothing ever compared the two numbers. Confirmed on
- * a second instance so the deletion covers the whole range, 0 on 32.0.12 and 0
- * on 34.0.2 alike.
- */
-const MIN_SUPPORTED_NC = 32
 
 /**
  * A ONE-VERSION SURVEY CANNOT JUDGE A CROSS-VERSION STYLESHEET.
@@ -353,29 +291,9 @@ const MIN_SUPPORTED_NC = 32
  * `app-menu__list` and `unified-search-menu`. So these twelve are not stale CSS
  * and not a timing artefact; they are markup that server does not have.
  *
- * ⚠️ CORRECTION, 2026-08-10. An earlier revision of this note claimed "the La
- * Suite header treatment does not reach NC 32 at all". THAT IS FALSE, and the
- * twelve rows above are not evidence for it — they are twelve selectors out of
- * a much larger set. Counted properly, by walking every rule in
- * css/systems/lasuite/element-overrides.css and matching it against a live NC
- * 32.0.12 with `lasuite` active: 67 header selectors, of which **43 match and
- * 24 do not**. The white bar, the brand-550 masked logo, the inverted app
- * icons, the avatar exclusion and the brand-650 semibold active app with its
- * 3px underline are all live on NC 32.
- *
- * 🔑 Twelve dead selectors was a count of what was LOOKED AT, not of the
- * treatment. Generalising from the sample that was in front of me turned a
- * narrow, true finding into a broad, false one.
- *
- * What was genuinely missing on NC 32 was ONE control: unified search. NC 34
- * renders a bordered 34px pill (`.unified-search-input`); NC 32 renders a bare
- * transparent 50x50 icon button (`.unified-search-menu .header-menu__trigger`)
- * that no rule in this theme touched. That is now fixed in element-overrides.css
- * — the fix matches 0 elements on NC 34, asserted in both directions.
- *
- * The waffle and the current-app wordmark need no NC 32 counterpart: that
- * server has neither control. Its always-visible app menu shows the active app
- * instead, and the app-menu rules already style it.
+ * NOTE FOR WHOEVER RAISES THE PIN. The same measurement says the La Suite
+ * header treatment does not reach NC 32 at all — worth its own change, and
+ * deliberately not smuggled into this one.
  */
 const SINCE: Array<{ pattern: RegExp; since: number; reason: string }> = [
 	{
@@ -941,21 +859,6 @@ test.describe('lasuite selector liveness', () => {
 				+ `(appinfo/info.xml max-version=${MAX_SUPPORTED_NC}), so nothing may be deferred to a newer `
 				+ `one. These selectors match nothing here and their SINCE entry has expired — delete the `
 				+ `entry and the CSS, or fix the selectors:\n  ${versionDeferred.join('\n  ')}`,
-		).toEqual([])
-
-		// THE MIRROR OF THE EXPIRY ABOVE. That one refuses to defer to a NEWER
-		// server once we survey the newest; this one refuses to excuse as a
-		// fallback for an OLDER server once we survey the oldest. Both are
-		// answering the same question — "is there actually a server on which
-		// this selector is alive?" — from the two ends of the supported range.
-		const olderServerExcused = dead.filter((sel) => excusedAsOlderServerFallback(sel))
-		expect(
-			serverMajor <= MIN_SUPPORTED_NC ? olderServerExcused : [],
-			`Surveyed Nextcloud ${serverMajor} is the OLDEST version this app supports `
-				+ `(appinfo/info.xml min-version=${MIN_SUPPORTED_NC}), so "kept for older servers" names no `
-				+ `server this app can run on. These selectors are dead here and their ALLOWED entry claims `
-				+ `an older server would render them — delete the entry and the CSS, or replace the reason `
-				+ `with one that is true:\n  ${olderServerExcused.join('\n  ')}`,
 		).toEqual([])
 
 		const deferredSet = new Set(deferred)

--- a/tests/e2e/spec-coverage/selector-liveness.spec.ts
+++ b/tests/e2e/spec-coverage/selector-liveness.spec.ts
@@ -189,23 +189,36 @@ const SURFACES: Array<Surface> = [
 /**
  * Selectors permitted to match nothing on every surveyed surface.
  * Each entry is a substring or /regex/ plus the reason it cannot match.
+ *
+ * `olderServer: true` marks the entries whose ONLY justification is "kept for
+ * older Nextcloud releases". Those are checked against the oldest release this
+ * app supports — see MIN_SUPPORTED_NC and the assertion that uses it. An
+ * excuse that names a server the app cannot even run on is not an excuse.
  */
-const ALLOWED: Array<{ pattern: RegExp; reason: string }> = [
+const ALLOWED: Array<{ pattern: RegExp; reason: string; olderServer?: boolean }> = [
 	{
 		pattern: /^#app-navigation(?![-\w])/,
 		reason: 'Deliberate pre-NC34 fallback; NC34 renders #app-navigation-vue. Kept so the theme still applies on older servers.',
+		// MEASURED opt-out: #app-navigation counts 1 on NC 32.0.12 at
+		// /settings/user, which IS one of the surveyed surfaces — so it is live
+		// in the union and never reaches the assertion anyway. The flag records
+		// the measurement rather than relying on that.
+		olderServer: false,
 	},
 	{
 		pattern: /#content\.content|#app-content(?!-vue)/,
 		reason: 'Cross-version shell fallbacks. NC34 uses #content (no class) + #content-vue + #app-content-vue.',
+		// Same: #app-content = 1 on NC 32.0.12 /settings/user.
 	},
 	{
 		pattern: /nav\.app-menu/,
-		reason: 'NC34 renders the app menu through a different structure; kept for older servers.',
-	},
-	{
-		pattern: /\.header-appname|\.header-left|\.header-right|\.menutoggle|\.unified-search__button|\.header-start \.icon-vue/,
-		reason: 'Pre-Vue header classes retained as fallbacks for older Nextcloud releases.',
+		reason: 'Structural prefix for the NC32 app-menu rules. `nav.app-menu` itself is LIVE on both 32.0.12 '
+			+ 'and 34.0.2 (count 1 each); it is the NC32-only descendants (.app-menu__list, .app-menu-entry*) '
+			+ 'that the surveyed NC34 markup replaces with .app-menu__waffle / .app-menu__current-app.',
+		// Corrected 2026-08-10. The previous reason read "NC34 renders the app
+		// menu through a different structure; kept for older servers", which is
+		// wrong about the selector it excuses: nav.app-menu counts 1 on NC34.
+		// An allowance that misdescribes what it allows cannot be audited.
 	},
 	{
 		pattern: /^(button|input)\.(primary|secondary)\b/,
@@ -233,10 +246,19 @@ const ALLOWED: Array<{ pattern: RegExp; reason: string }> = [
 			+ 'Vue apps that render their own components instead, but these still apply on form-bearing '
 			+ 'admin pages and inside dialogs.',
 	},
-	{
-		pattern: /unified-search__input/,
-		reason: 'Pre-NC34 unified-search markup, retained as a fallback for older servers.',
-	},
+	// REMOVED 2026-08-10, together with the CSS they excused:
+	//
+	//   /\.header-appname|\.header-left|\.header-right|\.menutoggle
+	//     |\.unified-search__button|\.header-start \.icon-vue/
+	//       "Pre-Vue header classes retained as fallbacks for older Nextcloud releases."
+	//   /unified-search__input/
+	//       "Pre-NC34 unified-search markup, retained as a fallback for older servers."
+	//
+	// Both reasons named a server this app cannot run on. Counted at rest on
+	// /apps/files/ with `lasuite` active, on two disposable instances:
+	// every one of those selectors is 0 on NC 32.0.12 AND 0 on NC 34.0.2, and
+	// info.xml declares min-version="32". The CSS is deleted in
+	// css/systems/lasuite/element-overrides.css; see the notes there.
 ]
 
 function allowedReason(selector: string): string | null {
@@ -247,11 +269,51 @@ function allowedReason(selector: string): string | null {
 }
 
 /**
+ * True when the selector's excuse is "kept for an OLDER Nextcloud".
+ *
+ * DERIVED FROM THE REASON TEXT, NOT FROM A HAND-SET FLAG, and deliberately so.
+ * A flag someone must remember to set is a check that quietly stops working the
+ * first time someone forgets — and the entries this is meant to catch are
+ * written by whoever is in a hurry to make the suite green. The reason string
+ * is the thing they cannot avoid writing, so that is what gets audited.
+ *
+ * `olderServer: false` opts an entry out, and is only honest with a measured
+ * count on the oldest supported server recorded next to it (both current
+ * opt-outs carry one).
+ */
+const OLDER_SERVER_EXCUSE = /older (nextcloud|server)/i
+
+function excusedAsOlderServerFallback(selector: string): boolean {
+	return ALLOWED.some(({ pattern, reason, olderServer }) =>
+		olderServer !== false && OLDER_SERVER_EXCUSE.test(reason) && pattern.test(selector))
+}
+
+/**
  * The newest Nextcloud this app declares support for (appinfo/info.xml
  * `<nextcloud min-version="32" max-version="34"/>`). It is the expiry date on
  * every SINCE entry below: once CI surveys this major, nothing may be deferred.
  */
 const MAX_SUPPORTED_NC = 34
+
+/**
+ * The OLDEST Nextcloud this app declares support for (info.xml min-version).
+ *
+ * THE OLDEST SUPPORTED SERVER IS THE POSITIVE CONTROL FOR "KEPT FOR OLDER
+ * SERVERS". MAX_SUPPORTED_NC expires the SINCE list — nothing may be deferred
+ * to a newer server once we survey the newest one. This is the missing mirror:
+ * nothing may be excused as a fallback for an OLDER server once we survey the
+ * oldest one, because there is no older server left for it to be a fallback for.
+ *
+ * The gap this closes was not hypothetical. CI pins `nextcloud-test-refs:
+ * ["stable32"]`, so the survey has ALWAYS run on the oldest supported release —
+ * and seven selectors sat in ALLOWED reading "retained as fallbacks for older
+ * Nextcloud releases" while matching nothing on the very server that was
+ * supposed to be the reason they existed. The data that refutes them was in
+ * hand on every single run; nothing ever compared the two numbers. Confirmed on
+ * a second instance so the deletion covers the whole range, 0 on 32.0.12 and 0
+ * on 34.0.2 alike.
+ */
+const MIN_SUPPORTED_NC = 32
 
 /**
  * A ONE-VERSION SURVEY CANNOT JUDGE A CROSS-VERSION STYLESHEET.
@@ -291,9 +353,29 @@ const MAX_SUPPORTED_NC = 34
  * `app-menu__list` and `unified-search-menu`. So these twelve are not stale CSS
  * and not a timing artefact; they are markup that server does not have.
  *
- * NOTE FOR WHOEVER RAISES THE PIN. The same measurement says the La Suite
- * header treatment does not reach NC 32 at all — worth its own change, and
- * deliberately not smuggled into this one.
+ * ⚠️ CORRECTION, 2026-08-10. An earlier revision of this note claimed "the La
+ * Suite header treatment does not reach NC 32 at all". THAT IS FALSE, and the
+ * twelve rows above are not evidence for it — they are twelve selectors out of
+ * a much larger set. Counted properly, by walking every rule in
+ * css/systems/lasuite/element-overrides.css and matching it against a live NC
+ * 32.0.12 with `lasuite` active: 67 header selectors, of which **43 match and
+ * 24 do not**. The white bar, the brand-550 masked logo, the inverted app
+ * icons, the avatar exclusion and the brand-650 semibold active app with its
+ * 3px underline are all live on NC 32.
+ *
+ * 🔑 Twelve dead selectors was a count of what was LOOKED AT, not of the
+ * treatment. Generalising from the sample that was in front of me turned a
+ * narrow, true finding into a broad, false one.
+ *
+ * What was genuinely missing on NC 32 was ONE control: unified search. NC 34
+ * renders a bordered 34px pill (`.unified-search-input`); NC 32 renders a bare
+ * transparent 50x50 icon button (`.unified-search-menu .header-menu__trigger`)
+ * that no rule in this theme touched. That is now fixed in element-overrides.css
+ * — the fix matches 0 elements on NC 34, asserted in both directions.
+ *
+ * The waffle and the current-app wordmark need no NC 32 counterpart: that
+ * server has neither control. Its always-visible app menu shows the active app
+ * instead, and the app-menu rules already style it.
  */
 const SINCE: Array<{ pattern: RegExp; since: number; reason: string }> = [
 	{
@@ -859,6 +941,21 @@ test.describe('lasuite selector liveness', () => {
 				+ `(appinfo/info.xml max-version=${MAX_SUPPORTED_NC}), so nothing may be deferred to a newer `
 				+ `one. These selectors match nothing here and their SINCE entry has expired — delete the `
 				+ `entry and the CSS, or fix the selectors:\n  ${versionDeferred.join('\n  ')}`,
+		).toEqual([])
+
+		// THE MIRROR OF THE EXPIRY ABOVE. That one refuses to defer to a NEWER
+		// server once we survey the newest; this one refuses to excuse as a
+		// fallback for an OLDER server once we survey the oldest. Both are
+		// answering the same question — "is there actually a server on which
+		// this selector is alive?" — from the two ends of the supported range.
+		const olderServerExcused = dead.filter((sel) => excusedAsOlderServerFallback(sel))
+		expect(
+			serverMajor <= MIN_SUPPORTED_NC ? olderServerExcused : [],
+			`Surveyed Nextcloud ${serverMajor} is the OLDEST version this app supports `
+				+ `(appinfo/info.xml min-version=${MIN_SUPPORTED_NC}), so "kept for older servers" names no `
+				+ `server this app can run on. These selectors are dead here and their ALLOWED entry claims `
+				+ `an older server would render them — delete the entry and the CSS, or replace the reason `
+				+ `with one that is true:\n  ${olderServerExcused.join('\n  ')}`,
 		).toEqual([])
 
 		const deferredSet = new Set(deferred)


### PR DESCRIPTION

Measured on two disposable instances built for the comparison — NC 32.0.12 and
NC 34.0.2, both with `lasuite` active, both at rest on /apps/files/.

FIRST, A CORRECTION TO THE NOTE THAT PROMPTED THIS. The previous revision of
selector-liveness.spec.ts said "the La Suite header treatment does not reach NC
32 at all". That is false. Walking every rule in element-overrides.css against a
live NC 32.0.12: 67 header selectors, 43 match and 24 do not. The white bar, the
brand-550 masked logo, the inverted app icons, the avatar exclusion and the
brand-650 semibold active app with its 3px underline are all live on NC 32.
Twelve dead selectors was a count of what had been looked at, not a measure of
the treatment.

WHAT WAS ACTUALLY MISSING: ONE CONTROL. NC 34 renders unified search as a
bordered 34px pill; NC 32 renders a bare transparent 50x50 icon button that no
rule in this theme touched, so the most recognisable affordance in the La Suite
header was absent on the oldest server the app supports.

    #header .unified-search-input                    0 on 32     1 on 34
    #header .unified-search-menu .header-menu__trigger  1 on 32     0 on 34

The counterpart selector is version-discriminating on its own, so the new block
needs no :has(), no version sniff and no @supports. Values are the ones measured
off NC 34's own pill in the same session, so the two servers land on the same
control rather than on two interpretations of it. The label is attr(aria-label),
not a string: NC 32's trigger has no visible text, and Nextcloud already
translates that attribute, so hard-coding an English prompt would have shipped an
untranslated word to every locale.

PROVEN BOTH DIRECTIONS:
  NC 32 before -> after   transparent/50x50/no label -> rgb(248,248,249),
                          1px rgb(226,226,234), 34px, 165px wide, "Unified search"
  NC 34 before vs after   byte-identical on all six measured properties; the four
                          new rules match 0 elements there
  positive control        planting `background-color: rgb(9,9,9)` on NC 34 moved
                          the reading, so "identical" is a measurement and not a
                          silent no-op

EIGHT SELECTORS DELETED, NOT DEFERRED. They were excused in ALLOWED as "retained
as fallbacks for older Nextcloud releases". info.xml declares min-version="32",
so NC 32 IS the oldest server this theme can run on — and .header-appname,
.header-left a, .header-right a, .header-right button, .menutoggle,
.unified-search__button, .header-start .icon-vue and .unified-search__input all
count 0 on 32 AND 0 on 34. Zero at both ends of the supported range is not a
fallback, it is dead CSS.

AND THE CHECK THAT WOULD HAVE CAUGHT THEM. MAX_SUPPORTED_NC already refuses to
defer a selector to a NEWER server once the survey reaches the newest one. This
adds its missing mirror: MIN_SUPPORTED_NC refuses to excuse one as a fallback
for an OLDER server once the survey reaches the oldest one. CI has pinned
stable32 all along, so the survey has ALWAYS run on the oldest supported release
— the data refuting those eight excuses was in hand on every run and nothing
ever compared the two numbers.

The condition is derived from the ALLOWED reason TEXT rather than a hand-set
flag, because a flag someone must remember to set is a check that stops working
the first time they forget. Replaying the pre-change ALLOWED list through the
new predicate flags exactly those 8 selectors; the shipped list flags 0.

Also corrected: the `nav.app-menu` allowance claimed "NC34 renders the app menu
through a different structure", but nav.app-menu counts 1 on NC 34. An allowance
that misdescribes what it allows cannot be audited.

The waffle and the current-app wordmark deliberately get no NC 32 counterpart:
that server has neither control, and its always-visible app menu already carries
the active-app treatment.

stylelint clean; test:lasuite-bridge-coverage OK (68 variables, 44 mapped, 24
reasoned); tsc reports no error in either changed file.

---

**Instruments.** Two disposable instances built for this comparison (`nextcloud:32-apache` and `nextcloud:34-apache`, sqlite, own volumes, names that are not substrings of anything else running), nldesign exported from `development` and `token_set=lasuite` on both. Neither the shared dev container nor any other agent's instance was touched.