### PR TITLE
fix(a11y): reduced-motion fallbacks that actually win the cascade, + gate-7 exemption

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -593,3 +593,20 @@
 	margin-top: 0.5em;
 	color: var(--color-text-maxcontrast);
 }
+
+/* ==========================================================================
+   Reduced motion — WCAG 2.2 SC 2.3.3
+   ==========================================================================
+
+   Unlike the design-system layers, the motion here is NOT `!important`, so a
+   same-specificity rule later in the file is enough. The selectors are
+   repeated rather than reset through `*` so that this block states exactly
+   which motion it removes. */
+@media (prefers-reduced-motion: reduce) {
+	.nldesign-token-set,
+	.nldesign-preview-button,
+	.nldesign-app-dropdown-trigger::after {
+		transition: none !important;
+		animation: none !important;
+	}
+}

--- a/css/systems/nldesign/theme.css
+++ b/css/systems/nldesign/theme.css
@@ -867,3 +867,42 @@ button,
 	box-shadow: none !important;
 	-webkit-box-shadow: none !important;
 }
+
+/* ==========================================================================
+   Reduced motion — WCAG 2.2 SC 2.3.3
+   ==========================================================================
+
+   Every motion declaration in this file is `!important` and carries class- or
+   attribute-level specificity. A universal `* { transition-duration: 0.01ms
+   !important }` reset therefore does NOT override them: between two
+   `!important` author declarations the more specific selector wins, and `*`
+   has specificity 0. Such a reset would silence the audit while leaving the
+   motion on screen.
+
+   So the selectors are repeated verbatim below — equal specificity, later in
+   source order, which is what actually wins the cascade. Keep this block in
+   step with the motion declarations above. */
+@media (prefers-reduced-motion: reduce) {
+	#body-login .button-vue--vue-primary,
+	#body-login input[type="submit"],
+	#body-login button.primary,
+	.login-form button[type="submit"],
+	.button-vue,
+	button,
+	.button,
+	#app-navigation li.active > a,
+	#app-navigation .app-navigation-entry.active,
+	a,
+	input[type="text"],
+	input[type="password"],
+	input[type="email"],
+	input[type="search"],
+	input[type="url"],
+	input[type="tel"],
+	input[type="number"],
+	textarea,
+	select {
+		transition: none !important;
+		animation: none !important;
+	}
+}

--- a/css/systems/summer-breeze/element-overrides.css
+++ b/css/systems/summer-breeze/element-overrides.css
@@ -456,3 +456,36 @@ body .app-item:focus-visible .app-item__circle,
 body .app-item.active .app-item__circle {
 	background-color: var(--summer-color-primary-light-hover) !important;
 }
+
+/* ==========================================================================
+   Reduced motion — WCAG 2.2 SC 2.3.3
+   ==========================================================================
+
+   The motion declarations above are `!important` at class-level specificity,
+   so a universal `*`-based reset (specificity 0) would lose the cascade to
+   them and turn the audit green without removing any motion. The selectors
+   are therefore repeated verbatim — equal specificity, later in source order.
+
+   `transform` is included in the card hover, so `transition: none` here also
+   removes the sliding/scaling motion, not only the colour fades. */
+@media (prefers-reduced-motion: reduce) {
+	.cn-card,
+	.cn-object-card,
+	.panel,
+	.widget,
+	.dashboard-widget,
+	.dashboard-panel,
+	.app-content-list-item,
+	input[type="text"],
+	input[type="search"],
+	input[type="email"],
+	input[type="url"],
+	input[type="tel"],
+	.input-field__input,
+	.button-vue,
+	button,
+	.button {
+		transition: none !important;
+		animation: none !important;
+	}
+}

--- a/lib/Controller/ContrastController.php
+++ b/lib/Controller/ContrastController.php
@@ -84,6 +84,20 @@ class ContrastController extends Controller
      * @return JSONResponse `{ results: [...] }`, or 400 on a malformed request.
      *
      * @spec openspec/specs/app-token-set-selection/spec.md
+     *
+     * @no-admin-idor-exempt Pure function over caller-supplied VALUES — there is
+     * no direct object reference to substitute, so IDOR is not structurally
+     * possible. The method takes zero parameters; the only request input is a
+     * `background` colour string and a `candidates` list of {name, value, role}
+     * triples, all of which the caller already possesses. It reads no id, no
+     * path and no session identity, and `ContrastService` has no constructor
+     * and no dependencies at all — no mapper, no ObjectService, no config, no
+     * filesystem — so the response is WCAG contrast arithmetic over the request
+     * body and nothing else. There is no stored object this endpoint can be
+     * pointed at, hence nothing an authorization guard could scope: adding one
+     * would assert a boundary that does not exist. `#[NoAdminRequired]` (not
+     * `#[PublicPage]`) is deliberate and remains the access control — the
+     * endpoint still requires an authenticated session.
      */
     #[NoAdminRequired]
     public function evaluate(): JSONResponse


### PR DESCRIPTION
Clears both non-coverage gate failures at full scope (gate-45 ×3, gate-7 ×1). nldesign's remaining full-scope debt is **gate-19 only**.

No conflict with #260 — that touches `css/systems/lasuite/element-overrides.css`; this touches `nldesign/theme.css`, `summer-breeze/element-overrides.css`, `admin.css` and `ContrastController.php`.

## gate-45 `prefers-reduced-motion` — 3 stylesheets (WCAG 2.2 SC 2.3.3)

Real defects: a user who asked their OS for reduced motion still gets every hover fade, and summer-breeze's card hover also *slides* (`transform`).

**The canonical remedy would have greened the gate without removing any motion.** The gate documents a universal `* { transition-duration: 0.01ms !important }` reset. Every motion declaration in the two design-system layers is `!important` at class/attribute specificity, and between two `!important` author declarations **the more specific selector wins**. `*` has specificity 0, so the reset loses to every rule it was meant to override — a green gate over a live defect, which is worse than the red one.

Each file therefore repeats its own motion selectors inside the media query: equal specificity, later in source order. `admin.css`'s motion is *not* `!important`, and its block says so rather than copying reasoning it does not need.

## gate-7 `no-admin-idor` — `ContrastController::evaluate`

Not a real IDOR, and the gate's own preamble asks for this check before believing it:

- takes **zero parameters**; the only inputs are a `background` colour string and `candidates` `{name, value, role}` triples — **values the caller already holds, not references**
- reads no id, no path, no session identity
- `ContrastService` has **no constructor and no dependencies at all** — no mapper, no ObjectService, no config, no filesystem

There is no stored object this endpoint can be pointed at, so nothing a guard could scope; adding one would assert a boundary that does not exist. Recorded with the gate's sanctioned reason-bearing `@no-admin-idor-exempt`. `#[NoAdminRequired]` (not `#[PublicPage]`) stays — an authenticated session is still required.

## Evidence — both directions

Runner CI uses (hydra-gates @ .github main, `--full --require-full-coverage`); the local run reproduces the CI dispatch byte-for-byte.

```
before: gate-45 FAIL 3, gate-7 FAIL 1
after:  gate-45 PASS,   gate-7 PASS
```

**Planted true positives**, to show neither guard went blind:

- an unguarded `#[NoAdminRequired] plantedIdorProbe(string $id)` added to `ContrastController` → gate-7 **FAIL 1**, naming `plantedIdorProbe` at line 147 — the *same file* whose other method is exempt, so the exemption is scoped to the method and did not silence the file
- `admin.css`'s new block removed → gate-45 **FAIL 1**, naming `admin.css`

Both reverted; re-verified PASS after.

stylelint clean; phpcs / phpmd / psalm / phpstan clean on the changed controller.